### PR TITLE
add 'extra_libraries' to SDK cabal file & fix test suite

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 source_env_if_exists ~/.cargo/env
 
-use flake . --override-input devenv-root "file+file://"<(printf %s "$PWD")
+use flake . --no-pure-eval
 
 source_env_if_exists .envrc.private

--- a/core/Setup.hs
+++ b/core/Setup.hs
@@ -100,8 +100,7 @@ rsAddLibraryInfo fl lbi' = do
           }
       updateLibBi libBuild =
         libBuild
-          { extraLibs = "temporal_bridge" : extraLibs libBuild
-          , extraLibDirs =
+          { extraLibDirs =
               if external
                 then extraLibDirs libBuild
                 else (dir </> buildDir lbi') : extraLibDirs libBuild

--- a/core/temporal-sdk-core.cabal
+++ b/core/temporal-sdk-core.cabal
@@ -34,6 +34,8 @@ custom-setup
 
 library
     import:           warnings
+
+    extra-libraries: temporal_bridge
     includes:
       rust/temporal_bridge.h
     include-dirs:     rust

--- a/flake.lock
+++ b/flake.lock
@@ -53,18 +53,6 @@
         "type": "github"
       }
     },
-    "devenv-root": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=",
-        "type": "file",
-        "url": "file:///dev/null"
-      },
-      "original": {
-        "type": "file",
-        "url": "file:///dev/null"
-      }
-    },
     "devenv_2": {
       "inputs": {
         "flake-compat": [
@@ -454,7 +442,6 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "devenv-root": "devenv-root",
         "fenix": "fenix",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     devenv.url = "github:cachix/devenv/v1.0.5";
-    # Hack to avoid needing to use impure when loading the devenv root.
-    #
-    # See .envrc for how we substitute this with the actual path.
-    devenv-root = {
-      url = "file+file:///dev/null";
-      flake = false;
-    };
-
     fenix = {
       url = "github:nix-community/fenix";
       inputs = {nixpkgs.follows = "nixpkgs";};
@@ -20,7 +12,6 @@
 
   outputs = inputs @ {
     self,
-    devenv-root,
     nixpkgs,
     devenv,
     flake-utils,
@@ -61,12 +52,6 @@
           inherit inputs pkgs;
           modules = [
             ({...}: {
-              devenv.root = let
-                devenvRootFileContent = builtins.readFile devenv-root.outPath;
-              in
-                pkgs.lib.mkIf (devenvRootFileContent != "") devenvRootFileContent;
-              # There should be a way to get this from the flake in the future.
-              # devenv.root = "/Users/ian/Code/mercury/hs-temporal-sdk";
               packages = with pkgs; [
                 ghciwatch
               ];

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -28,7 +28,8 @@ import Control.Monad.Logger
 import Control.Monad.Reader
 import Data.Aeson (FromJSON, ToJSON, Value)
 import qualified Data.ByteString as BS
-import Data.Foldable (sequenceA_, traverse_)
+import System.Environment (lookupEnv)
+import Data.Foldable (traverse_)
 import Data.Functor
 import Data.Int
 import Data.Map.Strict (Map)
@@ -318,10 +319,9 @@ spec = do
     setup :: (TestEnv -> IO ()) -> IO ()
     setup go = do
       let withServer f = do
-            if True -- Use local server instead of ephemeral server. Flip to use ephemeral server.
-              then do
-                f 7233
-              else do
+            lookupEnv "HS_TEMPORAL_SDK_LOCAL_TEST_SERVER" >>= \case
+              Just _ -> f 7233
+              _ -> do
                 fp <- getFreePort
                 mTemporalPath <- findExecutable "temporal"
                 conf <- case mTemporalPath of


### PR DESCRIPTION
## description

* test suite now consults `HS_TEMPORAL_SDK_LOCAL_TEST_SERVER` to see if it should spawn ephemeral servers or use an external dev server for testing
  * if the variable exists, a dev server was started (e.g. with `temporal server start-dev`) in the background
* `temporal-sdk-core` now explicitly lists `temporal_bridge` in its `extra-libraries` stanza
  * this means that `cabal2nix` will add it to the argument list, and it more accurately reflects the fact that this is required for the library to function
  * local development should be unchanged; the custom `Setup.hs` will look for the `external_lib` flag and default to building & sourcing `temporal_bridge` w/ `cargo` if it's set to `False`