### PR TITLE
Add support for the continue_as_new_suggested field. This signals to Workflows that they are about to run into event history limits and should continue as new if they're not about to complete.

### DIFF
--- a/src/Temporal/Workflow/Types.hs
+++ b/src/Temporal/Workflow/Types.hs
@@ -17,22 +17,23 @@ import qualified Proto.Temporal.Sdk.Core.ChildWorkflow.ChildWorkflow as ChildWor
 data Info = Info
   { historyLength :: {-# UNPACK #-} !Word32
   , attempt :: {-# UNPACK #-} !Int
-  , continuedRunId :: Maybe RunId
-  , cronSchedule :: Maybe Text
-  , executionTimeout :: Maybe Duration
-  , headers :: Map Text Payload
-  , namespace :: Namespace
-  , parent :: Maybe ParentInfo
-  , rawMemo :: Map Text Payload
-  , retryPolicy :: Maybe RetryPolicy
-  , runId :: RunId
-  , runTimeout :: Maybe Duration
-  , searchAttributes :: Map Text SearchAttributeType
-  , startTime :: SystemTime
-  , taskQueue :: TaskQueue
-  , taskTimeout :: Duration
-  , workflowId :: WorkflowId
-  , workflowType :: WorkflowType
+  , continuedRunId :: !(Maybe RunId)
+  , cronSchedule :: !(Maybe Text)
+  , executionTimeout :: !(Maybe Duration)
+  , headers :: !(Map Text Payload)
+  , namespace :: !Namespace
+  , parent :: !(Maybe ParentInfo)
+  , rawMemo :: !(Map Text Payload)
+  , retryPolicy :: !(Maybe RetryPolicy)
+  , runId :: !RunId
+  , runTimeout :: !(Maybe Duration)
+  , searchAttributes :: !(Map Text SearchAttributeType)
+  , startTime :: !SystemTime
+  , taskQueue :: !TaskQueue
+  , taskTimeout :: !Duration
+  , workflowId :: !WorkflowId
+  , workflowType :: !WorkflowType
+  , continueAsNewSuggested :: !Bool
   }
 
 data StartActivityOptions = StartActivityOptions

--- a/src/Temporal/Workflow/Worker.hs
+++ b/src/Temporal/Workflow/Worker.hs
@@ -208,6 +208,7 @@ handleActivation activation = do
                       fromMaybe 
                         (activation ^. Activation.timestamp) 
                         (startWorkflow ^. Activation.maybe'startTime)
+                  , continueAsNewSuggested = False
                   }
             case HashMap.lookup (startWorkflow ^. Activation.workflowType) worker.workerWorkflowFunctions of 
               Nothing -> pure Nothing

--- a/src/Temporal/WorkflowInstance.hs
+++ b/src/Temporal/WorkflowInstance.hs
@@ -228,7 +228,10 @@ activate
 activate act suspension = do
   inst <- ask
   info <- atomicModifyIORef' inst.workflowInstanceInfo $ \info -> 
-    let info' = info { historyLength = act ^. Activation.historyLength }
+    let info' = info 
+          { historyLength = act ^. Activation.historyLength 
+          , continueAsNewSuggested = act ^. Activation.continueAsNewSuggested
+          }
     in (info', info')
   let completionBase = defMessage & Completion.runId .~ rawRunId info.runId
   writeIORef inst.workflowTime (act ^. Activation.timestamp . to timespecFromTimestamp)


### PR DESCRIPTION
that they are about to run into event history limits and should continue as new
if they're not about to complete.