### PR TITLE
revert(haskell): downgrade `hs-opentelemetry-api`

### DIFF
--- a/nix/overlays/haskell/deps.nix
+++ b/nix/overlays/haskell/deps.nix
@@ -1,9 +1,26 @@
 { haskell, ... }:
 hfinal: hprev:
 let
-  inherit (haskell.lib.compose) markUnbroken;
+  inherit (haskell.lib.compose) markUnbroken packageSourceOverrides;
 in
 {
-  hs-opentelemetry-propagator-datadog = markUnbroken hprev.hs-opentelemetry-propagator-datadog;
   if-instance = markUnbroken hprev.if-instance;
-}
+} // (packageSourceOverrides {
+  hs-opentelemetry-api = "0.1.0.0";
+  hs-opentelemetry-exporter-in-memory = "0.0.1.3";
+  hs-opentelemetry-exporter-otlp = "0.0.1.5";
+  hs-opentelemetry-instrumentation-cloudflare = "0.2.0.0";
+  hs-opentelemetry-instrumentation-conduit = "0.1.0.0";
+  hs-opentelemetry-instrumentation-hspec = "0.0.1.1";
+  hs-opentelemetry-instrumentation-http-client = "0.1.0.0";
+  hs-opentelemetry-instrumentation-persistent = "0.1.0.0";
+  hs-opentelemetry-instrumentation-postgresql-simple = "0.1.0.0";
+  hs-opentelemetry-instrumentation-wai = "0.1.0.0";
+  hs-opentelemetry-instrumentation-yesod = "0.1.0.0";
+  hs-opentelemetry-otlp = "0.0.1.0";
+  hs-opentelemetry-propagator-b3 = "0.0.1.1";
+  hs-opentelemetry-propagator-w3c = "0.0.1.3";
+  hs-opentelemetry-sdk = "0.0.3.6";
+  hs-opentelemetry-utils-exceptions = "0.2.0.0";
+  hs-opentelemetry-vendor-honeycomb = "0.0.1.1";
+} hfinal hprev)

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -123,7 +123,7 @@ makeOpenTelemetryInterceptor = do
   let tracer =
         makeTracer
           tracerProvider
-          (InstrumentationLibrary "temporal-sdk" (T.pack $ showVersion Paths_temporal_sdk.version) "" emptyAttributes)
+          (InstrumentationLibrary "temporal-sdk" (T.pack $ showVersion Paths_temporal_sdk.version))
           (TracerOptions Nothing)
   return $
     Interceptors

--- a/sdk/src/Temporal/Worker.hs
+++ b/sdk/src/Temporal/Worker.hs
@@ -508,7 +508,7 @@ startReplayWorker rt conf = provideCallStack $ runWorkerContext conf $ do
       workerActivityWorker = ()
       workerActivityLoop = ()
       workerType = Core.SReplay
-      workerTracer = makeTracer conf.tracerProvider (InstrumentationLibrary "hs-temporal-sdk" "0.0.1.0" "" emptyAttributes) tracerOptions
+      workerTracer = makeTracer conf.tracerProvider (InstrumentationLibrary "hs-temporal-sdk" "0.0.1.0") tracerOptions
   workerWorkflowLoop <- asyncLabelled (T.unpack $ T.concat ["temporal/worker/workflow/", Core.namespace conf.coreConfig, "/", Core.taskQueue conf.coreConfig]) $ do
     $(logDebug) "Starting workflow worker loop"
     Workflow.execute workflowWorker
@@ -549,7 +549,7 @@ traced conf m =
   runReaderT m $
     makeTracer
       conf.tracerProvider
-      (InstrumentationLibrary "hs-temporal-sdk" "0.0.1.0" "" emptyAttributes)
+      (InstrumentationLibrary "hs-temporal-sdk" "0.0.1.0")
       tracerOptions
 
 
@@ -597,7 +597,7 @@ startWorker client conf = provideCallStack $ runWorkerContext conf $ inSpan "sta
       payloadProcessor = conf.payloadProcessor
       workerActivityWorker = Activity.ActivityWorker {..}
       workerClient = client
-      workerTracer = makeTracer conf.tracerProvider (InstrumentationLibrary "hs-temporal-sdk" "0.0.1.0" "" emptyAttributes) tracerOptions
+      workerTracer = makeTracer conf.tracerProvider (InstrumentationLibrary "hs-temporal-sdk" "0.0.1.0") tracerOptions
   let workerType = Core.SReal
   -- logs <- liftIO $ fetchLogs globalRuntime
   -- forM_ logs $ \l -> case l.level of


### PR DESCRIPTION
## description

downstream consumers have pinned `hs-opentelemetry-api` to 0.1.0.0, so we need to revert this version in our own package set (for CI) and go back to using the old `InstrumentationLibrary` API.