### PR TITLE
STAB-516: add support for api keys

### DIFF
--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -23,6 +23,7 @@ pub struct ClientConfig {
     identity: String,
     tls_config: Option<ClientTlsConfig>,
     retry_config: Option<ClientRetryConfig>,
+    api_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -81,6 +82,10 @@ fn client_config_to_options(
                 .map(Duration::from_millis),
             max_retries: retry_config.max_retries,
         });
+    }
+
+    if client_config.api_key.is_some() {
+        options_builder = options_builder.api_key(client_config.api_key)
     }
 
     options_builder.build()

--- a/core/src/Temporal/Core/Client.hs
+++ b/core/src/Temporal/Core/Client.hs
@@ -87,7 +87,7 @@ data ClientConfig = ClientConfig
   , identity :: Text
   , tlsConfig :: Maybe ClientTlsConfig
   , retryConfig :: Maybe ClientRetryConfig
-  , apiKey :: Maybe Text
+  , apiKey :: Maybe APIKey
   }
 
 
@@ -107,6 +107,17 @@ data ClientRetryConfig = ClientRetryConfig
   , maxElapsedTimeMillis :: Maybe Word64
   , maxRetries :: Word64
   }
+
+
+newtype APIKey = APIKey {unAPIKey :: Text}
+
+
+instance ToJSON APIKey where
+  toJSON (APIKey text) = toJSON text
+
+
+instance FromJSON APIKey where
+  parseJSON = fmap APIKey . parseJSON
 
 
 {- | A client connection to the Temporal server.

--- a/core/src/Temporal/Core/Client.hs
+++ b/core/src/Temporal/Core/Client.hs
@@ -21,6 +21,7 @@ module Temporal.Core.Client (
   ClientTlsConfig (..),
   ByteVector (..),
   ClientRetryConfig (..),
+  APIKey (..),
 
   -- * Making calls to the server
 

--- a/core/src/Temporal/Core/Client.hs
+++ b/core/src/Temporal/Core/Client.hs
@@ -87,6 +87,7 @@ data ClientConfig = ClientConfig
   , identity :: Text
   , tlsConfig :: Maybe ClientTlsConfig
   , retryConfig :: Maybe ClientRetryConfig
+  , apiKey :: Maybe Text
   }
 
 
@@ -208,6 +209,7 @@ defaultClientConfig =
     , identity = ""
     , tlsConfig = Nothing
     , retryConfig = Nothing
+    , apiKey = Nothing
     }
 
 


### PR DESCRIPTION
add support for using API keys.

this was smoke-tested by running mercurytechnologies/mercury-web-backend#42097 locally, pointing that at the (new, created for this purpose) `staging-ng` namespace, and successfully executing a workflow.

for the test, i started mwb with `TEMPORAL_ENABLED=true TEMPORAL_WORKER_ENABLED=true TEMPORAL_HOST="https://us-east-1.aws.api.temporal.io:7233" TEMPORAL_NAMESPACE="staging-ng.uoqel" TEMPORAL_API_KEY="<snip>" make run

<img width="1512" alt="Screenshot 2025-03-13 at 3 29 29 PM" src="https://github.com/user-attachments/assets/4c747e1f-ab7b-450f-a168-5569d7aec16b" />