### PR TITLE
fix(direnv): only source cargo env if it exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-source ~/.cargo/env
+source_env_if_exists ~/.cargo/env
 
 use flake . --override-input devenv-root "file+file://"<(printf %s "$PWD")
 


### PR DESCRIPTION
## description

this should be the moral equivalent of checking if the file exists & then just calling `. ~/.cargo/env`.

without the check, `direnv` complains if the file doesn't exist when it loads the shell.