### PR TITLE
Signal-with-start support

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ dependencies:
 
 default-extensions:
 - BangPatterns
+- BlockArguments
 - DataKinds
 - DerivingStrategies
 - FlexibleContexts

--- a/src/Temporal/Operator.hs
+++ b/src/Temporal/Operator.hs
@@ -71,11 +71,14 @@ listSearchAttributes c (Namespace n) = do
 
 addSearchAttributes :: MonadIO m => Client -> Namespace -> Map Text IndexedValueType -> m (Either RpcError ())
 addSearchAttributes c (Namespace n) newAttrs = do
-  res <- liftIO $ Core.addSearchAttributes c 
-    ( defMessage 
-      & Proto.namespace .~ n
-      & Proto.searchAttributes .~ converted
-    )
-  pure $ fmap (\_ -> ()) res
+  if null newAttrs
+    then pure $ Right ()
+    else do
+      res <- liftIO $ Core.addSearchAttributes c 
+        ( defMessage 
+          & Proto.namespace .~ n
+          & Proto.searchAttributes .~ converted
+        )
+      pure $ fmap (\_ -> ()) res
   where
     converted = fmap searchAttributeTypeToProto newAttrs

--- a/src/Temporal/Workflow.hs
+++ b/src/Temporal/Workflow.hs
@@ -154,7 +154,6 @@ module Temporal.Workflow
   -- $signals
   , HasSignalRef(..)
   , SignalRef(..)
-  , SignalDefinition(..)
   , setSignalHandler
   , ValidSignalHandler
   , Condition
@@ -423,7 +422,7 @@ gatherActivityArgs c f = gatherArgs (Proxy @args) c id f
 -- Given the following Workflow definition:
 class WorkflowHandle h where
   -- | Signal a running Workflow.
-  signal :: RequireCallStack => h result -> SignalDefinition args -> (args :->: Workflow (Task ()))
+  signal :: (HasSignalRef ref, RequireCallStack) => h result -> ref -> (SignalArgs ref :->: Workflow (Task ()))
 
 instance WorkflowHandle ChildWorkflowHandle where
   signal h =
@@ -439,6 +438,7 @@ instance WorkflowHandle ExternalWorkflowHandle where
         -- TODO
         -- & Common.namespace .~ rawNamespace h.externalNamespace
 
+-- | A Workflow can send a Signal to another Workflow, in which case it's called an External Signal.
 signalWorkflow 
   :: forall result h ref
   .  (RequireCallStack, HasSignalRef ref)

--- a/src/Temporal/Workflow/Definition.hs
+++ b/src/Temporal/Workflow/Definition.hs
@@ -21,7 +21,6 @@ module Temporal.Workflow.Definition
   , WorkflowDefinition(..) -- TODO, only export the type, not the constructor from this module
   , KnownWorkflow(..)
   , SignalRef(..)
-  , SignalDefinition(..)
   , WorkflowSignalDefinition(..)
   -- , StartChildWorkflow(..)
   , gatherStartChildWorkflowArgs

--- a/src/Temporal/Workflow/Internal/Monad.hs
+++ b/src/Temporal/Workflow/Internal/Monad.hs
@@ -579,7 +579,7 @@ data WorkflowInstance = WorkflowInstance
   , workflowCancellationVar :: {-# UNPACK #-} !(IVar ())
   , workflowDeadlockTimeout :: Maybe Int
   -- These are how the instance gets its work done
-  , activationChannel :: Chan Core.WorkflowActivation
+  , activationChannel :: TQueue Core.WorkflowActivation
   , executionThread :: IORef (Async ())
   , inboundInterceptor :: WorkflowInboundInterceptor
   , outboundInterceptor :: WorkflowOutboundInterceptor

--- a/src/Temporal/Workflow/Signal.hs
+++ b/src/Temporal/Workflow/Signal.hs
@@ -12,12 +12,6 @@ data SignalRef (args :: [Type]) = forall codec. (ApplyPayloads codec args, Gathe
     , signalCodec :: codec
     }
 
-data SignalDefinition (args :: [Type]) =
-  SignalDefinition 
-    { signalDefinitionRef :: SignalRef args
-    , signalDefinitionApply :: forall res. Proxy res -> (args :->: res) -> Vector Payload -> IO res
-    }
-
 class HasSignalRef sig where
   type SignalArgs sig :: [Type]
   signalRef :: sig -> SignalRef (SignalArgs sig)
@@ -25,7 +19,3 @@ class HasSignalRef sig where
 instance HasSignalRef (SignalRef args) where
   type SignalArgs (SignalRef args) = args
   signalRef = id
-
-instance HasSignalRef (SignalDefinition args) where
-  type SignalArgs (SignalDefinition args) = args
-  signalRef (SignalDefinition ref _) = ref

--- a/src/Temporal/Workflow/Worker.hs
+++ b/src/Temporal/Workflow/Worker.hs
@@ -139,7 +139,7 @@ handleActivation activation = do
           let withoutStart = filter (\job -> not $ isJust (job ^. Activation.maybe'startWorkflow)) (activation ^. Activation.jobs)
           case withoutStart of
             [] -> pure ()
-            otherJobs -> writeChan inst.activationChannel (activation & Activation.jobs .~ otherJobs)
+            otherJobs -> atomically $ writeTQueue inst.activationChannel (activation & Activation.jobs .~ otherJobs)
     else do
       $(logDebug) "Workflow does not need to run."
       let completionMessage = defMessage 

--- a/temporal-sdk.cabal
+++ b/temporal-sdk.cabal
@@ -60,6 +60,7 @@ library
       src
   default-extensions:
       BangPatterns
+      BlockArguments
       DataKinds
       DerivingStrategies
       FlexibleContexts
@@ -137,6 +138,7 @@ test-suite temporal-sdk-tests
       test
   default-extensions:
       BangPatterns
+      BlockArguments
       DataKinds
       DerivingStrategies
       FlexibleContexts

--- a/test/IntegrationSpec.hs
+++ b/test/IntegrationSpec.hs
@@ -991,7 +991,27 @@ needsClient = do
       -- specify "to same workflow keeps memo and search attributes" pending
       -- specify "to different workflow keeps memo and search attributes by default" pending
       -- specify "to different workflow can set memo and search attributes" pending
-  --   describe "signalWithStart" $ do
+    describe "signalWithStart" do
+      it "works" $ \TestEnv{..} -> do
+        let conf = configure () testConf baseConf
+        withWorker conf $ do
+          let opts = (C.workflowStartOptions taskQueue)
+                { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                , C.timeouts = C.TimeoutOptions
+                    { C.runTimeout = Just $ seconds 4
+                    , C.executionTimeout = Nothing
+                    , C.taskTimeout = Nothing
+                    }
+                }
+          useClient $ do
+            liftIO $ putStrLn "signalWithStart call"
+            wfH <- C.signalWithStart 
+              testRefs.workflowWaitConditionWorks 
+              "signalWithStart" 
+              opts
+              unblockWorkflowSignal 
+            lift $ C.waitWorkflowResult wfH `shouldReturn` ()
+
   --     specify "works as intended and returns correct runId" pending
   describe "RetryPolicy" $ do
     specify "is used for retryable failures" $ \TestEnv{..} -> do


### PR DESCRIPTION
We had most of the support for this in place already, but the tricky bit was that we had to move Workflow execution away from a 1:1 receive commands from Temporal server -> flush commands to Temporal server model. We actually need to exhaust the activation queue in its entirety before flushing results up to the server. Switching to away from Control.Concurrent.Chan to Conctrol.Concurrent.STM.TQueue gives us the necessary primitives to do this properly.