### PR TITLE
Add Activity env as locally alterable in middleware

### DIFF
--- a/sdk/src/Temporal/Activity/Definition.hs
+++ b/sdk/src/Temporal/Activity/Definition.hs
@@ -176,7 +176,7 @@ askActivityClient = Activity $ asks (getWorkerClient . (.activityWorker))
 
 instance MonadReader env (Activity env) where
   ask = Activity $ asks (.activityEnv)
-  local f (Activity m) = Activity $ local (\a -> a {activityEnv = f $ activityEnv a}) m
+  local f (Activity m) = Activity $ local (\a -> a {Temporal.Activity.Definition.activityEnv = f $ Temporal.Activity.Definition.activityEnv a}) m
 
 
 data ActivityCancelReason

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -116,7 +116,7 @@ headersPropagator =
 -- CONTINUE_AS_NEW = 'ContinueAsNew',
 
 -- TODO, we will need to account for replays when we support them
-makeOpenTelemetryInterceptor :: MonadIO m => m Interceptors
+makeOpenTelemetryInterceptor :: MonadIO m => m (Interceptors env)
 makeOpenTelemetryInterceptor = do
   tracerProvider <- getGlobalTracerProvider
   let tracer =
@@ -249,7 +249,7 @@ makeOpenTelemetryInterceptor = do
             }
       , activityInboundInterceptors =
           ActivityInboundInterceptor
