### PR TITLE
fix: garnix build matrix

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,15 +1,15 @@
 builds:
   - include:
-    - 'checks.x86_64-linux.*'
-    - 'packages.x86_64-linux.*'
-    - 'packages.*.temporal-bridge'
+      # Haskell package sets aren't always cached for 'aarch64-linux'.
+      - 'checks.x86_64-linux.*'
+      - 'packages.x86_64-linux.*'
+      - 'checks.aarch64-darwin.*'
+      - 'packages.aarch64-darwin.*'
+      - 'checks.x86_64-darwin.*'
+      - 'packages.x86_64-darwin.*'
+      # Rust should build just fine for all architectures.
+      - 'packages.*.temporal-bridge'
     exclude:
-    - 'packages.*.default'
-    - 'packages.*.devenv-up'
-    # Unable to build because devenv is impure
-    - 'devShells.*.*'
-  - include:
-    - 'packages.aarch64-darwin.*'
-    - 'packages.aarch64-linux.*'
-    exclude: []
-    branch: main
+      # Unable to build because devenv is impure.
+      - 'devShells.*.*'
+      - 'packages.*.devenv-up'


### PR DESCRIPTION
## description

trying to figure out what does & doesn't work for Garnix builds:
* 'aarch64' + GHC 9.8 seems to fail w/ a lot of cache misses
* 'exclude' doesn't appear to union across all branches
  * adding 'devenv-up' to all branch 'exclude' doesn't stop it on 'main'