### PR TITLE
CRPCError `details` field is a pointer

### DIFF
--- a/core/src/Temporal/Core/CTypes.hsc
+++ b/core/src/Temporal/Core/CTypes.hsc
@@ -151,7 +151,7 @@ instance Exception RpcError
 data CRPCError = CRPCError
   { code :: Word32
   , message :: CString
-  , details :: CArray Word8
+  , details :: Ptr (CArray Word8)
   }
 
 instance Storable CRPCError where
@@ -172,7 +172,7 @@ foreign import ccall "&hs_temporal_drop_rpc_error" rust_drop_rpc_error :: Finali
 peekCRPCError :: CRPCError -> IO RpcError
 peekCRPCError CRPCError{..} = do
   message <- fromPtr0 $ castPtr message
-  details <- cArrayToByteString details
+  details <- cArrayToByteString =<< peek details
   pure RpcError{..}
 
 newtype CoreClient = CoreClient


### PR DESCRIPTION
## description

in Rust, the `details` field of `CRPCError` is a pointer to a `CArray`, but in Haskell we were attempting to unmarshall it directly.

the `CRPCError` type now accurately represents this as a `Ptr (CArray a)`, and `CArray Word8 -> ByteString` code has been updated to correctly dereference this before copying the data over.

nb. prior to this change, the `size` field must have just been some unspecified chunk of memory, which makes me wonder where some of the displayed values we were seeing in CI actually came from.