-            { executeActivity = \input next -> do
+            { executeActivity = \env input next -> do
                 let ActivityInfo {..} = input.activityInfo
                     spanArgs =
                       defaultSpanArguments
@@ -270,7 +270,7 @@ makeOpenTelemetryInterceptor = do
                 ctxt <- extract headersPropagator input.activityHeaders Ctxt.empty
                 _ <- attachContext ctxt
                 inSpan'' tracer ("RunActivity:" <> input.activityInfo.activityType) spanArgs $ \_span -> do
-                  next input
+                  next env input
             }
       , activityOutboundInterceptors = ActivityOutboundInterceptor
       , clientInterceptors =

--- a/sdk/src/Temporal/Interceptor.hs
+++ b/sdk/src/Temporal/Interceptor.hs
@@ -71,51 +71,51 @@ import Temporal.Workflow.Internal.Monad
 import Temporal.Workflow.Types
 
 
-data ActivityInboundInterceptor = ActivityInboundInterceptor
-  { executeActivity :: ExecuteActivityInput -> (ExecuteActivityInput -> IO (Either String Payload)) -> IO (Either String Payload)
+data ActivityInboundInterceptor env = ActivityInboundInterceptor
+  { executeActivity :: env -> ExecuteActivityInput -> (env -> ExecuteActivityInput -> IO (Either String Payload)) -> IO (Either String Payload)
   }
 
 
-instance Semigroup ActivityInboundInterceptor where
+instance Semigroup (ActivityInboundInterceptor env) where
   l <> r =
     ActivityInboundInterceptor
-      { executeActivity = \input next -> executeActivity l input $ \input' -> executeActivity r input' next
+      { executeActivity = \env input next -> executeActivity l env input $ \env' input' -> executeActivity r env' input' next
       }
 
 
-instance Monoid ActivityInboundInterceptor where
+instance Monoid (ActivityInboundInterceptor env) where
   mempty =
     ActivityInboundInterceptor
-      { executeActivity = \input next -> next input
+      { executeActivity = \env input next -> next env input
       }
 
 
-data ActivityOutboundInterceptor = ActivityOutboundInterceptor {}
+data ActivityOutboundInterceptor env = ActivityOutboundInterceptor {}
 
 
-instance Semigroup ActivityOutboundInterceptor where
+instance Semigroup (ActivityOutboundInterceptor env) where
   ActivityOutboundInterceptor <> ActivityOutboundInterceptor = ActivityOutboundInterceptor
 
 
-instance Monoid ActivityOutboundInterceptor where
+instance Monoid (ActivityOutboundInterceptor env) where
   mempty = ActivityOutboundInterceptor
 
 
-data Interceptors = Interceptors
+data Interceptors env = Interceptors
   { workflowInboundInterceptors :: WorkflowInboundInterceptor
   , workflowOutboundInterceptors :: WorkflowOutboundInterceptor
-  , activityInboundInterceptors :: ActivityInboundInterceptor
-  , activityOutboundInterceptors :: ActivityOutboundInterceptor
+  , activityInboundInterceptors :: ActivityInboundInterceptor env
+  , activityOutboundInterceptors :: ActivityOutboundInterceptor env
   , clientInterceptors :: ClientInterceptors
   , scheduleClientInterceptors :: ScheduleClientInterceptors
   }
 
 
-instance Semigroup Interceptors where
+instance Semigroup (Interceptors env) where
   Interceptors a b c d e f <> Interceptors a' b' c' d' e' f' = Interceptors (a <> a') (b <> b') (c <> c') (d <> d') (e <> e') (f <> f')
 
 
-instance Monoid Interceptors where
+instance Monoid (Interceptors env) where
   mempty = Interceptors mempty mempty mempty mempty mempty mempty
 
 

--- a/sdk/src/Temporal/TH/Classes.hs
+++ b/sdk/src/Temporal/TH/Classes.hs
@@ -21,12 +21,10 @@ import Data.Kind (Type)
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
 import Data.Typeable
-import Language.Haskell.TH (Name)
 import qualified Language.Haskell.TH.Syntax as TH
 import RequireCallStack (provideCallStack)
 import Temporal.Activity
 import Temporal.Activity.Definition
-import Temporal.Client
 import Temporal.Payload
 import Temporal.Workflow
 import Temporal.Workflow.Definition

--- a/sdk/src/Temporal/TH/Internal.hs
+++ b/sdk/src/Temporal/TH/Internal.hs
@@ -20,23 +20,12 @@
 
 module Temporal.TH.Internal where
 
-import Control.Monad.IO.Class
 import Data.Char
--- import qualified Language.Haskell.TH.Datatype as TH
-
-import Data.Data (Data)
-import Data.Kind (Type)
-import Data.Maybe
-import Data.Proxy (Proxy)
 import qualified Data.Text as Text
-import Data.Typeable
 import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH.Lib
 import qualified Language.Haskell.TH.Syntax as TH
-import Temporal.Activity (Activity, ProvidedActivity, provideActivity)
-import Temporal.Bundle (Def, Ref)
-import Temporal.Client (StartWorkflowOptions)
-import Temporal.Payload
+import Temporal.Activity (Activity)
 import Temporal.TH.Classes
 import Temporal.Workflow
 

--- a/sdk/src/Temporal/Worker.hs
+++ b/sdk/src/Temporal/Worker.hs
@@ -212,7 +212,7 @@ instance (ToDefinitions env _1, ToDefinitions env _2, ToDefinitions env _3, ToDe
   toDefinitions (a, b, c, d, e, f) = toDefinitions a <> toDefinitions b <> toDefinitions c <> toDefinitions d <> toDefinitions e <> toDefinitions f
 
 
-addInterceptors :: Interceptors -> ConfigM actEnv ()
+addInterceptors :: Interceptors actEnv -> ConfigM actEnv ()
 addInterceptors i = ConfigM $ modify' $ \conf ->
   conf
     { interceptorConfig = i <> interceptorConfig conf

--- a/sdk/src/Temporal/Worker/Types.hs
+++ b/sdk/src/Temporal/Worker/Types.hs
@@ -32,7 +32,7 @@ data WorkerConfig activityEnv = WorkerConfig
   , actEnv :: activityEnv
   , actDefs :: HashMap Text (ActivityDefinition activityEnv)
   , coreConfig :: Core.WorkerConfig
-  , interceptorConfig :: Interceptors
+  , interceptorConfig :: Interceptors activityEnv
   , applicationErrorConverters :: [ApplicationFailureHandler]
   , tracerProvider :: TracerProvider
   -- ^ This TracerProvider should only need to be supplied if you want to observe

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -129,7 +129,7 @@ sillyEncryptionPayloadProcessor = PayloadProcessor incr decr
     decr (Payload data_ meta) = pure $ Right $ Payload (BS.map (\x -> x - 1) data_) meta
 
 
-makeClient :: PortNumber -> Interceptors -> IO (C.WorkflowClient, Client)
+makeClient :: PortNumber -> Interceptors env -> IO (C.WorkflowClient, Client)
 makeClient pn Interceptors {..} = do
   let conf = configWithRetry pn
   c <- connectClient globalRuntime conf
@@ -363,7 +363,7 @@ testConf :: Definitions ()
 testConf = collectTemporalDefinitions testDefs
 
 
-mkBaseConf :: Interceptors -> IO (ConfigM () (), W.TaskQueue)
+mkBaseConf :: Interceptors () -> IO (ConfigM () (), W.TaskQueue)
 mkBaseConf interceptors = do
   taskQueue <- W.TaskQueue <$> uuidText
   pure


### PR DESCRIPTION
We would like to be able to set `application_name` in PG based off of the workflow type. This change should let us set our `appSqlApplicationName` on `App` locally within an executing Activity so that `runDB` wires up the workflow name.