### PR TITLE
auto-formatting & linting

### DIFF
--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -1,28 +1,28 @@
-use temporal_client::{
-  ClientOptions, ClientOptionsBuilder, ClientOptionsBuilderError, ConfiguredClient,
-  RetryClient, RetryConfig, TemporalServiceClientWithMetrics, TlsConfig,
-};
-use tonic::{metadata::{MetadataKey, errors::InvalidMetadataValue}};
+use crate::runtime::{self, Capability, HsCallback, MVar};
 use ffi_convert::*;
-use crate::runtime::{self, Capability, MVar, HsCallback};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::str::{from_utf8_unchecked, FromStr};
 use std::time::Duration;
-use serde::{Deserialize, Serialize};
+use temporal_client::{
+    ClientOptions, ClientOptionsBuilder, ClientOptionsBuilderError, ConfiguredClient, RetryClient,
+    RetryConfig, TemporalServiceClientWithMetrics, TlsConfig,
+};
+use tonic::metadata::{errors::InvalidMetadataValue, MetadataKey};
 use url::Url;
-use std::str::{FromStr, from_utf8_unchecked};
 
 type Client = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;
 
 #[derive(Serialize, Deserialize)]
 pub struct ClientConfig {
-  target_url: String,
-  client_name: String,
-  client_version: String,
-  metadata: HashMap<String, String>,
-  identity: String,
-  tls_config: Option<ClientTlsConfig>,
-  retry_config: Option<ClientRetryConfig>,
+    target_url: String,
+    client_name: String,
+    client_version: String,
+    metadata: HashMap<String, String>,
+    identity: String,
+    tls_config: Option<ClientTlsConfig>,
+    retry_config: Option<ClientRetryConfig>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -43,263 +43,275 @@ struct ClientRetryConfig {
     pub max_retries: usize,
 }
 
-fn client_config_to_options(client_config: ClientConfig) -> Result<ClientOptions, ClientOptionsBuilderError> {
-  let mut defaults = ClientOptionsBuilder::default();
-  let mut options_builder = defaults
-    .target_url(Url::parse(&client_config.target_url).unwrap())
-    .client_name(client_config.client_name)
-    .client_version(client_config.client_version)
-    .identity(client_config.identity);
+fn client_config_to_options(
+    client_config: ClientConfig,
+) -> Result<ClientOptions, ClientOptionsBuilderError> {
+    let mut defaults = ClientOptionsBuilder::default();
+    let mut options_builder = defaults
+        .target_url(Url::parse(&client_config.target_url).unwrap())
+        .client_name(client_config.client_name)
+        .client_version(client_config.client_version)
+        .identity(client_config.identity);
 
-  match client_config.tls_config {
-    Some(tls_config) => {
-      let tls_config = TlsConfig {
-        server_root_ca_cert: tls_config.server_root_ca_cert,
-        domain: tls_config.domain,
-        client_tls_config: match (tls_config.client_cert, tls_config.client_private_key) {
-          (Some(client_cert), Some(client_private_key)) => {
-            Some(temporal_client::ClientTlsConfig {
-              client_cert, client_private_key
-            })
-          }
-          _ => None,
-        },
-      };
-      options_builder = options_builder.tls_cfg(tls_config);
+    match client_config.tls_config {
+        Some(tls_config) => {
+            let tls_config = TlsConfig {
+                server_root_ca_cert: tls_config.server_root_ca_cert,
+                domain: tls_config.domain,
+                client_tls_config: match (tls_config.client_cert, tls_config.client_private_key) {
+                    (Some(client_cert), Some(client_private_key)) => {
+                        Some(temporal_client::ClientTlsConfig {
+                            client_cert,
+                            client_private_key,
+                        })
+                    }
+                    _ => None,
+                },
+            };
+            options_builder = options_builder.tls_cfg(tls_config);
+        }
+        None => {}
     }
-    None => {}
-  }
 
-  if let Some(retry_config) = client_config.retry_config {
-    options_builder = options_builder.retry_config(RetryConfig {
-      initial_interval: Duration::from_millis(retry_config.initial_interval_millis),
-      randomization_factor: retry_config.randomization_factor,
-      multiplier: retry_config.multiplier,
-      max_interval: Duration::from_millis(retry_config.max_interval_millis),
-      max_elapsed_time: retry_config.max_elapsed_time_millis.map(Duration::from_millis),
-      max_retries: retry_config.max_retries,
-    });
-  }
+    if let Some(retry_config) = client_config.retry_config {
+        options_builder = options_builder.retry_config(RetryConfig {
+            initial_interval: Duration::from_millis(retry_config.initial_interval_millis),
+            randomization_factor: retry_config.randomization_factor,
+            multiplier: retry_config.multiplier,
+            max_interval: Duration::from_millis(retry_config.max_interval_millis),
+            max_elapsed_time: retry_config
+                .max_elapsed_time_millis
+                .map(Duration::from_millis),
+            max_retries: retry_config.max_retries,
+        });
+    }
 
-  options_builder.build()
+    options_builder.build()
 }
 
 #[repr(C)]
 pub struct HaskellHashMapEntries {
-  key: *const u8,
-  key_len: usize,
-  value: *const u8,
-  value_len: usize,
-  next: *const HaskellHashMapEntries,
+    key: *const u8,
+    key_len: usize,
+    value: *const u8,
+    value_len: usize,
+    next: *const HaskellHashMapEntries,
 }
 
-pub fn convert_hashmap(
-  hashmap: *const HaskellHashMapEntries
-) -> HashMap<String, String> {
-  let mut map = HashMap::new();
-  if hashmap.is_null() {
-    return map;
-  }
+pub fn convert_hashmap(hashmap: *const HaskellHashMapEntries) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    if hashmap.is_null() {
+        return map;
+    }
 
-  let mut hashmap_ptr = hashmap;
-  while !hashmap_ptr.is_null() {
-    let hashmap_val = unsafe { &*hashmap_ptr };
-    let key = unsafe { 
-      from_utf8_unchecked(std::slice::from_raw_parts(hashmap_val.key, hashmap_val.key_len))
-    };
-    let value = unsafe { 
-      from_utf8_unchecked(std::slice::from_raw_parts(hashmap_val.value, hashmap_val.value_len))
-    };
-    map.insert(key.to_string(), value.to_string());
-    hashmap_ptr = unsafe { (*hashmap).next };
-  }
+    let mut hashmap_ptr = hashmap;
+    while !hashmap_ptr.is_null() {
+        let hashmap_val = unsafe { &*hashmap_ptr };
+        let key = unsafe {
+            from_utf8_unchecked(std::slice::from_raw_parts(
+                hashmap_val.key,
+                hashmap_val.key_len,
+            ))
+        };
+        let value = unsafe {
+            from_utf8_unchecked(std::slice::from_raw_parts(
+                hashmap_val.value,
+                hashmap_val.value_len,
+            ))
+        };
+        map.insert(key.to_string(), value.to_string());
+        hashmap_ptr = unsafe { (*hashmap).next };
+    }
 
-  map
+    map
 }
 #[repr(C)]
 pub struct RpcCall {
-  req: *const CArray<u8>,
-  retry: bool,
-  metadata: *const HaskellHashMapEntries,
-  // nullable
-  timeout_millis: *const u64,
+    req: *const CArray<u8>,
+    retry: bool,
+    metadata: *const HaskellHashMapEntries,
+    // nullable
+    timeout_millis: *const u64,
 }
 
 pub(crate) struct TemporalCall {
-  pub(crate) req: Vec<u8>,
-  pub(crate) retry: bool,
-  pub(crate) metadata: HashMap<String, String>,
-  pub(crate) timeout_millis: Option<u64>,
+    pub(crate) req: Vec<u8>,
+    pub(crate) retry: bool,
+    pub(crate) metadata: HashMap<String, String>,
+    pub(crate) timeout_millis: Option<u64>,
 }
 
 impl From<&RpcCall> for TemporalCall {
-  fn from(rpc_call: &RpcCall) -> Self {
-    TemporalCall {
-      req: unsafe {
-        let req_array = rpc_call.req;
-        let rust_vec = (*req_array).as_rust();
-        rust_vec.unwrap().clone()
-      },
-      retry: rpc_call.retry,
-      metadata: convert_hashmap(rpc_call.metadata),
-      timeout_millis: if rpc_call.timeout_millis.is_null() {
-        None
-      } else {
-        Some(unsafe { *rpc_call.timeout_millis })
-      }
+    fn from(rpc_call: &RpcCall) -> Self {
+        TemporalCall {
+            req: unsafe {
+                let req_array = rpc_call.req;
+                let rust_vec = (*req_array).as_rust();
+                rust_vec.unwrap().clone()
+            },
+            retry: rpc_call.retry,
+            metadata: convert_hashmap(rpc_call.metadata),
+            timeout_millis: if rpc_call.timeout_millis.is_null() {
+                None
+            } else {
+                Some(unsafe { *rpc_call.timeout_millis })
+            },
+        }
     }
-  }
 }
 
 pub struct ClientRef {
-  pub(crate) retry_client: Client,
-  pub(crate) runtime: runtime::Runtime,
+    pub(crate) retry_client: Client,
+    pub(crate) runtime: runtime::Runtime,
 }
 
 impl RawPointerConverter<ClientRef> for ClientRef {
-  fn into_raw_pointer(self) -> *const ClientRef {
-    convert_into_raw_pointer(self)
-  }
+    fn into_raw_pointer(self) -> *const ClientRef {
+        convert_into_raw_pointer(self)
+    }
 
-  fn into_raw_pointer_mut(self) -> *mut ClientRef {
-    convert_into_raw_pointer_mut(self)
-  }
+    fn into_raw_pointer_mut(self) -> *mut ClientRef {
+        convert_into_raw_pointer_mut(self)
+    }
 
-  unsafe fn from_raw_pointer(ptr: *const ClientRef) -> Result<Self, UnexpectedNullPointerError> {
-    take_back_from_raw_pointer(ptr)
-  }
+    unsafe fn from_raw_pointer(ptr: *const ClientRef) -> Result<Self, UnexpectedNullPointerError> {
+        take_back_from_raw_pointer(ptr)
+    }
 
-  unsafe fn from_raw_pointer_mut(ptr: *mut ClientRef) -> Result<Self, UnexpectedNullPointerError> {
-    take_back_from_raw_pointer_mut(ptr)
-  }
+    unsafe fn from_raw_pointer_mut(
+        ptr: *mut ClientRef,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        take_back_from_raw_pointer_mut(ptr)
+    }
 }
 
 pub fn connect_client(
-  runtime_ref: &runtime::RuntimeRef,
-  config: ClientConfig,
-  hs_callback: HsCallback<ClientRef, CArray<u8>>,
+    runtime_ref: &runtime::RuntimeRef,
+    config: ClientConfig,
+    hs_callback: HsCallback<ClientRef, CArray<u8>>,
 ) -> () {
-  let opts: ClientOptions = client_config_to_options(config).unwrap();
-  let runtime = runtime_ref.runtime.clone();
-  runtime_ref.runtime.future_result_into_hs(hs_callback, async move {
-    let retry_client_result = opts
-          .connect_no_namespace(runtime.core.as_ref().telemetry().get_metric_meter())
-          .await;
-        
-    match retry_client_result {
-      Ok(retry_client) => {
-        Ok(ClientRef {
-          retry_client,
-          runtime,
+    let opts: ClientOptions = client_config_to_options(config).unwrap();
+    let runtime = runtime_ref.runtime.clone();
+    runtime_ref
+        .runtime
+        .future_result_into_hs(hs_callback, async move {
+            let retry_client_result = opts
+                .connect_no_namespace(runtime.core.as_ref().telemetry().get_metric_meter())
+                .await;
+
+            match retry_client_result {
+                Ok(retry_client) => Ok(ClientRef {
+                    retry_client,
+                    runtime,
+                }),
+                Err(e) => {
+                    eprintln!("Error: {:?}", e);
+                    let err_message = e.to_string().into_bytes();
+                    Err(CArray::c_repr_of(err_message).unwrap())
+                }
+            }
         })
-      }
-      Err(e) => {
-        eprintln!("Error: {:?}", e);
-        let err_message = e.to_string().into_bytes();
-        Err(
-          CArray::c_repr_of(err_message).unwrap()
-        )
-      }
-    }
-  })
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_connect_client(
-  runtime_ref: *const runtime::RuntimeRef,
-  config_json: *const libc::c_char,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CArray<u8>,
-  result_slot: *mut*mut ClientRef
+    runtime_ref: *const runtime::RuntimeRef,
+    config_json: *const libc::c_char,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CArray<u8>,
+    result_slot: *mut *mut ClientRef,
 ) {
-  let runtime_ref = unsafe { &*runtime_ref };
-  let config_json = unsafe { CStr::from_ptr(config_json) };
-  let config: ClientConfig = serde_json::from_slice(config_json.to_bytes()).unwrap();
-  let hs_callback = runtime::HsCallback {
-    cap, 
-    mvar, 
-    error_slot,
-    result_slot
-  };
-  connect_client(runtime_ref, config, hs_callback);
+    let runtime_ref = unsafe { &*runtime_ref };
+    let config_json = unsafe { CStr::from_ptr(config_json) };
+    let config: ClientConfig = serde_json::from_slice(config_json.to_bytes()).unwrap();
+    let hs_callback = runtime::HsCallback {
+        cap,
+        mvar,
+        error_slot,
+        result_slot,
+    };
+    connect_client(runtime_ref, config, hs_callback);
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_drop_client(client: *mut ClientRef) {
-  unsafe {
-    drop(Box::from_raw(client));
-  }
+    unsafe {
+        drop(Box::from_raw(client));
+    }
 }
 
-pub(crate) fn rpc_req<P: prost::Message + Default>(call: TemporalCall) -> Result<tonic::Request<P>, String> {
-  let buf = call.req.as_slice();
-  let proto = P::decode(buf).map_err(|err| err.to_string())?;
-  let mut req = tonic::Request::new(proto);
-  let metadata = &call.metadata;
-  for (k, v) in metadata {
-      req.metadata_mut().insert(
-          MetadataKey::from_str(k.as_str())
-              .map_err(|err| err.to_string())?,
-          v.parse()
-              .map_err(|err: InvalidMetadataValue| err.to_string())?,
-      );
-  }
-  if let Some(timeout_millis) = call.timeout_millis {
-      req.set_timeout(Duration::from_millis(timeout_millis));
-  }
-  Ok(req)
+pub(crate) fn rpc_req<P: prost::Message + Default>(
+    call: TemporalCall,
+) -> Result<tonic::Request<P>, String> {
+    let buf = call.req.as_slice();
+    let proto = P::decode(buf).map_err(|err| err.to_string())?;
+    let mut req = tonic::Request::new(proto);
+    let metadata = &call.metadata;
+    for (k, v) in metadata {
+        req.metadata_mut().insert(
+            MetadataKey::from_str(k.as_str()).map_err(|err| err.to_string())?,
+            v.parse()
+                .map_err(|err: InvalidMetadataValue| err.to_string())?,
+        );
+    }
+    if let Some(timeout_millis) = call.timeout_millis {
+        req.set_timeout(Duration::from_millis(timeout_millis));
+    }
+    Ok(req)
 }
 
 #[derive(Debug)]
 pub struct RPCError {
-  pub code: u32,
-  pub message: String,
-  pub details: Vec<u8>,
+    pub code: u32,
+    pub message: String,
+    pub details: Vec<u8>,
 }
 
 #[repr(C)]
 #[derive(CReprOf, AsRust, CDrop, RawPointerConverter)]
 #[target_type(RPCError)]
 pub struct CRPCError {
-  code: u32,
-  message: *const libc::c_char,
-  details: *const CArray<u8>,
+    code: u32,
+    message: *const libc::c_char,
+    details: *const CArray<u8>,
 }
 
 impl From<String> for CRPCError {
-  fn from(err: String) -> Self {
-    CRPCError::c_repr_of(
-      RPCError {
-          code: 0,
-          message: err,
-          details: vec![],
-      }
-    ).unwrap()
-  }
+    fn from(err: String) -> Self {
+        CRPCError::c_repr_of(RPCError {
+            code: 0,
+            message: err,
+            details: vec![],
+        })
+        .unwrap()
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_drop_rpc_error(error: *mut CRPCError) {
-  unsafe {
-    CRPCError::drop_raw_pointer(error).unwrap();
-  }
+    unsafe {
+        CRPCError::drop_raw_pointer(error).unwrap();
+    }
 }
 
-pub(crate) fn rpc_resp<P>(res: Result<tonic::Response<P>, tonic::Status>) -> Result<Vec<u8>, CRPCError>
+pub(crate) fn rpc_resp<P>(
+    res: Result<tonic::Response<P>, tonic::Status>,
+) -> Result<Vec<u8>, CRPCError>
 where
-  P: prost::Message,
-  P: Default,
+    P: prost::Message,
+    P: Default,
 {
-  match res {
-      Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
-      Err(err) => {
-        eprintln!("Error: {:?}", err);
-        Err(CRPCError::c_repr_of(RPCError {
-          code: err.code() as u32,
-          message: err.message().to_owned(),
-          details: err.details().into(),
-        }).unwrap())
-      }
-  }
+    match res {
+        Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
+        Err(err) => {
+            eprintln!("Error: {:?}", err);
+            Err(CRPCError::c_repr_of(RPCError {
+                code: err.code() as u32,
+                message: err.message().to_owned(),
+                details: err.details().into(),
+            })
+            .unwrap())
+        }
+    }
 }

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -98,7 +98,11 @@ pub struct HaskellHashMapEntries {
     next: *const HaskellHashMapEntries,
 }
 
-pub fn convert_hashmap(hashmap: *const HaskellHashMapEntries) -> HashMap<String, String> {
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
+pub unsafe fn convert_hashmap(hashmap: *const HaskellHashMapEntries) -> HashMap<String, String> {
     let mut map = HashMap::new();
     if hashmap.is_null() {
         return map;
@@ -150,7 +154,7 @@ impl From<&RpcCall> for TemporalCall {
                 rust_vec.unwrap().clone()
             },
             retry: rpc_call.retry,
-            metadata: convert_hashmap(rpc_call.metadata),
+            metadata: unsafe { convert_hashmap(rpc_call.metadata) },
             timeout_millis: if rpc_call.timeout_millis.is_null() {
                 None
             } else {
@@ -213,8 +217,12 @@ pub fn connect_client(
         })
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_connect_client(
+pub unsafe extern "C" fn hs_temporal_connect_client(
     runtime_ref: *const runtime::RuntimeRef,
     config_json: *const libc::c_char,
     mvar: *mut MVar,
@@ -234,8 +242,12 @@ pub extern "C" fn hs_temporal_connect_client(
     connect_client(runtime_ref, config, hs_callback);
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_client(client: *mut ClientRef) {
+pub unsafe extern "C" fn hs_temporal_drop_client(client: *mut ClientRef) {
     unsafe {
         drop(Box::from_raw(client));
     }
@@ -288,8 +300,12 @@ impl From<String> for CRPCError {
     }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_rpc_error(error: *mut CRPCError) {
+pub unsafe extern "C" fn hs_temporal_drop_rpc_error(error: *mut CRPCError) {
     unsafe {
         CRPCError::drop_raw_pointer(error).unwrap();
     }

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -53,24 +53,21 @@ fn client_config_to_options(
         .client_version(client_config.client_version)
         .identity(client_config.identity);
 
-    match client_config.tls_config {
-        Some(tls_config) => {
-            let tls_config = TlsConfig {
-                server_root_ca_cert: tls_config.server_root_ca_cert,
-                domain: tls_config.domain,
-                client_tls_config: match (tls_config.client_cert, tls_config.client_private_key) {
-                    (Some(client_cert), Some(client_private_key)) => {
-                        Some(temporal_client::ClientTlsConfig {
-                            client_cert,
-                            client_private_key,
-                        })
-                    }
-                    _ => None,
-                },
-            };
-            options_builder = options_builder.tls_cfg(tls_config);
-        }
-        None => {}
+    if let Some(tls_config) = client_config.tls_config {
+        let tls_config = TlsConfig {
+            server_root_ca_cert: tls_config.server_root_ca_cert,
+            domain: tls_config.domain,
+            client_tls_config: match (tls_config.client_cert, tls_config.client_private_key) {
+                (Some(client_cert), Some(client_private_key)) => {
+                    Some(temporal_client::ClientTlsConfig {
+                        client_cert,
+                        client_private_key,
+                    })
+                }
+                _ => None,
+            },
+        };
+        options_builder = options_builder.tls_cfg(tls_config);
     }
 
     if let Some(retry_config) = client_config.retry_config {
@@ -193,7 +190,7 @@ pub fn connect_client(
     runtime_ref: &runtime::RuntimeRef,
     config: ClientConfig,
     hs_callback: HsCallback<ClientRef, CArray<u8>>,
-) -> () {
+) {
     let opts: ClientOptions = client_config_to_options(config).unwrap();
     let runtime = runtime_ref.runtime.clone();
     runtime_ref

--- a/core/rust/src/ephemeral_server.rs
+++ b/core/rust/src/ephemeral_server.rs
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn hs_temporal_start_test_server(
     cap: Capability,
     error_slot: *mut *mut CArray<u8>,
     result_slot: *mut *mut EphemeralServerRef,
-) -> () {
+) {
     let runtime_ref = unsafe { runtime.as_ref().unwrap() };
     let runtime = &runtime_ref.runtime;
     let mut de = serde_json::Deserializer::from_str(unsafe {

--- a/core/rust/src/ephemeral_server.rs
+++ b/core/rust/src/ephemeral_server.rs
@@ -87,8 +87,12 @@ pub struct TemporalDevServerConfigDef {
     pub extra_args: Vec<String>,
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_start_dev_server(
+pub unsafe extern "C" fn hs_temporal_start_dev_server(
     runtime: *mut RuntimeRef,
     json_string: *const c_char,
     mvar: *mut MVar,
@@ -124,8 +128,12 @@ pub extern "C" fn hs_temporal_start_dev_server(
     })
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_shutdown_ephemeral_server(
+pub unsafe extern "C" fn hs_temporal_shutdown_ephemeral_server(
     server: *mut EphemeralServerRef,
     mvar: *mut MVar,
     cap: Capability,
@@ -165,8 +173,12 @@ pub struct TestServerConfigDef {
     pub extra_args: Vec<String>,
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_start_test_server(
+pub unsafe extern "C" fn hs_temporal_start_test_server(
     runtime: *mut RuntimeRef,
     json_string: *const c_char,
     mvar: *mut MVar,

--- a/core/rust/src/lib.rs
+++ b/core/rust/src/lib.rs
@@ -1,6 +1,5 @@
-
-pub mod runtime;
 pub mod client;
-pub mod rpc;
-pub mod worker;
 pub mod ephemeral_server;
+pub mod rpc;
+pub mod runtime;
+pub mod worker;

--- a/core/rust/src/rpc.rs
+++ b/core/rust/src/rpc.rs
@@ -32,8 +32,12 @@ macro_rules! rpc_call {
 }
 
 // TODO, these are all quite repetitive, can we generate them?
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_count_workflow_executions(
+pub unsafe extern "C" fn hs_count_workflow_executions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -59,8 +63,12 @@ pub extern "C" fn hs_count_workflow_executions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_create_schedule(
+pub unsafe extern "C" fn hs_create_schedule(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -86,8 +94,12 @@ pub extern "C" fn hs_create_schedule(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_delete_schedule(
+pub unsafe extern "C" fn hs_delete_schedule(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -113,8 +125,12 @@ pub extern "C" fn hs_delete_schedule(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_deprecate_namespace(
+pub unsafe extern "C" fn hs_deprecate_namespace(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -140,8 +156,12 @@ pub extern "C" fn hs_deprecate_namespace(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_describe_namespace(
+pub unsafe extern "C" fn hs_describe_namespace(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -167,8 +187,12 @@ pub extern "C" fn hs_describe_namespace(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_describe_schedule(
+pub unsafe extern "C" fn hs_describe_schedule(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -194,8 +218,12 @@ pub extern "C" fn hs_describe_schedule(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_describe_task_queue(
+pub unsafe extern "C" fn hs_describe_task_queue(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -221,8 +249,12 @@ pub extern "C" fn hs_describe_task_queue(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_describe_workflow_execution(
+pub unsafe extern "C" fn hs_describe_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -248,8 +280,12 @@ pub extern "C" fn hs_describe_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_cluster_info(
+pub unsafe extern "C" fn hs_get_cluster_info(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -275,8 +311,12 @@ pub extern "C" fn hs_get_cluster_info(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_search_attributes(
+pub unsafe extern "C" fn hs_get_search_attributes(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -302,8 +342,12 @@ pub extern "C" fn hs_get_search_attributes(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_system_info(
+pub unsafe extern "C" fn hs_get_system_info(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -329,8 +373,12 @@ pub extern "C" fn hs_get_system_info(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_worker_build_id_compatibility(
+pub unsafe extern "C" fn hs_get_worker_build_id_compatibility(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -356,8 +404,12 @@ pub extern "C" fn hs_get_worker_build_id_compatibility(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_workflow_execution_history(
+pub unsafe extern "C" fn hs_get_workflow_execution_history(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -383,8 +435,12 @@ pub extern "C" fn hs_get_workflow_execution_history(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_workflow_execution_history_reverse(
+pub unsafe extern "C" fn hs_get_workflow_execution_history_reverse(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -410,8 +466,12 @@ pub extern "C" fn hs_get_workflow_execution_history_reverse(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_archived_workflow_executions(
+pub unsafe extern "C" fn hs_list_archived_workflow_executions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -437,8 +497,12 @@ pub extern "C" fn hs_list_archived_workflow_executions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_closed_workflow_executions(
+pub unsafe extern "C" fn hs_list_closed_workflow_executions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -464,8 +528,12 @@ pub extern "C" fn hs_list_closed_workflow_executions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_namespaces(
+pub unsafe extern "C" fn hs_list_namespaces(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -491,8 +559,12 @@ pub extern "C" fn hs_list_namespaces(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_open_workflow_executions(
+pub unsafe extern "C" fn hs_list_open_workflow_executions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -518,8 +590,12 @@ pub extern "C" fn hs_list_open_workflow_executions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_schedule_matching_times(
+pub unsafe extern "C" fn hs_list_schedule_matching_times(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -545,8 +621,12 @@ pub extern "C" fn hs_list_schedule_matching_times(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_schedules(
+pub unsafe extern "C" fn hs_list_schedules(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -572,8 +652,12 @@ pub extern "C" fn hs_list_schedules(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_task_queue_partitions(
+pub unsafe extern "C" fn hs_list_task_queue_partitions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -599,8 +683,12 @@ pub extern "C" fn hs_list_task_queue_partitions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_workflow_executions(
+pub unsafe extern "C" fn hs_list_workflow_executions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -626,8 +714,12 @@ pub extern "C" fn hs_list_workflow_executions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_patch_schedule(
+pub unsafe extern "C" fn hs_patch_schedule(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -653,8 +745,12 @@ pub extern "C" fn hs_patch_schedule(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_poll_activity_task_queue(
+pub unsafe extern "C" fn hs_poll_activity_task_queue(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -680,8 +776,12 @@ pub extern "C" fn hs_poll_activity_task_queue(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_poll_workflow_execution_update(
+pub unsafe extern "C" fn hs_poll_workflow_execution_update(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -707,8 +807,12 @@ pub extern "C" fn hs_poll_workflow_execution_update(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_poll_workflow_task_queue(
+pub unsafe extern "C" fn hs_poll_workflow_task_queue(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -734,8 +838,12 @@ pub extern "C" fn hs_poll_workflow_task_queue(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_query_workflow(
+pub unsafe extern "C" fn hs_query_workflow(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -761,8 +869,12 @@ pub extern "C" fn hs_query_workflow(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_record_activity_task_heartbeat(
+pub unsafe extern "C" fn hs_record_activity_task_heartbeat(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -788,8 +900,12 @@ pub extern "C" fn hs_record_activity_task_heartbeat(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_record_activity_task_heartbeat_by_id(
+pub unsafe extern "C" fn hs_record_activity_task_heartbeat_by_id(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -815,8 +931,12 @@ pub extern "C" fn hs_record_activity_task_heartbeat_by_id(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_register_namespace(
+pub unsafe extern "C" fn hs_register_namespace(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -842,8 +962,12 @@ pub extern "C" fn hs_register_namespace(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_request_cancel_workflow_execution(
+pub unsafe extern "C" fn hs_request_cancel_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -869,8 +993,12 @@ pub extern "C" fn hs_request_cancel_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_reset_sticky_task_queue(
+pub unsafe extern "C" fn hs_reset_sticky_task_queue(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -896,8 +1024,12 @@ pub extern "C" fn hs_reset_sticky_task_queue(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_reset_workflow_execution(
+pub unsafe extern "C" fn hs_reset_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -923,8 +1055,12 @@ pub extern "C" fn hs_reset_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_canceled(
+pub unsafe extern "C" fn hs_respond_activity_task_canceled(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -950,8 +1086,12 @@ pub extern "C" fn hs_respond_activity_task_canceled(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_canceled_by_id(
+pub unsafe extern "C" fn hs_respond_activity_task_canceled_by_id(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -977,8 +1117,12 @@ pub extern "C" fn hs_respond_activity_task_canceled_by_id(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_completed(
+pub unsafe extern "C" fn hs_respond_activity_task_completed(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1004,8 +1148,12 @@ pub extern "C" fn hs_respond_activity_task_completed(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_completed_by_id(
+pub unsafe extern "C" fn hs_respond_activity_task_completed_by_id(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1031,8 +1179,12 @@ pub extern "C" fn hs_respond_activity_task_completed_by_id(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_failed(
+pub unsafe extern "C" fn hs_respond_activity_task_failed(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1058,8 +1210,12 @@ pub extern "C" fn hs_respond_activity_task_failed(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_failed_by_id(
+pub unsafe extern "C" fn hs_respond_activity_task_failed_by_id(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1085,8 +1241,12 @@ pub extern "C" fn hs_respond_activity_task_failed_by_id(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_query_task_completed(
+pub unsafe extern "C" fn hs_respond_query_task_completed(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1112,8 +1272,12 @@ pub extern "C" fn hs_respond_query_task_completed(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_workflow_task_completed(
+pub unsafe extern "C" fn hs_respond_workflow_task_completed(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1139,8 +1303,12 @@ pub extern "C" fn hs_respond_workflow_task_completed(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_respond_workflow_task_failed(
+pub unsafe extern "C" fn hs_respond_workflow_task_failed(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1166,8 +1334,12 @@ pub extern "C" fn hs_respond_workflow_task_failed(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_scan_workflow_executions(
+pub unsafe extern "C" fn hs_scan_workflow_executions(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1193,8 +1365,12 @@ pub extern "C" fn hs_scan_workflow_executions(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_signal_with_start_workflow_execution(
+pub unsafe extern "C" fn hs_signal_with_start_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1220,8 +1396,12 @@ pub extern "C" fn hs_signal_with_start_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_signal_workflow_execution(
+pub unsafe extern "C" fn hs_signal_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1247,8 +1427,12 @@ pub extern "C" fn hs_signal_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_start_workflow_execution(
+pub unsafe extern "C" fn hs_start_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1274,8 +1458,12 @@ pub extern "C" fn hs_start_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_terminate_workflow_execution(
+pub unsafe extern "C" fn hs_terminate_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1301,8 +1489,12 @@ pub extern "C" fn hs_terminate_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_update_namespace(
+pub unsafe extern "C" fn hs_update_namespace(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1328,8 +1520,12 @@ pub extern "C" fn hs_update_namespace(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_update_schedule(
+pub unsafe extern "C" fn hs_update_schedule(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1355,8 +1551,12 @@ pub extern "C" fn hs_update_schedule(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_update_workflow_execution(
+pub unsafe extern "C" fn hs_update_workflow_execution(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1382,8 +1582,12 @@ pub extern "C" fn hs_update_workflow_execution(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_update_worker_build_id_compatibility(
+pub unsafe extern "C" fn hs_update_worker_build_id_compatibility(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1409,8 +1613,12 @@ pub extern "C" fn hs_update_worker_build_id_compatibility(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_get_current_time(
+pub unsafe extern "C" fn hs_get_current_time(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1436,8 +1644,12 @@ pub extern "C" fn hs_get_current_time(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_lock_time_skipping(
+pub unsafe extern "C" fn hs_lock_time_skipping(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1463,8 +1675,12 @@ pub extern "C" fn hs_lock_time_skipping(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_sleep_until(
+pub unsafe extern "C" fn hs_sleep_until(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1490,8 +1706,12 @@ pub extern "C" fn hs_sleep_until(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_sleep(
+pub unsafe extern "C" fn hs_sleep(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1517,8 +1737,12 @@ pub extern "C" fn hs_sleep(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_unlock_time_skipping_with_sleep(
+pub unsafe extern "C" fn hs_unlock_time_skipping_with_sleep(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1544,8 +1768,12 @@ pub extern "C" fn hs_unlock_time_skipping_with_sleep(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_unlock_time_skipping(
+pub unsafe extern "C" fn hs_unlock_time_skipping(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1571,8 +1799,12 @@ pub extern "C" fn hs_unlock_time_skipping(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_add_or_update_remote_cluster(
+pub unsafe extern "C" fn hs_add_or_update_remote_cluster(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1598,8 +1830,12 @@ pub extern "C" fn hs_add_or_update_remote_cluster(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_add_search_attributes(
+pub unsafe extern "C" fn hs_add_search_attributes(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1625,8 +1861,12 @@ pub extern "C" fn hs_add_search_attributes(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_delete_namespace(
+pub unsafe extern "C" fn hs_delete_namespace(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1652,8 +1892,12 @@ pub extern "C" fn hs_delete_namespace(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_clusters(
+pub unsafe extern "C" fn hs_list_clusters(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1679,8 +1923,12 @@ pub extern "C" fn hs_list_clusters(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_list_search_attributes(
+pub unsafe extern "C" fn hs_list_search_attributes(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1706,8 +1954,12 @@ pub extern "C" fn hs_list_search_attributes(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_remove_remote_cluster(
+pub unsafe extern "C" fn hs_remove_remote_cluster(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,
@@ -1733,8 +1985,12 @@ pub extern "C" fn hs_remove_remote_cluster(
     });
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_remove_search_attributes(
+pub unsafe extern "C" fn hs_remove_search_attributes(
     client: *mut ClientRef,
     c_call: *const RpcCall,
     mvar: *mut MVar,

--- a/core/rust/src/rpc.rs
+++ b/core/rust/src/rpc.rs
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn hs_count_workflow_executions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn hs_create_schedule(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn hs_delete_schedule(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn hs_deprecate_namespace(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn hs_describe_namespace(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn hs_describe_schedule(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn hs_describe_task_queue(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -261,7 +261,7 @@ pub unsafe extern "C" fn hs_describe_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -292,7 +292,7 @@ pub unsafe extern "C" fn hs_get_cluster_info(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -323,7 +323,7 @@ pub unsafe extern "C" fn hs_get_search_attributes(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -354,7 +354,7 @@ pub unsafe extern "C" fn hs_get_system_info(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -385,7 +385,7 @@ pub unsafe extern "C" fn hs_get_worker_build_id_compatibility(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -416,7 +416,7 @@ pub unsafe extern "C" fn hs_get_workflow_execution_history(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn hs_get_workflow_execution_history_reverse(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -478,7 +478,7 @@ pub unsafe extern "C" fn hs_list_archived_workflow_executions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn hs_list_closed_workflow_executions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -540,7 +540,7 @@ pub unsafe extern "C" fn hs_list_namespaces(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -571,7 +571,7 @@ pub unsafe extern "C" fn hs_list_open_workflow_executions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -602,7 +602,7 @@ pub unsafe extern "C" fn hs_list_schedule_matching_times(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -633,7 +633,7 @@ pub unsafe extern "C" fn hs_list_schedules(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -664,7 +664,7 @@ pub unsafe extern "C" fn hs_list_task_queue_partitions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -695,7 +695,7 @@ pub unsafe extern "C" fn hs_list_workflow_executions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -726,7 +726,7 @@ pub unsafe extern "C" fn hs_patch_schedule(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -757,7 +757,7 @@ pub unsafe extern "C" fn hs_poll_activity_task_queue(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -788,7 +788,7 @@ pub unsafe extern "C" fn hs_poll_workflow_execution_update(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -819,7 +819,7 @@ pub unsafe extern "C" fn hs_poll_workflow_task_queue(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -850,7 +850,7 @@ pub unsafe extern "C" fn hs_query_workflow(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -881,7 +881,7 @@ pub unsafe extern "C" fn hs_record_activity_task_heartbeat(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -912,7 +912,7 @@ pub unsafe extern "C" fn hs_record_activity_task_heartbeat_by_id(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -943,7 +943,7 @@ pub unsafe extern "C" fn hs_register_namespace(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -974,7 +974,7 @@ pub unsafe extern "C" fn hs_request_cancel_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1005,7 +1005,7 @@ pub unsafe extern "C" fn hs_reset_sticky_task_queue(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1036,7 +1036,7 @@ pub unsafe extern "C" fn hs_reset_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1067,7 +1067,7 @@ pub unsafe extern "C" fn hs_respond_activity_task_canceled(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1098,7 +1098,7 @@ pub unsafe extern "C" fn hs_respond_activity_task_canceled_by_id(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1129,7 +1129,7 @@ pub unsafe extern "C" fn hs_respond_activity_task_completed(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1160,7 +1160,7 @@ pub unsafe extern "C" fn hs_respond_activity_task_completed_by_id(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1191,7 +1191,7 @@ pub unsafe extern "C" fn hs_respond_activity_task_failed(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1222,7 +1222,7 @@ pub unsafe extern "C" fn hs_respond_activity_task_failed_by_id(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1253,7 +1253,7 @@ pub unsafe extern "C" fn hs_respond_query_task_completed(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1284,7 +1284,7 @@ pub unsafe extern "C" fn hs_respond_workflow_task_completed(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1315,7 +1315,7 @@ pub unsafe extern "C" fn hs_respond_workflow_task_failed(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1346,7 +1346,7 @@ pub unsafe extern "C" fn hs_scan_workflow_executions(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1377,7 +1377,7 @@ pub unsafe extern "C" fn hs_signal_with_start_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1408,7 +1408,7 @@ pub unsafe extern "C" fn hs_signal_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1439,7 +1439,7 @@ pub unsafe extern "C" fn hs_start_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1470,7 +1470,7 @@ pub unsafe extern "C" fn hs_terminate_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1501,7 +1501,7 @@ pub unsafe extern "C" fn hs_update_namespace(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1532,7 +1532,7 @@ pub unsafe extern "C" fn hs_update_schedule(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1563,7 +1563,7 @@ pub unsafe extern "C" fn hs_update_workflow_execution(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1594,7 +1594,7 @@ pub unsafe extern "C" fn hs_update_worker_build_id_compatibility(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1625,7 +1625,7 @@ pub unsafe extern "C" fn hs_get_current_time(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1656,7 +1656,7 @@ pub unsafe extern "C" fn hs_lock_time_skipping(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1687,7 +1687,7 @@ pub unsafe extern "C" fn hs_sleep_until(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1718,7 +1718,7 @@ pub unsafe extern "C" fn hs_sleep(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1749,7 +1749,7 @@ pub unsafe extern "C" fn hs_unlock_time_skipping_with_sleep(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1780,7 +1780,7 @@ pub unsafe extern "C" fn hs_unlock_time_skipping(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1811,7 +1811,7 @@ pub unsafe extern "C" fn hs_add_or_update_remote_cluster(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1842,7 +1842,7 @@ pub unsafe extern "C" fn hs_add_search_attributes(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1873,7 +1873,7 @@ pub unsafe extern "C" fn hs_delete_namespace(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1904,7 +1904,7 @@ pub unsafe extern "C" fn hs_list_clusters(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1935,7 +1935,7 @@ pub unsafe extern "C" fn hs_list_search_attributes(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1966,7 +1966,7 @@ pub unsafe extern "C" fn hs_remove_remote_cluster(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };
@@ -1997,7 +1997,7 @@ pub unsafe extern "C" fn hs_remove_search_attributes(
     cap: Capability,
     error_slot: *mut *mut CRPCError,
     result_slot: *mut *mut CArray<u8>,
-) -> () {
+) {
     let client = unsafe { &mut *client };
     let mut retry_client = client.retry_client.clone();
     let call: TemporalCall = unsafe { (&*c_call).into() };

--- a/core/rust/src/rpc.rs
+++ b/core/rust/src/rpc.rs
@@ -1,996 +1,1761 @@
-use crate::client::{rpc_req, rpc_resp, RPCError, CRPCError, TemporalCall, RpcCall, ClientRef};
-use crate::runtime::{HsCallback, Capability, MVar};
+use crate::client::{rpc_req, rpc_resp, CRPCError, ClientRef, RPCError, RpcCall, TemporalCall};
+use crate::runtime::{Capability, HsCallback, MVar};
 use ffi_convert::{CArray, CReprOf};
-use temporal_client::WorkflowService;
-use temporal_client::TestService;
 use temporal_client::OperatorService;
+use temporal_client::TestService;
+use temporal_client::WorkflowService;
 
 macro_rules! rpc_call {
-  ($retry_client:ident, $call:ident, $call_name:ident) => {
-    {
-      if $call.retry {
-        let req = rpc_req($call).map_err(|err| 
-              CRPCError::c_repr_of(RPCError {
-                code: 0,
-                message: err,
-                details: vec![],
-              }).unwrap())?;
-        rpc_resp($retry_client.$call_name(req).await)
-      } else {
-        let req = rpc_req($call).map_err(|err| 
-              CRPCError::c_repr_of(RPCError {
-                code: 0,
-                message: err,
-                details: vec![],
-              }).unwrap())?;
-        rpc_resp($retry_client.into_inner().$call_name(req).await)
-      }
-    }
-  };
+    ($retry_client:ident, $call:ident, $call_name:ident) => {{
+        if $call.retry {
+            let req = rpc_req($call).map_err(|err| {
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: err,
+                    details: vec![],
+                })
+                .unwrap()
+            })?;
+            rpc_resp($retry_client.$call_name(req).await)
+        } else {
+            let req = rpc_req($call).map_err(|err| {
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: err,
+                    details: vec![],
+                })
+                .unwrap()
+            })?;
+            rpc_resp($retry_client.into_inner().$call_name(req).await)
+        }
+    }};
 }
 
 // TODO, these are all quite repetitive, can we generate them?
 #[no_mangle]
-pub extern "C" fn hs_count_workflow_executions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_count_workflow_executions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, count_workflow_executions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, count_workflow_executions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_create_schedule(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_create_schedule(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, create_schedule) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, create_schedule) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_delete_schedule(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_delete_schedule(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, delete_schedule) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, delete_schedule) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_deprecate_namespace(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_deprecate_namespace(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, deprecate_namespace) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, deprecate_namespace) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_describe_namespace(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_describe_namespace(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, describe_namespace) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, describe_namespace) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_describe_schedule(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_describe_schedule(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, describe_schedule) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, describe_schedule) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_describe_task_queue(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_describe_task_queue(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, describe_task_queue) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, describe_task_queue) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_describe_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_describe_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, describe_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, describe_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_cluster_info(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_cluster_info(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_cluster_info) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_cluster_info) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_search_attributes(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_search_attributes(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_search_attributes) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_search_attributes) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_system_info(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_system_info(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_system_info) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_system_info) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_worker_build_id_compatibility(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_worker_build_id_compatibility(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_worker_build_id_compatibility) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_worker_build_id_compatibility) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_workflow_execution_history(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_workflow_execution_history(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_workflow_execution_history) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_workflow_execution_history) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_workflow_execution_history_reverse(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_workflow_execution_history_reverse(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_workflow_execution_history_reverse) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_workflow_execution_history_reverse) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_archived_workflow_executions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_archived_workflow_executions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_archived_workflow_executions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_archived_workflow_executions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_closed_workflow_executions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_closed_workflow_executions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_closed_workflow_executions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_closed_workflow_executions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_namespaces(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_namespaces(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_namespaces) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_namespaces) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_open_workflow_executions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_open_workflow_executions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_open_workflow_executions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_open_workflow_executions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_schedule_matching_times(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_schedule_matching_times(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_schedule_matching_times) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_schedule_matching_times) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_schedules(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_schedules(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_schedules) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_schedules) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_task_queue_partitions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_task_queue_partitions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_task_queue_partitions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_task_queue_partitions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_workflow_executions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_workflow_executions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_workflow_executions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_workflow_executions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_patch_schedule(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_patch_schedule(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, patch_schedule) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, patch_schedule) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_poll_activity_task_queue(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_poll_activity_task_queue(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, poll_activity_task_queue) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, poll_activity_task_queue) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_poll_workflow_execution_update(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_poll_workflow_execution_update(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, poll_workflow_execution_update) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, poll_workflow_execution_update) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_poll_workflow_task_queue(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_poll_workflow_task_queue(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, poll_workflow_task_queue) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, poll_workflow_task_queue) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_query_workflow(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_query_workflow(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, query_workflow) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, query_workflow) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_record_activity_task_heartbeat(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_record_activity_task_heartbeat(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, record_activity_task_heartbeat) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, record_activity_task_heartbeat) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_record_activity_task_heartbeat_by_id(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_record_activity_task_heartbeat_by_id(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, record_activity_task_heartbeat_by_id) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, record_activity_task_heartbeat_by_id) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_register_namespace(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_register_namespace(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, register_namespace) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, register_namespace) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_request_cancel_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_request_cancel_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, request_cancel_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, request_cancel_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_reset_sticky_task_queue(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_reset_sticky_task_queue(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, reset_sticky_task_queue) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, reset_sticky_task_queue) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_reset_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_reset_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, reset_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, reset_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_canceled(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_activity_task_canceled(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_activity_task_canceled) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_activity_task_canceled) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_canceled_by_id(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_activity_task_canceled_by_id(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_activity_task_canceled_by_id) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_activity_task_canceled_by_id) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_completed(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_activity_task_completed(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_activity_task_completed) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_activity_task_completed) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_completed_by_id(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_activity_task_completed_by_id(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_activity_task_completed_by_id) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_activity_task_completed_by_id) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_failed(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_activity_task_failed(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_activity_task_failed) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_activity_task_failed) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_activity_task_failed_by_id(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_activity_task_failed_by_id(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_activity_task_failed_by_id) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_activity_task_failed_by_id) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_query_task_completed(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_query_task_completed(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_query_task_completed) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_query_task_completed) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_workflow_task_completed(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_workflow_task_completed(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_workflow_task_completed) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_workflow_task_completed) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_respond_workflow_task_failed(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_respond_workflow_task_failed(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, respond_workflow_task_failed) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, respond_workflow_task_failed) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_scan_workflow_executions(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_scan_workflow_executions(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, scan_workflow_executions) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, scan_workflow_executions) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_signal_with_start_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_signal_with_start_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, signal_with_start_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, signal_with_start_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_signal_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_signal_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, signal_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, signal_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_start_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_start_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, start_workflow_execution) {
-      Ok(resp) => {
-        Ok(CArray::c_repr_of(resp).unwrap())
-      },
-      Err(err) => {
-        Err(err)
-      }
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, start_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_terminate_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_terminate_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, terminate_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, terminate_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_update_namespace(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_update_namespace(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, update_namespace) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, update_namespace) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_update_schedule(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_update_schedule(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, update_schedule) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, update_schedule) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_update_workflow_execution(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_update_workflow_execution(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, update_workflow_execution) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, update_workflow_execution) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_update_worker_build_id_compatibility(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_update_worker_build_id_compatibility(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, update_worker_build_id_compatibility) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, update_worker_build_id_compatibility) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_get_current_time(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_get_current_time(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, get_current_time) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, get_current_time) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_lock_time_skipping(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_lock_time_skipping(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, lock_time_skipping) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, lock_time_skipping) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_sleep_until(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_sleep_until(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, sleep_until) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, sleep_until) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_sleep(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_sleep(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, sleep) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, sleep) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_unlock_time_skipping_with_sleep(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_unlock_time_skipping_with_sleep(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, unlock_time_skipping_with_sleep) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, unlock_time_skipping_with_sleep) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_unlock_time_skipping(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_unlock_time_skipping(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, unlock_time_skipping) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
-}
-
-
-#[no_mangle]
-pub extern "C" fn hs_add_or_update_remote_cluster(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
-
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, add_or_update_remote_cluster) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, unlock_time_skipping) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_add_search_attributes(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_add_or_update_remote_cluster(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, add_search_attributes) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, add_or_update_remote_cluster) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_delete_namespace(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_add_search_attributes(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, delete_namespace) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, add_search_attributes) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_clusters(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_delete_namespace(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_clusters) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, delete_namespace) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_list_search_attributes(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_clusters(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, list_search_attributes) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_clusters) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_remove_remote_cluster(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_list_search_attributes(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, remove_remote_cluster) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, list_search_attributes) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }
 
 #[no_mangle]
-pub extern "C" fn hs_remove_search_attributes(client: *mut ClientRef, c_call: *const RpcCall, mvar: *mut MVar, cap: Capability, error_slot: *mut*mut CRPCError, result_slot: *mut*mut CArray<u8>) -> () {
-  let client = unsafe { &mut *client };
-  let mut retry_client = client.retry_client.clone();
-  let call: TemporalCall = unsafe { (&*c_call).into() };
+pub extern "C" fn hs_remove_remote_cluster(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
 
-  let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback { cap, mvar, result_slot, error_slot };
-  client.runtime.future_result_into_hs(callback, async move {
-    match rpc_call!(retry_client, call, remove_search_attributes) {
-      Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
-      Err(err) => Err(err)
-    }
-  });
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, remove_remote_cluster) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn hs_remove_search_attributes(
+    client: *mut ClientRef,
+    c_call: *const RpcCall,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CRPCError,
+    result_slot: *mut *mut CArray<u8>,
+) -> () {
+    let client = unsafe { &mut *client };
+    let mut retry_client = client.retry_client.clone();
+    let call: TemporalCall = unsafe { (&*c_call).into() };
+
+    let callback: HsCallback<CArray<u8>, CRPCError> = HsCallback {
+        cap,
+        mvar,
+        result_slot,
+        error_slot,
+    };
+    client.runtime.future_result_into_hs(callback, async move {
+        match rpc_call!(retry_client, call, remove_search_attributes) {
+            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Err(err) => Err(err),
+        }
+    });
 }

--- a/core/rust/src/runtime.rs
+++ b/core/rust/src/runtime.rs
@@ -1,238 +1,257 @@
-use std::collections::HashMap;
 use ffi_convert::*;
-use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder};
-use temporal_sdk_core::telemetry::{build_otlp_metric_exporter, construct_filter_string, start_prometheus_metric_exporter};
-use temporal_sdk_core_api::telemetry::{CoreTelemetry, TelemetryOptions, TelemetryOptionsBuilder, Logger, OtelCollectorOptionsBuilder, PrometheusExporterOptionsBuilder};
-use std::sync::Arc;
-use std::os::raw::c_int;
-use std::future::Future;
-use std::net::{SocketAddr};
-use std::time::{Duration, SystemTime};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::os::raw::c_int;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use temporal_sdk_core::telemetry::{
+    build_otlp_metric_exporter, construct_filter_string, start_prometheus_metric_exporter,
+};
+use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder};
 use temporal_sdk_core_api::telemetry::metrics::{CoreMeter, NoOpCoreMeter};
+use temporal_sdk_core_api::telemetry::{
+    CoreTelemetry, Logger, OtelCollectorOptionsBuilder, PrometheusExporterOptionsBuilder,
+    TelemetryOptions, TelemetryOptionsBuilder,
+};
 use tracing::Level;
 
 pub struct RuntimeRef {
-  pub(crate) runtime: Runtime,
+    pub(crate) runtime: Runtime,
 }
 
 #[derive(Clone)]
 pub(crate) struct Runtime {
-  pub(crate) core: Arc<CoreRuntime>,
-  pub(crate) try_put_mvar: extern fn(capability: Capability, mvar: *mut MVar) -> (),
+    pub(crate) core: Arc<CoreRuntime>,
+    pub(crate) try_put_mvar: extern "C" fn(capability: Capability, mvar: *mut MVar) -> (),
 }
 
-fn init_runtime(telemetry_config: TelemetryOptions, late_telemetry_options: HsTelemetryOptions, try_put_mvar: extern fn(capability: Capability, mvar: *mut MVar) -> ()) -> Box<RuntimeRef> {
-  let mut runtime = CoreRuntime::new(
-    telemetry_config,
-    TokioRuntimeBuilder::default()
-  ).unwrap();
+fn init_runtime(
+    telemetry_config: TelemetryOptions,
+    late_telemetry_options: HsTelemetryOptions,
+    try_put_mvar: extern "C" fn(capability: Capability, mvar: *mut MVar) -> (),
+) -> Box<RuntimeRef> {
+    let mut runtime = CoreRuntime::new(telemetry_config, TokioRuntimeBuilder::default()).unwrap();
 
-  let _guard = runtime.tokio_handle().enter();
-  let core_meter: Arc<dyn CoreMeter> = match late_telemetry_options {
-    HsTelemetryOptions::NoTelemetry => {
-      Arc::new(NoOpCoreMeter) as Arc<dyn CoreMeter>
-    },
-    HsTelemetryOptions::OtelTelemetryOptions { url, headers, metric_periodicity, global_tags } => {
-      Arc::new(build_otlp_metric_exporter(
-        OtelCollectorOptionsBuilder::default()
-            .url(url.parse().expect("Invalid URL"))
-            .metric_periodicity(metric_periodicity.unwrap_or_else(|| Duration::new(1, 0)))
-            .headers(headers)
-            .global_tags(global_tags)
-            .build()
-            .expect("Invalid OTEl configuration")
-      ).expect("Otel Metric exporter")) as Arc<dyn CoreMeter>
-    },
-    HsTelemetryOptions::PrometheusTelemetryOptions { socket_addr, global_tags, counters_total_suffix, unit_suffix } => {
-      let srv = start_prometheus_metric_exporter(
-        PrometheusExporterOptionsBuilder::default()
-            .socket_addr(socket_addr)
-            .unit_suffix(unit_suffix)
-            .global_tags(global_tags)
-            .counters_total_suffix(counters_total_suffix)
-            .build().expect("Invalid Prometheus configuration")
-      ).expect("Failed to start prometheus exporter");
-      srv.meter as Arc<dyn CoreMeter>
-    }
-  };
-  runtime.telemetry_mut().attach_late_init_metrics(core_meter);
+    let _guard = runtime.tokio_handle().enter();
+    let core_meter: Arc<dyn CoreMeter> = match late_telemetry_options {
+        HsTelemetryOptions::NoTelemetry => Arc::new(NoOpCoreMeter) as Arc<dyn CoreMeter>,
+        HsTelemetryOptions::OtelTelemetryOptions {
+            url,
+            headers,
+            metric_periodicity,
+            global_tags,
+        } => Arc::new(
+            build_otlp_metric_exporter(
+                OtelCollectorOptionsBuilder::default()
+                    .url(url.parse().expect("Invalid URL"))
+                    .metric_periodicity(metric_periodicity.unwrap_or_else(|| Duration::new(1, 0)))
+                    .headers(headers)
+                    .global_tags(global_tags)
+                    .build()
+                    .expect("Invalid OTEl configuration"),
+            )
+            .expect("Otel Metric exporter"),
+        ) as Arc<dyn CoreMeter>,
+        HsTelemetryOptions::PrometheusTelemetryOptions {
+            socket_addr,
+            global_tags,
+            counters_total_suffix,
+            unit_suffix,
+        } => {
+            let srv = start_prometheus_metric_exporter(
+                PrometheusExporterOptionsBuilder::default()
+                    .socket_addr(socket_addr)
+                    .unit_suffix(unit_suffix)
+                    .global_tags(global_tags)
+                    .counters_total_suffix(counters_total_suffix)
+                    .build()
+                    .expect("Invalid Prometheus configuration"),
+            )
+            .expect("Failed to start prometheus exporter");
+            srv.meter as Arc<dyn CoreMeter>
+        }
+    };
+    runtime.telemetry_mut().attach_late_init_metrics(core_meter);
 
-  // TODO need to figure out how to handle errors here
-  Box::new(
-    RuntimeRef {
-      runtime: Runtime {
-        core: Arc::new(runtime),
-        try_put_mvar
-      },
-    }
-  )
+    // TODO need to figure out how to handle errors here
+    Box::new(RuntimeRef {
+        runtime: Runtime {
+            core: Arc::new(runtime),
+            try_put_mvar,
+        },
+    })
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "tag")]
 pub enum HsTelemetryOptions {
-  OtelTelemetryOptions {
-    url: String,
-    headers: HashMap<String, String>,
-    metric_periodicity: Option<Duration>,
-    global_tags: HashMap<String, String>
-  },
-  PrometheusTelemetryOptions {
-    socket_addr: SocketAddr,
-    global_tags: HashMap<String, String>,
-    counters_total_suffix: bool,
-    unit_suffix: bool
-  },
-  NoTelemetry
+    OtelTelemetryOptions {
+        url: String,
+        headers: HashMap<String, String>,
+        metric_periodicity: Option<Duration>,
+        global_tags: HashMap<String, String>,
+    },
+    PrometheusTelemetryOptions {
+        socket_addr: SocketAddr,
+        global_tags: HashMap<String, String>,
+        counters_total_suffix: bool,
+        unit_suffix: bool,
+    },
+    NoTelemetry,
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_init_runtime(telemetry_opts: *const CArray<u8>, try_put_mvar: extern fn(Capability, *mut MVar) -> ()) -> *mut RuntimeRef {
-  let telemetry_opts = unsafe {
-    CArray::raw_borrow(telemetry_opts).unwrap().as_rust().unwrap().clone()
-  };
-  let telemetry_opts: HsTelemetryOptions = serde_json::from_slice(
-    telemetry_opts.as_slice()
-  ).expect("Failed to parse");
+pub extern "C" fn hs_temporal_init_runtime(
+    telemetry_opts: *const CArray<u8>,
+    try_put_mvar: extern "C" fn(Capability, *mut MVar) -> (),
+) -> *mut RuntimeRef {
+    let telemetry_opts = unsafe {
+        CArray::raw_borrow(telemetry_opts)
+            .unwrap()
+            .as_rust()
+            .unwrap()
+            .clone()
+    };
+    let telemetry_opts: HsTelemetryOptions =
+        serde_json::from_slice(telemetry_opts.as_slice()).expect("Failed to parse");
 
-  let early_options = TelemetryOptionsBuilder::default()
-          .logging(Logger::Forward {
+    let early_options = TelemetryOptionsBuilder::default()
+        .logging(Logger::Forward {
             filter: construct_filter_string(Level::INFO, Level::ERROR),
-          })
-          .attach_service_name(true)
-          // .metrics(core_meter)
-          .build()
-          .expect("Invalid TelemetryOptions");
-  let rt = init_runtime(early_options, telemetry_opts, try_put_mvar);
-  Box::into_raw(rt)
+        })
+        .attach_service_name(true)
+        // .metrics(core_meter)
+        .build()
+        .expect("Invalid TelemetryOptions");
+    let rt = init_runtime(early_options, telemetry_opts, try_put_mvar);
+    Box::into_raw(rt)
 }
 
 fn safe_drop_runtime(runtime: Box<RuntimeRef>) {
-  drop(runtime)
+    drop(runtime)
 }
 
 #[no_mangle]
-pub unsafe extern fn hs_temporal_free_runtime(runtime: *mut RuntimeRef) {
-  safe_drop_runtime(Box::from_raw(runtime));
+pub unsafe extern "C" fn hs_temporal_free_runtime(runtime: *mut RuntimeRef) {
+    safe_drop_runtime(Box::from_raw(runtime));
 }
 
 #[repr(C)]
 pub struct MVar {
     _data: [u8; 0],
-    _marker:
-        core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+    _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
 #[repr(C)]
 pub struct Capability {
-  pub cap_num: c_int
+    pub cap_num: c_int,
 }
-
 
 pub struct HsCallback<A, E> {
-  pub cap: Capability,
-  pub mvar: *mut MVar,
-  pub result_slot: *mut*mut A,
-  pub error_slot: *mut*mut E,
+    pub cap: Capability,
+    pub mvar: *mut MVar,
+    pub result_slot: *mut *mut A,
+    pub error_slot: *mut *mut E,
 }
 
-impl <A, E> HsCallback<A, E> {
-  pub(crate) fn put_success(self, runtime: &Runtime, result: A)
-  where
-    A: RawPointerConverter<A>,
-  {
-    unsafe {
-      *self.result_slot = result.into_raw_pointer_mut();
-      *self.error_slot = std::ptr::null_mut();
-      runtime.put_mvar(self.cap, self.mvar);
+impl<A, E> HsCallback<A, E> {
+    pub(crate) fn put_success(self, runtime: &Runtime, result: A)
+    where
+        A: RawPointerConverter<A>,
+    {
+        unsafe {
+            *self.result_slot = result.into_raw_pointer_mut();
+            *self.error_slot = std::ptr::null_mut();
+            runtime.put_mvar(self.cap, self.mvar);
+        }
     }
-  }
 
-  pub(crate) fn put_failure(self, runtime: &Runtime, error: E)
-  where
-    E: RawPointerConverter<E>,
-  {
-    unsafe {
-      *self.error_slot = error.into_raw_pointer_mut();
-      *self.result_slot = std::ptr::null_mut();
-      runtime.put_mvar(self.cap, self.mvar);
+    pub(crate) fn put_failure(self, runtime: &Runtime, error: E)
+    where
+        E: RawPointerConverter<E>,
+    {
+        unsafe {
+            *self.error_slot = error.into_raw_pointer_mut();
+            *self.result_slot = std::ptr::null_mut();
+            runtime.put_mvar(self.cap, self.mvar);
+        }
     }
-  }
 
-  pub(crate) fn put_result(self, runtime: &Runtime, result: Result<A, E>)
-  where
-    A: RawPointerConverter<A>,
-    E: RawPointerConverter<E>,
-  {
-    match result {
-      Ok(result) => self.put_success(runtime, result),
-      Err(error) => self.put_failure(runtime, error),
+    pub(crate) fn put_result(self, runtime: &Runtime, result: Result<A, E>)
+    where
+        A: RawPointerConverter<A>,
+        E: RawPointerConverter<E>,
+    {
+        match result {
+            Ok(result) => self.put_success(runtime, result),
+            Err(error) => self.put_failure(runtime, error),
+        }
     }
-  }
 }
 
 impl Runtime {
+    pub fn future_result_into_hs<F, T, E>(&self, callback: HsCallback<T, E>, fut: F)
+    where
+        F: Future<Output = Result<T, E>> + Send + 'static,
+        T: RawPointerConverter<T>,
+        E: RawPointerConverter<E>,
+    {
+        let handle = self.core.tokio_handle();
+        let _guard = handle.enter();
+        let result = handle.block_on(fut);
+        callback.put_result(self, result);
+    }
 
-  pub fn future_result_into_hs<F, T, E>(&self, callback: HsCallback<T, E>, fut: F)
-  where
-      F: Future<Output = Result<T, E>> + Send + 'static,
-      T: RawPointerConverter<T>,
-      E: RawPointerConverter<E>
-  {
-    let handle = self.core.tokio_handle();
-    let _guard = handle.enter();
-    let result = handle.block_on(fut);
-    callback.put_result(self, result);
-  }
-
-  pub fn put_mvar(&self, capability: Capability, mvar: *mut MVar) {
-    (self.try_put_mvar)(capability, mvar);
-  }
+    pub fn put_mvar(&self, capability: Capability, mvar: *mut MVar) {
+        (self.try_put_mvar)(capability, mvar);
+    }
 }
 
 #[no_mangle]
-pub extern fn hs_temporal_drop_byte_array(str: *const CArray<u8>) {
-  unsafe {
-    drop(CArray::from_raw_pointer(str));
-  }
+pub extern "C" fn hs_temporal_drop_byte_array(str: *const CArray<u8>) {
+    unsafe {
+        drop(CArray::from_raw_pointer(str));
+    }
 }
 
 #[derive(Serialize)]
 pub struct CoreLogDef {
-  pub target: String,
-  pub message: String,
-  pub timestamp: SystemTime,
-  pub level: String,
-  pub fields: HashMap<String, serde_json::Value>,
-  pub span_contexts: Vec<String>
+    pub target: String,
+    pub message: String,
+    pub timestamp: SystemTime,
+    pub level: String,
+    pub fields: HashMap<String, serde_json::Value>,
+    pub span_contexts: Vec<String>,
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_runtime_fetch_logs(
-  runtime: *mut RuntimeRef,
+    runtime: *mut RuntimeRef,
 ) -> *const CArray<CArray<u8>> {
-  let runtime = unsafe { &*runtime };
-  let logs = runtime.runtime.core.telemetry().fetch_buffered_logs();
-  let hs_logs: Vec<Vec<u8>> = logs.iter().map(|log| {
-    let log = CoreLogDef {
-      target: log.target.clone(),
-      message: log.message.clone(),
-      timestamp: log.timestamp,
-      level: String::from(log.level.as_str()),
-      fields: log.fields.clone(),
-      span_contexts: log.span_contexts.clone()
-    };
-    serde_json::to_vec(&log).expect("Failed to serialize log line")
-  }).collect();
-  CArray::c_repr_of(hs_logs).unwrap().into_raw_pointer()
+    let runtime = unsafe { &*runtime };
+    let logs = runtime.runtime.core.telemetry().fetch_buffered_logs();
+    let hs_logs: Vec<Vec<u8>> = logs
+        .iter()
+        .map(|log| {
+            let log = CoreLogDef {
+                target: log.target.clone(),
+                message: log.message.clone(),
+                timestamp: log.timestamp,
+                level: String::from(log.level.as_str()),
+                fields: log.fields.clone(),
+                span_contexts: log.span_contexts.clone(),
+            };
+            serde_json::to_vec(&log).expect("Failed to serialize log line")
+        })
+        .collect();
+    CArray::c_repr_of(hs_logs).unwrap().into_raw_pointer()
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_runtime_free_logs(
-  logs: *const CArray<CArray<u8>>
-) {
-  unsafe {
-    drop(CArray::from_raw_pointer(logs));
-  }
+pub extern "C" fn hs_temporal_runtime_free_logs(logs: *const CArray<CArray<u8>>) {
+    unsafe {
+        drop(CArray::from_raw_pointer(logs));
+    }
 }

--- a/core/rust/src/runtime.rs
+++ b/core/rust/src/runtime.rs
@@ -102,8 +102,12 @@ pub enum HsTelemetryOptions {
     NoTelemetry,
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_init_runtime(
+pub unsafe extern "C" fn hs_temporal_init_runtime(
     telemetry_opts: *const CArray<u8>,
     try_put_mvar: extern "C" fn(Capability, *mut MVar) -> (),
 ) -> *mut RuntimeRef {
@@ -133,6 +137,10 @@ fn safe_drop_runtime(runtime: Box<RuntimeRef>) {
     drop(runtime)
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
 pub unsafe extern "C" fn hs_temporal_free_runtime(runtime: *mut RuntimeRef) {
     safe_drop_runtime(Box::from_raw(runtime));
@@ -209,8 +217,12 @@ impl Runtime {
     }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_byte_array(str: *const CArray<u8>) {
+pub unsafe extern "C" fn hs_temporal_drop_byte_array(str: *const CArray<u8>) {
     unsafe {
         drop(CArray::from_raw_pointer(str));
     }
@@ -226,8 +238,12 @@ pub struct CoreLogDef {
     pub span_contexts: Vec<String>,
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_runtime_fetch_logs(
+pub unsafe extern "C" fn hs_temporal_runtime_fetch_logs(
     runtime: *mut RuntimeRef,
 ) -> *const CArray<CArray<u8>> {
     let runtime = unsafe { &*runtime };
@@ -249,8 +265,12 @@ pub extern "C" fn hs_temporal_runtime_fetch_logs(
     CArray::c_repr_of(hs_logs).unwrap().into_raw_pointer()
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_runtime_free_logs(logs: *const CArray<CArray<u8>>) {
+pub unsafe extern "C" fn hs_temporal_runtime_free_logs(logs: *const CArray<CArray<u8>>) {
     unsafe {
         drop(CArray::from_raw_pointer(logs));
     }

--- a/core/rust/src/worker.rs
+++ b/core/rust/src/worker.rs
@@ -170,13 +170,23 @@ pub struct CWorkerValidationError {
     message: *const c_char,
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_worker_validation_error(err: *mut CWorkerValidationError) -> () {
+pub unsafe extern "C" fn hs_temporal_drop_worker_validation_error(
+    err: *mut CWorkerValidationError,
+) -> () {
     unsafe { drop(CWorkerValidationError::from_raw_pointer_mut(err)) }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_worker_error(err: *mut CWorkerError) -> () {
+pub unsafe extern "C" fn hs_temporal_drop_worker_error(err: *mut CWorkerError) -> () {
     unsafe { drop(CWorkerError::from_raw_pointer_mut(err)) }
 }
 
@@ -186,8 +196,12 @@ pub struct Unit {}
 #[target_type(Unit)]
 pub struct CUnit {}
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_unit(unit: *mut CUnit) -> () {
+pub unsafe extern "C" fn hs_temporal_drop_unit(unit: *mut CUnit) -> () {
     unsafe { drop(CUnit::from_raw_pointer_mut(unit)) }
 }
 
@@ -209,13 +223,21 @@ fn new_worker(client: &client::ClientRef, config: WorkerConfig) -> Result<Worker
     })
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_drop_worker(worker: *mut WorkerRef) -> () {
+pub unsafe extern "C" fn hs_temporal_drop_worker(worker: *mut WorkerRef) -> () {
     unsafe { drop(Box::from_raw(worker)) }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_new_worker(
+pub unsafe extern "C" fn hs_temporal_new_worker(
     client: *mut client::ClientRef,
     config: *const CArray<u8>,
     result_slot: *mut *mut WorkerRef,
@@ -280,8 +302,12 @@ fn new_replay_worker(
     Ok((worker, history_pusher))
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_new_replay_worker(
+pub unsafe extern "C" fn hs_temporal_new_replay_worker(
     runtime: *mut runtime::RuntimeRef,
     config: *const CArray<u8>,
     worker_slot: *mut *mut WorkerRef,
@@ -473,8 +499,12 @@ impl WorkerRef {
     }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_validate_worker(
+pub unsafe extern "C" fn hs_temporal_validate_worker(
     worker: *mut WorkerRef,
     mvar: *mut MVar,
     cap: Capability,
@@ -502,8 +532,12 @@ pub extern "C" fn hs_temporal_validate_worker(
     })
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_poll_workflow_activation(
+pub unsafe extern "C" fn hs_temporal_worker_poll_workflow_activation(
     worker: *mut WorkerRef,
     mvar: *mut MVar,
     cap: Capability,
@@ -520,8 +554,12 @@ pub extern "C" fn hs_temporal_worker_poll_workflow_activation(
     worker.poll_workflow_activation(hs)
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_poll_activity_task(
+pub unsafe extern "C" fn hs_temporal_worker_poll_activity_task(
     worker: *mut WorkerRef,
     mvar: *mut MVar,
     cap: Capability,
@@ -538,8 +576,12 @@ pub extern "C" fn hs_temporal_worker_poll_activity_task(
     worker.poll_activity_task(hs)
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_complete_workflow_activation(
+pub unsafe extern "C" fn hs_temporal_worker_complete_workflow_activation(
     worker: *mut WorkerRef,
     proto: *const CArray<u8>,
     mvar: *mut MVar,
@@ -559,8 +601,12 @@ pub extern "C" fn hs_temporal_worker_complete_workflow_activation(
     worker.complete_workflow_activation(hs, proto)
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_complete_activity_task(
+pub unsafe extern "C" fn hs_temporal_worker_complete_activity_task(
     worker: *mut WorkerRef,
     proto: *const CArray<u8>,
     mvar: *mut MVar,
@@ -580,8 +626,12 @@ pub extern "C" fn hs_temporal_worker_complete_activity_task(
     worker.complete_activity_task(hs, proto)
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_record_activity_heartbeat(
+pub unsafe extern "C" fn hs_temporal_worker_record_activity_heartbeat(
     worker: *mut WorkerRef,
     proto: *const CArray<u8>,
     error_slot: *mut *mut CWorkerError,
@@ -606,8 +656,12 @@ pub extern "C" fn hs_temporal_worker_record_activity_heartbeat(
     }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_request_workflow_eviction(
+pub unsafe extern "C" fn hs_temporal_worker_request_workflow_eviction(
     worker: *mut WorkerRef,
     run_id: *const CArray<u8>,
 ) {
@@ -618,14 +672,22 @@ pub extern "C" fn hs_temporal_worker_request_workflow_eviction(
     worker.request_workflow_eviction(run_id)
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_initiate_shutdown(worker: *mut WorkerRef) {
+pub unsafe extern "C" fn hs_temporal_worker_initiate_shutdown(worker: *mut WorkerRef) {
     let worker = unsafe { &*worker };
     worker.initiate_shutdown()
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_finalize_shutdown(
+pub unsafe extern "C" fn hs_temporal_worker_finalize_shutdown(
     worker: *mut WorkerRef,
     mvar: *mut MVar,
     cap: Capability,
@@ -705,8 +767,12 @@ impl HistoryPusher {
     }
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell <-> Tokio FFI bridge invariants.
 #[no_mangle]
-pub extern "C" fn hs_temporal_history_pusher_push_history(
+pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     history_pusher: *mut HistoryPusher,
     workflow_id: *const CArray<u8>,
     history_proto: *const CArray<u8>,
@@ -733,14 +799,28 @@ pub extern "C" fn hs_temporal_history_pusher_push_history(
     )
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
+///
+/// The caller must ensure that the argument is a live pointer to a [`HistoryPusher`], typically from across the FFI
+/// boundary after having been constructed by [`hs_temporal_new_replay_worker`].
 #[no_mangle]
-pub extern "C" fn hs_temporal_history_pusher_close(history_pusher: *mut HistoryPusher) {
+pub unsafe extern "C" fn hs_temporal_history_pusher_close(history_pusher: *mut HistoryPusher) {
     let history_pusher = unsafe { &mut *history_pusher };
     history_pusher.close()
 }
 
+// TODO: [publish-crate]
+/// # Safety
+///
+/// Haskell FFI bridge invariants.
+///
+/// The caller must ensure that the argument is a live pointer to a [`HistoryPusher`], typically from across the FFI
+/// boundary after having been constructed by [`hs_temporal_new_replay_worker`].
 #[no_mangle]
-pub extern "C" fn hs_temporal_history_pusher_drop(history_pusher: *mut HistoryPusher) {
+pub unsafe extern "C" fn hs_temporal_history_pusher_drop(history_pusher: *mut HistoryPusher) {
     let history_pusher = unsafe { Box::from_raw(history_pusher) };
     drop(history_pusher)
 }

--- a/core/rust/src/worker.rs
+++ b/core/rust/src/worker.rs
@@ -1,14 +1,14 @@
-use std::collections::{HashMap, HashSet};
-use ffi_convert::{CArray, RawPointerConverter, AsRust, CReprOf, CDrop, CDropError, RawBorrow};
+use ffi_convert::{AsRust, CArray, CDrop, CDropError, CReprOf, RawBorrow, RawPointerConverter};
 use libc::c_char;
 use prost::Message;
+use std::collections::{HashMap, HashSet};
 use std::str;
 use std::sync::Arc;
 use std::time::Duration;
 use temporal_sdk_core::api::errors::{PollActivityError, PollWfError};
 use temporal_sdk_core::replay::{HistoryForReplay, ReplayWorkerInput};
 use temporal_sdk_core_api::errors::WorkflowErrorType;
-use temporal_sdk_core_api::{Worker};
+use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCompletion;
 use temporal_sdk_core_protos::coresdk::{ActivityHeartbeat, ActivityTaskCompletion};
 use temporal_sdk_core_protos::temporal::api::history::v1::History;
@@ -16,147 +16,147 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::client;
-use crate::runtime::{self, HsCallback, Capability, MVar};
+use crate::runtime::{self, Capability, HsCallback, MVar};
 use serde::{Deserialize, Serialize};
 
 pub struct WorkerRef {
-  worker: Option<Arc<temporal_sdk_core::Worker>>,
-  runtime: runtime::Runtime,
+    worker: Option<Arc<temporal_sdk_core::Worker>>,
+    runtime: runtime::Runtime,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct WorkerConfig {
-  namespace: String,
-  task_queue: String,
-  build_id: String,
-  identity_override: Option<String>,
-  max_cached_workflows: usize,
-  max_outstanding_workflow_tasks: usize,
-  max_outstanding_activities: usize,
-  max_outstanding_local_activities: usize,
-  max_concurrent_workflow_task_polls: usize,
-  nonsticky_to_sticky_poll_ratio: f32,
-  max_concurrent_activity_task_polls: usize,
-  no_remote_activities: bool,
-  sticky_queue_schedule_to_start_timeout_millis: u64,
-  max_heartbeat_throttle_interval_millis: u64,
-  default_heartbeat_throttle_interval_millis: u64,
-  max_activities_per_second: Option<f64>,
-  max_task_queue_activities_per_second: Option<f64>,
-  graceful_shutdown_period_millis: u64,
-  nondeterminism_as_workflow_fail: bool,
-  nondeterminism_as_workflow_fail_for_types: Vec<String>,
+    namespace: String,
+    task_queue: String,
+    build_id: String,
+    identity_override: Option<String>,
+    max_cached_workflows: usize,
+    max_outstanding_workflow_tasks: usize,
+    max_outstanding_activities: usize,
+    max_outstanding_local_activities: usize,
+    max_concurrent_workflow_task_polls: usize,
+    nonsticky_to_sticky_poll_ratio: f32,
+    max_concurrent_activity_task_polls: usize,
+    no_remote_activities: bool,
+    sticky_queue_schedule_to_start_timeout_millis: u64,
+    max_heartbeat_throttle_interval_millis: u64,
+    default_heartbeat_throttle_interval_millis: u64,
+    max_activities_per_second: Option<f64>,
+    max_task_queue_activities_per_second: Option<f64>,
+    graceful_shutdown_period_millis: u64,
+    nondeterminism_as_workflow_fail: bool,
+    nondeterminism_as_workflow_fail_for_types: Vec<String>,
 }
 
 impl TryFrom<WorkerConfig> for temporal_sdk_core::WorkerConfig {
-  type Error = WorkerError;
+    type Error = WorkerError;
 
-  fn try_from(conf: WorkerConfig) -> Result<Self, WorkerError> {
-      temporal_sdk_core::WorkerConfigBuilder::default()
-          .namespace(conf.namespace)
-          .task_queue(conf.task_queue)
-          .worker_build_id(conf.build_id)
-          .client_identity_override(conf.identity_override)
-          .max_cached_workflows(conf.max_cached_workflows)
-          .max_outstanding_workflow_tasks(conf.max_outstanding_workflow_tasks)
-          .max_outstanding_activities(conf.max_outstanding_activities)
-          .max_outstanding_local_activities(conf.max_outstanding_local_activities)
-          .max_concurrent_wft_polls(conf.max_concurrent_workflow_task_polls)
-          .nonsticky_to_sticky_poll_ratio(conf.nonsticky_to_sticky_poll_ratio)
-          .max_concurrent_at_polls(conf.max_concurrent_activity_task_polls)
-          .no_remote_activities(conf.no_remote_activities)
-          .sticky_queue_schedule_to_start_timeout(Duration::from_millis(
-              conf.sticky_queue_schedule_to_start_timeout_millis,
-          ))
-          .max_heartbeat_throttle_interval(Duration::from_millis(
-              conf.max_heartbeat_throttle_interval_millis,
-          ))
-          .default_heartbeat_throttle_interval(Duration::from_millis(
-              conf.default_heartbeat_throttle_interval_millis,
-          ))
-          .max_worker_activities_per_second(conf.max_activities_per_second)
-          .max_task_queue_activities_per_second(conf.max_task_queue_activities_per_second)
-          // Even though grace period is optional, if it is not set then the
-          // auto-cancel-activity behavior of shutdown will not occur, so we
-          // always set it even if 0.
-          .graceful_shutdown_period(Duration::from_millis(conf.graceful_shutdown_period_millis))
-          .workflow_failure_errors(if conf.nondeterminism_as_workflow_fail {
-            HashSet::from([WorkflowErrorType::Nondeterminism])
-          } else {
-            HashSet::new()
-          })
-          .workflow_types_to_failure_errors(conf
-            .nondeterminism_as_workflow_fail_for_types
-            .iter()
-            .map(|s| {
-              (
-                s.to_owned(),
-                HashSet::from([WorkflowErrorType::Nondeterminism]),
-              )
+    fn try_from(conf: WorkerConfig) -> Result<Self, WorkerError> {
+        temporal_sdk_core::WorkerConfigBuilder::default()
+            .namespace(conf.namespace)
+            .task_queue(conf.task_queue)
+            .worker_build_id(conf.build_id)
+            .client_identity_override(conf.identity_override)
+            .max_cached_workflows(conf.max_cached_workflows)
+            .max_outstanding_workflow_tasks(conf.max_outstanding_workflow_tasks)
+            .max_outstanding_activities(conf.max_outstanding_activities)
+            .max_outstanding_local_activities(conf.max_outstanding_local_activities)
+            .max_concurrent_wft_polls(conf.max_concurrent_workflow_task_polls)
+            .nonsticky_to_sticky_poll_ratio(conf.nonsticky_to_sticky_poll_ratio)
+            .max_concurrent_at_polls(conf.max_concurrent_activity_task_polls)
+            .no_remote_activities(conf.no_remote_activities)
+            .sticky_queue_schedule_to_start_timeout(Duration::from_millis(
+                conf.sticky_queue_schedule_to_start_timeout_millis,
+            ))
+            .max_heartbeat_throttle_interval(Duration::from_millis(
+                conf.max_heartbeat_throttle_interval_millis,
+            ))
+            .default_heartbeat_throttle_interval(Duration::from_millis(
+                conf.default_heartbeat_throttle_interval_millis,
+            ))
+            .max_worker_activities_per_second(conf.max_activities_per_second)
+            .max_task_queue_activities_per_second(conf.max_task_queue_activities_per_second)
+            // Even though grace period is optional, if it is not set then the
+            // auto-cancel-activity behavior of shutdown will not occur, so we
+            // always set it even if 0.
+            .graceful_shutdown_period(Duration::from_millis(conf.graceful_shutdown_period_millis))
+            .workflow_failure_errors(if conf.nondeterminism_as_workflow_fail {
+                HashSet::from([WorkflowErrorType::Nondeterminism])
+            } else {
+                HashSet::new()
             })
-            .collect::<HashMap<String, HashSet<WorkflowErrorType>>>(),
-          )
-          .build()
-          .map_err(|err| WorkerError {
-            code: WorkerErrorCode::InvalidWorkerConfig,
-            message: format!("{}", err)
-          })
-  }
+            .workflow_types_to_failure_errors(
+                conf.nondeterminism_as_workflow_fail_for_types
+                    .iter()
+                    .map(|s| {
+                        (
+                            s.to_owned(),
+                            HashSet::from([WorkflowErrorType::Nondeterminism]),
+                        )
+                    })
+                    .collect::<HashMap<String, HashSet<WorkflowErrorType>>>(),
+            )
+            .build()
+            .map_err(|err| WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: format!("{}", err),
+            })
+    }
 }
 
 macro_rules! enter_sync {
-  ($runtime:expr) => {
-    if let Some(subscriber) = $runtime.core.telemetry().trace_subscriber() {
-      temporal_sdk_core::telemetry::set_trace_subscriber_for_current_thread(subscriber);
-    }
-    let _guard = $runtime.core.tokio_handle().enter();
-  };
+    ($runtime:expr) => {
+        if let Some(subscriber) = $runtime.core.telemetry().trace_subscriber() {
+            temporal_sdk_core::telemetry::set_trace_subscriber_for_current_thread(subscriber);
+        }
+        let _guard = $runtime.core.tokio_handle().enter();
+    };
 }
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum WorkerErrorCode {
-  SDKError = 1,
-  InitWorkerFailed = 2,
-  InitReplayWorkerFailed = 3,
-  InvalidProto = 4,
-  ReplayWorkerClosed = 5,
-  PollShutdownError = 6,
-  PollFailure = 7,
-  CompletionFailure = 8,
-  InvalidWorkerConfig = 9,
+    SDKError = 1,
+    InitWorkerFailed = 2,
+    InitReplayWorkerFailed = 3,
+    InvalidProto = 4,
+    ReplayWorkerClosed = 5,
+    PollShutdownError = 6,
+    PollFailure = 7,
+    CompletionFailure = 8,
+    InvalidWorkerConfig = 9,
 }
 
 impl AsRust<WorkerErrorCode> for WorkerErrorCode {
-  fn as_rust(&self) -> Result<WorkerErrorCode, ffi_convert::AsRustError> {
-    Ok(*self)
-  }
+    fn as_rust(&self) -> Result<WorkerErrorCode, ffi_convert::AsRustError> {
+        Ok(*self)
+    }
 }
 
 impl CDrop for WorkerErrorCode {
-  fn do_drop(&mut self) -> Result<(), CDropError>{
-    Ok(())
-  }
+    fn do_drop(&mut self) -> Result<(), CDropError> {
+        Ok(())
+    }
 }
 
 impl CReprOf<WorkerErrorCode> for WorkerErrorCode {
-  fn c_repr_of(input: WorkerErrorCode) -> Result<WorkerErrorCode, ffi_convert::CReprOfError> {
-    Ok(input)
-  }
+    fn c_repr_of(input: WorkerErrorCode) -> Result<WorkerErrorCode, ffi_convert::CReprOfError> {
+        Ok(input)
+    }
 }
 
 #[derive(Debug)]
 pub struct WorkerError {
-  code: WorkerErrorCode,
-  message: String,
+    code: WorkerErrorCode,
+    message: String,
 }
 
 #[repr(C)]
 #[derive(CReprOf, AsRust, RawPointerConverter, CDrop)]
 #[target_type(WorkerError)]
 pub struct CWorkerError {
-  code: WorkerErrorCode,
-  message: *const c_char,
+    code: WorkerErrorCode,
+    message: *const c_char,
 }
 
 struct FormattedError {
@@ -167,17 +167,17 @@ struct FormattedError {
 #[derive(CReprOf, AsRust, RawPointerConverter, CDrop)]
 #[target_type(FormattedError)]
 pub struct CWorkerValidationError {
-    message: *const c_char
+    message: *const c_char,
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_drop_worker_validation_error(err: *mut CWorkerValidationError) -> () {
-  unsafe { drop(CWorkerValidationError::from_raw_pointer_mut(err)) }
+    unsafe { drop(CWorkerValidationError::from_raw_pointer_mut(err)) }
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_drop_worker_error(err: *mut CWorkerError) -> () {
-  unsafe { drop(CWorkerError::from_raw_pointer_mut(err)) }
+    unsafe { drop(CWorkerError::from_raw_pointer_mut(err)) }
 }
 
 pub struct Unit {}
@@ -188,536 +188,559 @@ pub struct CUnit {}
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_drop_unit(unit: *mut CUnit) -> () {
-  unsafe { drop(CUnit::from_raw_pointer_mut(unit)) }
+    unsafe { drop(CUnit::from_raw_pointer_mut(unit)) }
 }
 
-fn new_worker(
-  client: &client::ClientRef,
-  config: WorkerConfig,
-) -> Result<WorkerRef, WorkerError> {
-  enter_sync!(&client.runtime);
-  let config: temporal_sdk_core::WorkerConfig = config.try_into()?;
-  let worker = temporal_sdk_core::init_worker(
-      &client.runtime.core,
-      config,
-      client.retry_client.clone().into_inner(),
-  )
-  .map_err(|err| WorkerError {
-    code: WorkerErrorCode::InitWorkerFailed,
-    message: format!("Failed creating worker: {}", err),
-  })?;
-  Ok(WorkerRef {
-      worker: Some(Arc::new(worker)),
-      runtime: client.runtime.clone(),
-  })
+fn new_worker(client: &client::ClientRef, config: WorkerConfig) -> Result<WorkerRef, WorkerError> {
+    enter_sync!(&client.runtime);
+    let config: temporal_sdk_core::WorkerConfig = config.try_into()?;
+    let worker = temporal_sdk_core::init_worker(
+        &client.runtime.core,
+        config,
+        client.retry_client.clone().into_inner(),
+    )
+    .map_err(|err| WorkerError {
+        code: WorkerErrorCode::InitWorkerFailed,
+        message: format!("Failed creating worker: {}", err),
+    })?;
+    Ok(WorkerRef {
+        worker: Some(Arc::new(worker)),
+        runtime: client.runtime.clone(),
+    })
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_drop_worker(worker: *mut WorkerRef) -> () {
-  unsafe{drop(Box::from_raw(worker))}
+    unsafe { drop(Box::from_raw(worker)) }
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_new_worker(client: *mut client::ClientRef, config: *const CArray<u8>, result_slot: *mut*mut WorkerRef, error_slot: *mut*mut CWorkerError) -> () {
-  let client_ref = unsafe { client.as_ref() }.expect("client is null");
-  let config_json = unsafe { CArray::raw_borrow(config).unwrap() };
-  let config = serde_json::from_slice(&config_json.as_rust().unwrap().clone()).map_err(|err| WorkerError {
-    code: WorkerErrorCode::InvalidWorkerConfig,
-    message: format!("{}", err),
-  });
-
-  match config {
-    Ok(config) => {
-      let result = new_worker(client_ref, config);
-      match result {
-        Ok(worker_ref) => {
-          unsafe { *result_slot = Box::into_raw(Box::new(worker_ref)) };
-        },
-        Err(worker_error) => {
-          eprintln!("Error: {:?}", worker_error);
-          unsafe { *error_slot = CWorkerError::c_repr_of(worker_error).unwrap().into_raw_pointer_mut() };
+pub extern "C" fn hs_temporal_new_worker(
+    client: *mut client::ClientRef,
+    config: *const CArray<u8>,
+    result_slot: *mut *mut WorkerRef,
+    error_slot: *mut *mut CWorkerError,
+) -> () {
+    let client_ref = unsafe { client.as_ref() }.expect("client is null");
+    let config_json = unsafe { CArray::raw_borrow(config).unwrap() };
+    let config = serde_json::from_slice(&config_json.as_rust().unwrap().clone()).map_err(|err| {
+        WorkerError {
+            code: WorkerErrorCode::InvalidWorkerConfig,
+            message: format!("{}", err),
         }
-      }
-    },
-    Err(worker_error) => {
-      eprintln!("Error: {:?}", worker_error);
-      unsafe { *error_slot = CWorkerError::c_repr_of(worker_error).unwrap().into_raw_pointer_mut() };
+    });
+
+    match config {
+        Ok(config) => {
+            let result = new_worker(client_ref, config);
+            match result {
+                Ok(worker_ref) => {
+                    unsafe { *result_slot = Box::into_raw(Box::new(worker_ref)) };
+                }
+                Err(worker_error) => {
+                    eprintln!("Error: {:?}", worker_error);
+                    unsafe {
+                        *error_slot = CWorkerError::c_repr_of(worker_error)
+                            .unwrap()
+                            .into_raw_pointer_mut()
+                    };
+                }
+            }
+        }
+        Err(worker_error) => {
+            eprintln!("Error: {:?}", worker_error);
+            unsafe {
+                *error_slot = CWorkerError::c_repr_of(worker_error)
+                    .unwrap()
+                    .into_raw_pointer_mut()
+            };
+        }
     }
-  }
 }
 
 fn new_replay_worker(
-  runtime_ref: &runtime::RuntimeRef,
-  config: WorkerConfig,
+    runtime_ref: &runtime::RuntimeRef,
+    config: WorkerConfig,
 ) -> Result<(WorkerRef, HistoryPusher), WorkerError> {
-  enter_sync!(runtime_ref.runtime);
-  let config: temporal_sdk_core::WorkerConfig = config.try_into()?;
-  let (history_pusher, stream) = HistoryPusher::new(runtime_ref.runtime.clone());
-  let worker = WorkerRef {
-      worker: Some(Arc::new(
-          temporal_sdk_core::init_replay_worker(ReplayWorkerInput::new(config, stream))
-          .map_err(|err| {
-              WorkerError {
-                code: WorkerErrorCode::InitReplayWorkerFailed,
-                message: format!("Failed creating replay worker: {}", err)
-              }
-          })?,
-      )),
-      runtime: runtime_ref.runtime.clone(),
-  };
+    enter_sync!(runtime_ref.runtime);
+    let config: temporal_sdk_core::WorkerConfig = config.try_into()?;
+    let (history_pusher, stream) = HistoryPusher::new(runtime_ref.runtime.clone());
+    let worker = WorkerRef {
+        worker: Some(Arc::new(
+            temporal_sdk_core::init_replay_worker(ReplayWorkerInput::new(config, stream)).map_err(
+                |err| WorkerError {
+                    code: WorkerErrorCode::InitReplayWorkerFailed,
+                    message: format!("Failed creating replay worker: {}", err),
+                },
+            )?,
+        )),
+        runtime: runtime_ref.runtime.clone(),
+    };
 
-  Ok((worker, history_pusher))
+    Ok((worker, history_pusher))
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_new_replay_worker(runtime: *mut runtime::RuntimeRef, config: *const CArray<u8>, worker_slot: *mut*mut WorkerRef, history_slot: *mut*mut HistoryPusher, error_slot: *mut*mut CWorkerError) -> () {
-  let runtime_ref = unsafe { runtime.as_ref() }.expect("client is null");
-  let config_json = unsafe { CArray::raw_borrow(config).unwrap() };
-  let config = serde_json::from_slice(&config_json.as_rust().unwrap()).map_err(|err| WorkerError {
-    code: WorkerErrorCode::InvalidWorkerConfig,
-    message: format!("{}", err),
-  });
+pub extern "C" fn hs_temporal_new_replay_worker(
+    runtime: *mut runtime::RuntimeRef,
+    config: *const CArray<u8>,
+    worker_slot: *mut *mut WorkerRef,
+    history_slot: *mut *mut HistoryPusher,
+    error_slot: *mut *mut CWorkerError,
+) -> () {
+    let runtime_ref = unsafe { runtime.as_ref() }.expect("client is null");
+    let config_json = unsafe { CArray::raw_borrow(config).unwrap() };
+    let config =
+        serde_json::from_slice(&config_json.as_rust().unwrap()).map_err(|err| WorkerError {
+            code: WorkerErrorCode::InvalidWorkerConfig,
+            message: format!("{}", err),
+        });
 
-  match config {
-    Ok(config) => {
-      let result = new_replay_worker(runtime_ref, config);
-      match result {
-        Ok((worker_ref, history_pusher)) => {
-          unsafe {
-            *worker_slot = Box::into_raw(Box::new(worker_ref));
-            *history_slot = Box::into_raw(Box::new(history_pusher));
-          }
-        },
-        Err(worker_error) => {
-          unsafe { *error_slot = CWorkerError::c_repr_of(worker_error).unwrap().into_raw_pointer_mut() };
+    match config {
+        Ok(config) => {
+            let result = new_replay_worker(runtime_ref, config);
+            match result {
+                Ok((worker_ref, history_pusher)) => unsafe {
+                    *worker_slot = Box::into_raw(Box::new(worker_ref));
+                    *history_slot = Box::into_raw(Box::new(history_pusher));
+                },
+                Err(worker_error) => {
+                    unsafe {
+                        *error_slot = CWorkerError::c_repr_of(worker_error)
+                            .unwrap()
+                            .into_raw_pointer_mut()
+                    };
+                }
+            }
         }
-      }
-    },
-    Err(worker_error) => {
-      unsafe { *error_slot = CWorkerError::c_repr_of(worker_error).unwrap().into_raw_pointer_mut() };
+        Err(worker_error) => {
+            unsafe {
+                *error_slot = CWorkerError::c_repr_of(worker_error)
+                    .unwrap()
+                    .into_raw_pointer_mut()
+            };
+        }
     }
-  }
 }
 
 impl WorkerRef {
-  fn poll_workflow_activation(&self, hs: HsCallback<CArray<u8>, CWorkerError>) -> () {
-      let worker = self.worker.as_ref().unwrap().clone();
-      self.runtime.future_result_into_hs(hs, async move {
-        let bytes = match worker.poll_workflow_activation().await {
-            Ok(act) => Ok(act.encode_to_vec()),
-            Err(PollWfError::ShutDown) => Err(WorkerError {
-              code: WorkerErrorCode::PollShutdownError,
-              message: format!("Poll shutdown error")
-            }),
-            Err(err) => Err(WorkerError {
-              code: WorkerErrorCode::PollFailure,
-              message: format!("{}", err),
+    fn poll_workflow_activation(&self, hs: HsCallback<CArray<u8>, CWorkerError>) -> () {
+        let worker = self.worker.as_ref().unwrap().clone();
+        self.runtime.future_result_into_hs(hs, async move {
+            let bytes = match worker.poll_workflow_activation().await {
+                Ok(act) => Ok(act.encode_to_vec()),
+                Err(PollWfError::ShutDown) => Err(WorkerError {
+                    code: WorkerErrorCode::PollShutdownError,
+                    message: format!("Poll shutdown error"),
+                }),
+                Err(err) => Err(WorkerError {
+                    code: WorkerErrorCode::PollFailure,
+                    message: format!("{}", err),
+                }),
+            };
+            Ok(
+                CArray::c_repr_of(bytes.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?)
+                    .unwrap(),
+            )
+        })
+    }
+
+    fn poll_activity_task(&self, hs: HsCallback<CArray<u8>, CWorkerError>) -> () {
+        let worker = self.worker.as_ref().unwrap().clone();
+        self.runtime.future_result_into_hs(hs, async move {
+            let bytes = (match worker.poll_activity_task().await {
+                Ok(task) => Ok(task.encode_to_vec()),
+                Err(PollActivityError::ShutDown) => Err(WorkerError {
+                    code: WorkerErrorCode::PollShutdownError,
+                    message: format!("Poll shutdown error"),
+                }),
+                Err(err) => Err(WorkerError {
+                    code: WorkerErrorCode::PollFailure,
+                    message: format!("Poll failure: {}", err),
+                }),
             })
-        };
-        Ok(CArray::c_repr_of(bytes.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?).unwrap())
-      })
-  }
+            .map_err(|err| CWorkerError::c_repr_of(err).unwrap());
+            Ok(CArray::c_repr_of(bytes?).unwrap())
+        })
+    }
 
-  fn poll_activity_task(&self, hs: HsCallback<CArray<u8>, CWorkerError>) -> () {
-      let worker = self.worker.as_ref().unwrap().clone();
-      self.runtime.future_result_into_hs(hs, async move {
-          let bytes = (match worker.poll_activity_task().await {
-              Ok(task) => Ok(task.encode_to_vec()),
-              Err(PollActivityError::ShutDown) => Err(WorkerError {
-                code: WorkerErrorCode::PollShutdownError,
-                message: format!("Poll shutdown error")
-              }),
-              Err(err) => Err(WorkerError {
-                code: WorkerErrorCode::PollFailure,
-                message: format!("Poll failure: {}", err)
-            }),
-          }).map_err(|err| {
-            CWorkerError::c_repr_of(err).unwrap()
-          });
-          Ok(CArray::c_repr_of(bytes?).unwrap())
-      })
-  }
-
-  fn complete_workflow_activation(
-      &self,
-      hs: HsCallback<CUnit, CWorkerError>,
-      proto: &[u8],
-  ) -> () {
-    let worker = self.worker.as_ref().unwrap().clone();
-    let completion = WorkflowActivationCompletion::decode(proto);
-      self.runtime.future_result_into_hs(hs, async move {
-        let completion = completion
-              .map_err(|err| CWorkerError::c_repr_of(WorkerError {
-                code: WorkerErrorCode::InvalidProto,
-                message: format!("Invalid proto: {}", err)
-              }).unwrap())?;
-          worker
-              .complete_workflow_activation(completion)
-              .await
-              .map_err(|err| {
+    fn complete_workflow_activation(
+        &self,
+        hs: HsCallback<CUnit, CWorkerError>,
+        proto: &[u8],
+    ) -> () {
+        let worker = self.worker.as_ref().unwrap().clone();
+        let completion = WorkflowActivationCompletion::decode(proto);
+        self.runtime.future_result_into_hs(hs, async move {
+            let completion = completion.map_err(|err| {
                 CWorkerError::c_repr_of(WorkerError {
-                  code: WorkerErrorCode::CompletionFailure,
-                  message: format!("{}", err)
-                }).unwrap()
-              })?;
-          Ok(CUnit{})
-      })
-  }
-
-  fn complete_activity_task(&self, hs: HsCallback<CUnit, CWorkerError>, proto: &[u8]) -> () {
-      let worker = self.worker.as_ref().unwrap().clone();
-      let completion = ActivityTaskCompletion::decode(proto);
-      self.runtime.future_result_into_hs(hs, async move {
-        let completion = completion
-          .map_err(|err| CWorkerError::c_repr_of(WorkerError {
-            code: WorkerErrorCode::InvalidProto,
-            message: format!("{}", err)
-          }).unwrap())?;
-        worker
-            .complete_activity_task(completion)
-            .await
-            .map_err(|err| {
-              CWorkerError::c_repr_of(WorkerError {
-                code: WorkerErrorCode::CompletionFailure,
-                message: format!("{}", err)
-              }).unwrap()
+                    code: WorkerErrorCode::InvalidProto,
+                    message: format!("Invalid proto: {}", err),
+                })
+                .unwrap()
             })?;
-        Ok(CUnit{})
-      })
-  }
+            worker
+                .complete_workflow_activation(completion)
+                .await
+                .map_err(|err| {
+                    CWorkerError::c_repr_of(WorkerError {
+                        code: WorkerErrorCode::CompletionFailure,
+                        message: format!("{}", err),
+                    })
+                    .unwrap()
+                })?;
+            Ok(CUnit {})
+        })
+    }
 
-  fn record_activity_heartbeat(&self, proto: &[u8]) -> Result<(), WorkerError> {
-      enter_sync!(self.runtime);
-      let heartbeat = ActivityHeartbeat::decode(proto)
-          .map_err(|err| WorkerError {
+    fn complete_activity_task(&self, hs: HsCallback<CUnit, CWorkerError>, proto: &[u8]) -> () {
+        let worker = self.worker.as_ref().unwrap().clone();
+        let completion = ActivityTaskCompletion::decode(proto);
+        self.runtime.future_result_into_hs(hs, async move {
+            let completion = completion.map_err(|err| {
+                CWorkerError::c_repr_of(WorkerError {
+                    code: WorkerErrorCode::InvalidProto,
+                    message: format!("{}", err),
+                })
+                .unwrap()
+            })?;
+            worker
+                .complete_activity_task(completion)
+                .await
+                .map_err(|err| {
+                    CWorkerError::c_repr_of(WorkerError {
+                        code: WorkerErrorCode::CompletionFailure,
+                        message: format!("{}", err),
+                    })
+                    .unwrap()
+                })?;
+            Ok(CUnit {})
+        })
+    }
+
+    fn record_activity_heartbeat(&self, proto: &[u8]) -> Result<(), WorkerError> {
+        enter_sync!(self.runtime);
+        let heartbeat = ActivityHeartbeat::decode(proto).map_err(|err| WorkerError {
             code: WorkerErrorCode::InvalidProto,
-            message: format!("{}", err)
-          });
+            message: format!("{}", err),
+        });
 
-      match self.worker.as_ref() {
-        None => Ok(()),
-        Some(worker) => {
-          worker.record_activity_heartbeat(heartbeat?);
-          // TODO return error
-          Ok(())
-        },
-      }
-  }
+        match self.worker.as_ref() {
+            None => Ok(()),
+            Some(worker) => {
+                worker.record_activity_heartbeat(heartbeat?);
+                // TODO return error
+                Ok(())
+            }
+        }
+    }
 
-  fn request_workflow_eviction(&self, run_id: &str) -> () {
-      enter_sync!(self.runtime);
-      self.worker
-          .as_ref()
-          .unwrap()
-          .request_workflow_eviction(run_id);
-  }
+    fn request_workflow_eviction(&self, run_id: &str) -> () {
+        enter_sync!(self.runtime);
+        self.worker
+            .as_ref()
+            .unwrap()
+            .request_workflow_eviction(run_id);
+    }
 
-  fn initiate_shutdown(&self) -> () {
-    let worker = self.worker.as_ref().unwrap().clone();
-    worker.initiate_shutdown();
-  }
+    fn initiate_shutdown(&self) -> () {
+        let worker = self.worker.as_ref().unwrap().clone();
+        worker.initiate_shutdown();
+    }
 
-  fn finalize_shutdown(&mut self, hs: HsCallback<CUnit, CWorkerError>) -> () {
-      // Take the worker out of the option and leave None. This should be the
-      // only reference remaining to the worker so try_unwrap will work.
-      let core_worker = match Arc::try_unwrap(self.worker.take().unwrap()) {
-          Ok(core_worker) => Ok(core_worker),
-          Err(arc) => Err(
-              WorkerError {
-                  code: WorkerErrorCode::SDKError,
-                  message: format!(
-                      "Cannot finalize, expected 1 reference, got {}",
-                      Arc::strong_count(&arc)
-                  ),
-              }
-          )
-      };
-      self.runtime.clone().future_result_into_hs(hs, async move {
-          match core_worker {
-              Ok(worker) => {
-                  worker.finalize_shutdown().await;
-                  Ok(CUnit{})
-              },
-              Err(err) => Err(CWorkerError::c_repr_of(err).unwrap())
-          }
-      })
-  }
+    fn finalize_shutdown(&mut self, hs: HsCallback<CUnit, CWorkerError>) -> () {
+        // Take the worker out of the option and leave None. This should be the
+        // only reference remaining to the worker so try_unwrap will work.
+        let core_worker = match Arc::try_unwrap(self.worker.take().unwrap()) {
+            Ok(core_worker) => Ok(core_worker),
+            Err(arc) => Err(WorkerError {
+                code: WorkerErrorCode::SDKError,
+                message: format!(
+                    "Cannot finalize, expected 1 reference, got {}",
+                    Arc::strong_count(&arc)
+                ),
+            }),
+        };
+        self.runtime.clone().future_result_into_hs(hs, async move {
+            match core_worker {
+                Ok(worker) => {
+                    worker.finalize_shutdown().await;
+                    Ok(CUnit {})
+                }
+                Err(err) => Err(CWorkerError::c_repr_of(err).unwrap()),
+            }
+        })
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_validate_worker(
-  worker: *mut WorkerRef,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerValidationError,
-  result_slot: *mut*mut CUnit
+    worker: *mut WorkerRef,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerValidationError,
+    result_slot: *mut *mut CUnit,
 ) {
     let worker = unsafe { &mut *worker };
     let hs = HsCallback {
         mvar,
         cap,
         error_slot,
-        result_slot
+        result_slot,
     };
 
     let w = worker.worker.as_ref().unwrap().clone();
     worker.runtime.future_result_into_hs(hs, async move {
         let result = w.validate().await;
         match result {
-            Ok(()) => Ok(CUnit{}),
+            Ok(()) => Ok(CUnit {}),
             Err(err) => Err(CWorkerValidationError::c_repr_of(FormattedError {
-              message: format!("{}", err)
-            }).unwrap())
+                message: format!("{}", err),
+            })
+            .unwrap()),
         }
     })
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_poll_workflow_activation(
-  worker: *mut WorkerRef,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CArray<u8>,
+    worker: *mut WorkerRef,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CArray<u8>,
 ) {
-  let worker = unsafe { &*worker };
-  let hs = HsCallback {
-    mvar,
-    cap,
-    error_slot,
-    result_slot,
-  };
-  worker.poll_workflow_activation(hs)
+    let worker = unsafe { &*worker };
+    let hs = HsCallback {
+        mvar,
+        cap,
+        error_slot,
+        result_slot,
+    };
+    worker.poll_workflow_activation(hs)
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_poll_activity_task(
-  worker: *mut WorkerRef,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CArray<u8>,
+    worker: *mut WorkerRef,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CArray<u8>,
 ) {
-  let worker = unsafe { &*worker };
-  let hs = HsCallback {
-    mvar,
-    cap,
-    error_slot,
-    result_slot,
-  };
-  worker.poll_activity_task(hs)
+    let worker = unsafe { &*worker };
+    let hs = HsCallback {
+        mvar,
+        cap,
+        error_slot,
+        result_slot,
+    };
+    worker.poll_activity_task(hs)
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_complete_workflow_activation(
-  worker: *mut WorkerRef,
-  proto: *const CArray<u8>,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CUnit
+    worker: *mut WorkerRef,
+    proto: *const CArray<u8>,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CUnit,
 ) {
-  let worker = unsafe { &*worker };
-  let proto: &CArray<u8> = unsafe {CArray::raw_borrow(proto).unwrap()};
-  let proto: &[u8] = &proto.as_rust().unwrap().clone();
-  let hs = HsCallback {
-    mvar,
-    cap,
-    error_slot,
-    result_slot,
-  };
-  worker.complete_workflow_activation(hs, proto)
+    let worker = unsafe { &*worker };
+    let proto: &CArray<u8> = unsafe { CArray::raw_borrow(proto).unwrap() };
+    let proto: &[u8] = &proto.as_rust().unwrap().clone();
+    let hs = HsCallback {
+        mvar,
+        cap,
+        error_slot,
+        result_slot,
+    };
+    worker.complete_workflow_activation(hs, proto)
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_complete_activity_task(
-  worker: *mut WorkerRef,
-  proto: *const CArray<u8>,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CUnit
+    worker: *mut WorkerRef,
+    proto: *const CArray<u8>,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CUnit,
 ) {
-  let worker = unsafe { &*worker };
-  let proto: &CArray<u8> = unsafe {CArray::raw_borrow(proto).unwrap()};
-  let proto: &[u8] = &proto.as_rust().unwrap().clone();
-  let hs = HsCallback {
-    mvar,
-    cap,
-    error_slot,
-    result_slot,
-  };
-  worker.complete_activity_task(hs, proto)
+    let worker = unsafe { &*worker };
+    let proto: &CArray<u8> = unsafe { CArray::raw_borrow(proto).unwrap() };
+    let proto: &[u8] = &proto.as_rust().unwrap().clone();
+    let hs = HsCallback {
+        mvar,
+        cap,
+        error_slot,
+        result_slot,
+    };
+    worker.complete_activity_task(hs, proto)
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_record_activity_heartbeat(
-  worker: *mut WorkerRef,
-  proto: *const CArray<u8>,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CUnit
+    worker: *mut WorkerRef,
+    proto: *const CArray<u8>,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CUnit,
 ) {
-  let worker = unsafe { &*worker };
-  let proto: &CArray<u8> = unsafe {CArray::raw_borrow(proto).unwrap()};
-  let proto: &[u8] = &proto.as_rust().unwrap().clone();
-  let result = worker.record_activity_heartbeat(proto);
-  match result {
-    Ok(_) => {
-      unsafe {
-        *error_slot = std::ptr::null_mut();
-        *result_slot = std::ptr::null_mut();
-      }
-    },
-    Err(err) => {
-      let err = CWorkerError::c_repr_of(err).unwrap();
-      unsafe {
-        *error_slot = err.into_raw_pointer_mut();
-        *result_slot = std::ptr::null_mut();
-      }
+    let worker = unsafe { &*worker };
+    let proto: &CArray<u8> = unsafe { CArray::raw_borrow(proto).unwrap() };
+    let proto: &[u8] = &proto.as_rust().unwrap().clone();
+    let result = worker.record_activity_heartbeat(proto);
+    match result {
+        Ok(_) => unsafe {
+            *error_slot = std::ptr::null_mut();
+            *result_slot = std::ptr::null_mut();
+        },
+        Err(err) => {
+            let err = CWorkerError::c_repr_of(err).unwrap();
+            unsafe {
+                *error_slot = err.into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+        }
     }
-  }
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_request_workflow_eviction(
-  worker: *mut WorkerRef,
-  run_id: *const CArray<u8>,
+    worker: *mut WorkerRef,
+    run_id: *const CArray<u8>,
 ) {
-  let worker = unsafe { &*worker };
-  let run_id: &CArray<u8> = unsafe {CArray::raw_borrow(run_id).unwrap()};
-  let run_id: &[u8] = &run_id.as_rust().unwrap().clone();
-  let run_id: &str = unsafe {str::from_utf8_unchecked(run_id)};
-  worker.request_workflow_eviction(run_id)
+    let worker = unsafe { &*worker };
+    let run_id: &CArray<u8> = unsafe { CArray::raw_borrow(run_id).unwrap() };
+    let run_id: &[u8] = &run_id.as_rust().unwrap().clone();
+    let run_id: &str = unsafe { str::from_utf8_unchecked(run_id) };
+    worker.request_workflow_eviction(run_id)
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_worker_initiate_shutdown(
-  worker: *mut WorkerRef
-) {
-  let worker = unsafe { &*worker };
-  worker.initiate_shutdown()
+pub extern "C" fn hs_temporal_worker_initiate_shutdown(worker: *mut WorkerRef) {
+    let worker = unsafe { &*worker };
+    worker.initiate_shutdown()
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_worker_finalize_shutdown(
-  worker: *mut WorkerRef,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CUnit
+    worker: *mut WorkerRef,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CUnit,
 ) {
-  let worker = unsafe { &mut *worker };
-  let hs = HsCallback {
-    mvar,
-    cap,
-    error_slot,
-    result_slot,
-  };
-  worker.finalize_shutdown(hs)
+    let worker = unsafe { &mut *worker };
+    let hs = HsCallback {
+        mvar,
+        cap,
+        error_slot,
+        result_slot,
+    };
+    worker.finalize_shutdown(hs)
 }
 
 pub struct HistoryPusher {
-  tx: Option<Sender<HistoryForReplay>>,
-  runtime: runtime::Runtime,
+    tx: Option<Sender<HistoryForReplay>>,
+    runtime: runtime::Runtime,
 }
 
 impl HistoryPusher {
-  fn new(runtime: runtime::Runtime) -> (Self, ReceiverStream<HistoryForReplay>) {
-      let (tx, rx) = channel(1);
-      (
-          Self {
-              tx: Some(tx),
-              runtime,
-          },
-          ReceiverStream::new(rx),
-      )
-  }
+    fn new(runtime: runtime::Runtime) -> (Self, ReceiverStream<HistoryForReplay>) {
+        let (tx, rx) = channel(1);
+        (
+            Self {
+                tx: Some(tx),
+                runtime,
+            },
+            ReceiverStream::new(rx),
+        )
+    }
 }
 
 impl HistoryPusher {
-  fn push_history(
-      &self,
-      workflow_id: &str,
-      history_proto: &[u8],
-      hs: HsCallback<CUnit, CWorkerError>,
-  ) -> () {
-      let history = History::decode(history_proto)
-          .map_err(|err| WorkerError {
+    fn push_history(
+        &self,
+        workflow_id: &str,
+        history_proto: &[u8],
+        hs: HsCallback<CUnit, CWorkerError>,
+    ) -> () {
+        let history = History::decode(history_proto).map_err(|err| WorkerError {
             code: WorkerErrorCode::InvalidProto,
-            message: format!("Invalid proto: {}", err)
-          });
-      let wfid = workflow_id.to_string();
-      let tx = if let Some(tx) = self.tx.as_ref() {
-          Ok(tx.clone())
-      } else {
-        Err(WorkerError {
-          code: WorkerErrorCode::ReplayWorkerClosed,
-          message: format!("Replay worker is no longer accepting new histories"),
+            message: format!("Invalid proto: {}", err),
+        });
+        let wfid = workflow_id.to_string();
+        let tx = if let Some(tx) = self.tx.as_ref() {
+            Ok(tx.clone())
+        } else {
+            Err(WorkerError {
+                code: WorkerErrorCode::ReplayWorkerClosed,
+                message: format!("Replay worker is no longer accepting new histories"),
+            })
+        };
+        // We accept this doesn't have logging/tracing
+        self.runtime.future_result_into_hs(hs, async move {
+            let history = history.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?;
+            let tx = tx.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?;
+
+            tx.send(HistoryForReplay::new(history, wfid))
+                .await
+                .map_err(|_| {
+                    CWorkerError::c_repr_of(WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: format!(
+                            "Channel for history replay was dropped, this is an SDK bug."
+                        ),
+                    })
+                    .unwrap()
+                })?;
+            Ok(CUnit {})
         })
-      };
-      // We accept this doesn't have logging/tracing
-      self.runtime.future_result_into_hs(hs, async move {
-        let history = history.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?;
-        let tx = tx.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?;
+    }
 
-        tx.send(HistoryForReplay::new(history, wfid))
-          .await
-          .map_err(|_| {
-            CWorkerError::c_repr_of(
-              WorkerError {
-                code: WorkerErrorCode::SDKError,
-                message: format!("Channel for history replay was dropped, this is an SDK bug."),
-            }).unwrap()
-          })?;
-        Ok(CUnit{})
-      })
-  }
-
-  fn close(&mut self) {
-      self.tx.take();
-  }
+    fn close(&mut self) {
+        self.tx.take();
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn hs_temporal_history_pusher_push_history(
-  history_pusher: *mut HistoryPusher,
-  workflow_id: *const CArray<u8>,
-  history_proto: *const CArray<u8>,
-  mvar: *mut MVar,
-  cap: Capability,
-  error_slot: *mut*mut CWorkerError,
-  result_slot: *mut*mut CUnit
+    history_pusher: *mut HistoryPusher,
+    workflow_id: *const CArray<u8>,
+    history_proto: *const CArray<u8>,
+    mvar: *mut MVar,
+    cap: Capability,
+    error_slot: *mut *mut CWorkerError,
+    result_slot: *mut *mut CUnit,
 ) {
-  let history_pusher = unsafe { &mut *history_pusher };
-  let workflow_id: &CArray<u8> = unsafe {CArray::raw_borrow(workflow_id).unwrap()};
-  let workflow_id = workflow_id.as_rust().unwrap().clone();
-  let workflow_id: &str = unsafe {str::from_utf8_unchecked(&workflow_id)};
-  let history_proto: &CArray<u8> = unsafe {CArray::raw_borrow(history_proto).unwrap()};
-  let history_proto: &[u8] = &history_proto.as_rust().unwrap().clone();
-  history_pusher.push_history(
-    workflow_id,
-    history_proto,
-    HsCallback {
-      mvar,
-      cap,
-      error_slot,
-      result_slot,
-    }
-  )
+    let history_pusher = unsafe { &mut *history_pusher };
+    let workflow_id: &CArray<u8> = unsafe { CArray::raw_borrow(workflow_id).unwrap() };
+    let workflow_id = workflow_id.as_rust().unwrap().clone();
+    let workflow_id: &str = unsafe { str::from_utf8_unchecked(&workflow_id) };
+    let history_proto: &CArray<u8> = unsafe { CArray::raw_borrow(history_proto).unwrap() };
+    let history_proto: &[u8] = &history_proto.as_rust().unwrap().clone();
+    history_pusher.push_history(
+        workflow_id,
+        history_proto,
+        HsCallback {
+            mvar,
+            cap,
+            error_slot,
+            result_slot,
+        },
+    )
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_history_pusher_close(
-  history_pusher: *mut HistoryPusher
-) {
-  let history_pusher = unsafe { &mut *history_pusher };
-  history_pusher.close()
+pub extern "C" fn hs_temporal_history_pusher_close(history_pusher: *mut HistoryPusher) {
+    let history_pusher = unsafe { &mut *history_pusher };
+    history_pusher.close()
 }
 
 #[no_mangle]
-pub extern "C" fn hs_temporal_history_pusher_drop(
-  history_pusher: *mut HistoryPusher
-) {
-  let history_pusher = unsafe { Box::from_raw(history_pusher) };
-  drop(history_pusher)
+pub extern "C" fn hs_temporal_history_pusher_drop(history_pusher: *mut HistoryPusher) {
+    let history_pusher = unsafe { Box::from_raw(history_pusher) };
+    drop(history_pusher)
 }


### PR DESCRIPTION
## description

my LSP integration was set up to auto-format with `rustfmt`; in the spirit of doing some spring cleaning, I ran through `clippy`'s errors & suggestions as well.

I'll add a few notes below, but the only thing I'm really unsure about is whether the `not_unsafe_ptr_arg_deref` lint handling here makes sense (details in f025784d32a65ac60552358d67f94b99fbea9233).