### PR TITLE
Create ConcurrentWorkflow and utility functions to make fanout actions more explicit.

### DIFF
--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -1540,7 +1540,7 @@ result of the others, so they can all explore as far as possible and get blocked
 unblocked in order to provide the result to the subsequent computation.
 -}
 newtype ConcurrentWorkflow a = ConcurrentWorkflow {runConcurrentlWorkflowActions :: Workflow a}
-  deriving newtype (Functor, MonadLogger, Semigroup, Monoid, Alternative, MonadIO, MonadUnliftIO, MonadCatch, MonadThrow, MonadReadStateVar, MonadWriteStateVar)
+  deriving newtype (Functor, MonadLogger, Semigroup, Monoid, Alternative, MonadCatch, MonadThrow)
 
 
 instance Applicative ConcurrentWorkflow where

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -703,7 +703,9 @@ needsClient = do
             `shouldReturn` ()
           wfId2 <- uuidText
           useClient (C.execute testRefs.workflowWithFailingChildren (WorkflowId wfId2) opts childWorkflowIds)
-            `shouldReturn` ()
+            `shouldThrow` \case
+              (WorkflowExecutionFailed _) -> True
+              _ -> False
 
       specify "invoke" $ \TestEnv {..} -> do
         parentId <- uuidText


### PR DESCRIPTION
This first PR creates a newtype around `Workflow` to provide a similar interface to `Control.Concurrent.Async.Concurrently` that admits applicative instances, and also adds some utility functions to make the code more explicit. This PR _doesn't_ change the current behaviour of `Workflow`'s `Applicative` instance to force sequencing just yet, as some consumers rely on this functionality. If they do, we need to give them a chance to switch things over before pulling the rug on their Workflow semantics.