### PR TITLE
Detect workflow replays

### DIFF
--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -239,6 +239,7 @@ activate act suspension = do
     in (info', info')
   let completionBase = defMessage & Completion.runId .~ rawRunId info.runId
   writeIORef inst.workflowTime (act ^. Activation.timestamp . to timespecFromTimestamp)
+  writeIORef inst.workflowIsReplaying (act ^. Activation.isReplaying)
   eResult <- case inst.workflowDeadlockTimeout of
     Nothing -> applyJobs (act ^. Activation.vec'jobs) suspension
     Just timeoutDuration -> do


### PR DESCRIPTION
We previously weren't updating the created Workflows against activations to properly detect if we were replaying previously run code. This understandably broke patching when restarting workflows 😮‍💨 
