### PR TITLE
add missing import

### DIFF
--- a/core/Setup.hs
+++ b/core/Setup.hs
@@ -8,6 +8,7 @@ import Distribution.Simple.LocalBuildInfo (
   InstallDirs (..),
   LocalBuildInfo (..),
   absoluteInstallDirs,
+  buildDir,
   localPkgDescr,
  )
 import Distribution.Simple.Program.Find (

--- a/core/temporal-sdk-core.cabal
+++ b/core/temporal-sdk-core.cabal
@@ -15,6 +15,7 @@ extra-source-files:
   rust/Cargo.toml,
   rust/Cargo.lock,
   rust/src/*.rs,
+  rust/temporal_bridge.h
 
 common warnings
     ghc-options: -Wall


### PR DESCRIPTION
fix this error from latest Cabal
```
cabal build temporal-sdk-core   --project-file=./nix/ghcHEAD/ghcHEAD-cabal.project 
Warning: this is a debug build of cabal-install with assertions enabled.
Build profile: -w ghc-9.11.20240913 -O0
In order, the following will be built (use -v for more details):
 - temporal-sdk-core-0.1.0.0 (lib:temporal-sdk-core) (requires build)
Starting     temporal-sdk-core-0.1.0.0 (all, legacy fallback: build-type is Custom)
Error: [Cabal-7125]
Failed to build temporal-sdk-core-0.1.0.0. The failure occurred during the configure step. The exception was:
  dieVerbatim: user error (Error: cabal: '/Users/ianwookim/repo/srcc/ghcHEAD/_build/stage1/bin/ghc'
exited with an error:
/Users/ianwookim/repo/mercury/mwb-on-ghcHEAD/20240914/mwb-20240914/dist-newstyle/tmp/src-60010/temporal-sdk-core-0.1.0.0/dist/setup/setup.hs:46:39:
error: [GHC-88464]
Variable not in scope: buildDir :: LocalBuildInfo -> FilePath
Suggested fix:
Add ‘buildDir’ to the import list in the import of
‘Distribution.Simple.LocalBuildInfo’
(at
/Users/ianwookim/repo/mercury/mwb-on-ghcHEAD/20240914/mwb-20240914/dist-newstyle/tmp/src-60010/temporal-sdk-core-0.1.0.0/dist/setup/setup.hs:(7,1)-(12,2)).
|
46 | copyTemporalBridge lbi (buildDir lbi)
| ^^^^^^^^

/Users/ianwookim/repo/mercury/mwb-on-ghcHEAD/20240914/mwb-20240914/dist-newstyle/tmp/src-60010/temporal-sdk-core-0.1.0.0/dist/setup/setup.hs:106:31:
error: [GHC-88464]
Variable not in scope: buildDir :: LocalBuildInfo -> FilePath
Suggested fix:
Add ‘buildDir’ to the import list in the import of
‘Distribution.Simple.LocalBuildInfo’
(at
/Users/ianwookim/repo/mercury/mwb-on-ghcHEAD/20240914/mwb-20240914/dist-newstyle/tmp/src-60010/temporal-sdk-core-0.1.0.0/dist/setup/setup.hs:(7,1)-(12,2)).
|
106 | else (dir </> buildDir lbi') : extraLibDirs libBuild
| ^^^^^^^^

)
```