### PR TITLE
Fix `Setup.hs` with Cabal 3.12

### DIFF
--- a/core/Setup.hs
+++ b/core/Setup.hs
@@ -8,6 +8,7 @@ import Distribution.Simple.LocalBuildInfo (
   InstallDirs (..),
   LocalBuildInfo (..),
   absoluteInstallDirs,
+  buildDir,
   localPkgDescr,
  )
 import Distribution.Simple.Program.Find (


### PR DESCRIPTION
I guess the imports changed, or something.