### PR TITLE
define default-extensions centrally

### DIFF
--- a/codec-encryption/package.yaml
+++ b/codec-encryption/package.yaml
@@ -1,3 +1,5 @@
+<<: !include hpack-common/defaults.yaml
+
 verbatim: { cabal-version: 3.0 }
 
 name:         temporal-codec-encryption
@@ -19,27 +21,6 @@ dependencies:
 - proto-lens
 - crypton
 - memory
-
-default-extensions:
-- DataKinds
-- FlexibleContexts
-- FlexibleInstances
-- GADTs
-- GeneralizedNewtypeDeriving
-- InstanceSigs
-- LambdaCase
-- MultiParamTypeClasses
-- NamedFieldPuns
-- RankNTypes
-- OverloadedRecordDot
-- OverloadedStrings
-- RecordWildCards
-- ScopedTypeVariables
-- StandaloneDeriving
-- TypeApplications
-- TypeFamilies
-- UndecidableInstances
-- TypeOperators
 
 ghc-options:
 # For details on warnings: https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html

--- a/codec-encryption/package.yaml
+++ b/codec-encryption/package.yaml
@@ -1,4 +1,5 @@
-<<: !include hpack-common/defaults.yaml
+defaults:
+  local: ../hpack-common/defaults.yaml
 
 verbatim: { cabal-version: 3.0 }
 

--- a/codec-encryption/temporal-codec-encryption.cabal
+++ b/codec-encryption/temporal-codec-encryption.cabal
@@ -18,7 +18,10 @@ library
   hs-source-dirs:
       src
   default-extensions:
+      BangPatterns
+      BlockArguments
       DataKinds
+      DerivingStrategies
       FlexibleContexts
       FlexibleInstances
       GADTs
@@ -27,6 +30,7 @@ library
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      NumericUnderscores
       RankNTypes
       OverloadedRecordDot
       OverloadedStrings
@@ -35,8 +39,9 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-      UndecidableInstances
       TypeOperators
+      UndecidableInstances
+      ViewPatterns
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-export-lists -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unused-packages -Wno-operator-whitespace -fdiagnostics-color=always -Wno-missing-kind-signatures -Wno-implicit-lift -Wno-implicit-prelude -fwarn-tabs +RTS -A128m -n2m -RTS -fdefer-diagnostics
   build-depends:
       base
@@ -60,7 +65,10 @@ test-suite encryption-tests
   hs-source-dirs:
       test
   default-extensions:
+      BangPatterns
+      BlockArguments
       DataKinds
+      DerivingStrategies
       FlexibleContexts
       FlexibleInstances
       GADTs
@@ -69,6 +77,7 @@ test-suite encryption-tests
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      NumericUnderscores
       RankNTypes
       OverloadedRecordDot
       OverloadedStrings
@@ -77,8 +86,9 @@ test-suite encryption-tests
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-      UndecidableInstances
       TypeOperators
+      UndecidableInstances
+      ViewPatterns
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-export-lists -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unused-packages -Wno-operator-whitespace -fdiagnostics-color=always -Wno-missing-kind-signatures -Wno-implicit-lift -Wno-implicit-prelude -fwarn-tabs +RTS -A128m -n2m -RTS -fdefer-diagnostics -g -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base

--- a/codec-server/package.yaml
+++ b/codec-server/package.yaml
@@ -1,4 +1,5 @@
-<<: !include hpack-common/defaults.yaml
+defaults:
+  local: ../hpack-common/defaults.yaml
 
 verbatim: { cabal-version: 3.0 }
 

--- a/codec-server/package.yaml
+++ b/codec-server/package.yaml
@@ -1,3 +1,5 @@
+<<: !include hpack-common/defaults.yaml
+
 verbatim: { cabal-version: 3.0 }
 
 name:         temporal-sdk-codec-server
@@ -22,27 +24,6 @@ dependencies:
 - text
 - vector
 - wai-cors
-
-default-extensions:
-- DataKinds
-- FlexibleContexts
-- FlexibleInstances
-- GADTs
-- GeneralizedNewtypeDeriving
-- InstanceSigs
-- LambdaCase
-- MultiParamTypeClasses
-- NamedFieldPuns
-- RankNTypes
-- OverloadedRecordDot
-- OverloadedStrings
-- RecordWildCards
-- ScopedTypeVariables
-- StandaloneDeriving
-- TypeApplications
-- TypeFamilies
-- UndecidableInstances
-- TypeOperators
 
 ghc-options:
 # For details on warnings: https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html

--- a/codec-server/temporal-sdk-codec-server.cabal
+++ b/codec-server/temporal-sdk-codec-server.cabal
@@ -18,7 +18,10 @@ library
   hs-source-dirs:
       src
   default-extensions:
+      BangPatterns
+      BlockArguments
       DataKinds
+      DerivingStrategies
       FlexibleContexts
       FlexibleInstances
       GADTs
@@ -27,6 +30,7 @@ library
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      NumericUnderscores
       RankNTypes
       OverloadedRecordDot
       OverloadedStrings
@@ -35,8 +39,9 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-      UndecidableInstances
       TypeOperators
+      UndecidableInstances
+      ViewPatterns
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-export-lists -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unused-packages -Wno-operator-whitespace -fdiagnostics-color=always -Wno-missing-kind-signatures -Wno-implicit-lift -Wno-implicit-prelude -fwarn-tabs +RTS -A128m -n2m -RTS -fdefer-diagnostics
   build-depends:
       aeson

--- a/hpack-common/default-extensions.yaml
+++ b/hpack-common/default-extensions.yaml
@@ -1,4 +1,4 @@
-default-extensions:
+default-extensions: &common-default-extensions
 - BangPatterns
 - BlockArguments
 - DataKinds

--- a/hpack-common/default-extensions.yaml
+++ b/hpack-common/default-extensions.yaml
@@ -1,0 +1,25 @@
+default-extensions:
+- BangPatterns
+- BlockArguments
+- DataKinds
+- DerivingStrategies
+- FlexibleContexts
+- FlexibleInstances
+- GADTs
+- GeneralizedNewtypeDeriving
+- InstanceSigs
+- LambdaCase
+- MultiParamTypeClasses
+- NamedFieldPuns
+- NumericUnderscores
+- RankNTypes
+- OverloadedRecordDot
+- OverloadedStrings
+- RecordWildCards
+- ScopedTypeVariables
+- StandaloneDeriving
+- TypeApplications
+- TypeFamilies
+- TypeOperators
+- UndecidableInstances
+- ViewPatterns

--- a/hpack-common/defaults.yaml
+++ b/hpack-common/defaults.yaml
@@ -1,1 +1,2 @@
-<<: !include default-extensions.yaml
+_default-extensions: !include "default-extensions.yaml"
+default-extensions: *common-default-extensions

--- a/hpack-common/defaults.yaml
+++ b/hpack-common/defaults.yaml
@@ -1,0 +1,1 @@
+<<: !include default-extensions.yaml

--- a/optimal-codec/package.yaml
+++ b/optimal-codec/package.yaml
@@ -1,4 +1,5 @@
-<<: !include hpack-common/defaults.yaml
+defaults:
+  local: ../hpack-common/defaults.yaml
 
 verbatim: { cabal-version: 3.0 }
 

--- a/optimal-codec/package.yaml
+++ b/optimal-codec/package.yaml
@@ -1,3 +1,5 @@
+<<: !include hpack-common/defaults.yaml
+
 verbatim: { cabal-version: 3.0 }
 
 name:         temporal-sdk-optimal-codec
@@ -14,27 +16,6 @@ dependencies:
 - temporal-sdk
 - if-instance >= 0.5
 - containers
-
-default-extensions:
-- DataKinds
-- FlexibleContexts
-- FlexibleInstances
-- GADTs
-- GeneralizedNewtypeDeriving
-- InstanceSigs
-- LambdaCase
-- MultiParamTypeClasses
-- NamedFieldPuns
-- RankNTypes
-- OverloadedRecordDot
-- OverloadedStrings
-- RecordWildCards
-- ScopedTypeVariables
-- StandaloneDeriving
-- TypeApplications
-- TypeFamilies
-- UndecidableInstances
-- TypeOperators
 
 ghc-options:
 # For details on warnings: https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html

--- a/optimal-codec/temporal-sdk-optimal-codec.cabal
+++ b/optimal-codec/temporal-sdk-optimal-codec.cabal
@@ -18,7 +18,10 @@ library
   hs-source-dirs:
       src
   default-extensions:
+      BangPatterns
+      BlockArguments
       DataKinds
+      DerivingStrategies
       FlexibleContexts
       FlexibleInstances
       GADTs
@@ -27,6 +30,7 @@ library
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      NumericUnderscores
       RankNTypes
       OverloadedRecordDot
       OverloadedStrings
@@ -35,8 +39,9 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-      UndecidableInstances
       TypeOperators
+      UndecidableInstances
+      ViewPatterns
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-export-lists -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unused-packages -Wno-operator-whitespace -fdiagnostics-color=always -Wno-missing-kind-signatures -Wno-implicit-lift -Wno-implicit-prelude -fwarn-tabs +RTS -A128m -n2m -RTS -fdefer-diagnostics
   build-depends:
       base

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -1,4 +1,5 @@
-<<: !include hpack-common/defaults.yaml
+defaults:
+  local: ../hpack-common/defaults.yaml
 
 verbatim: { cabal-version: 3.0 }
 

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -1,3 +1,5 @@
+<<: !include hpack-common/defaults.yaml
+
 verbatim: { cabal-version: 3.0 }
 
 name:         temporal-sdk
@@ -52,32 +54,6 @@ dependencies:
 - first-class-families
 - validation-selective
 - vault
-
-default-extensions:
-- BangPatterns
-- BlockArguments
-- DataKinds
-- DerivingStrategies
-- FlexibleContexts
-- FlexibleInstances
-- GADTs
-- GeneralizedNewtypeDeriving
-- InstanceSigs
-- LambdaCase
-- MultiParamTypeClasses
-- NamedFieldPuns
-- NumericUnderscores
-- RankNTypes
-- OverloadedRecordDot
-- OverloadedStrings
-- RecordWildCards
-- ScopedTypeVariables
-- StandaloneDeriving
-- TypeApplications
-- TypeFamilies
-- TypeOperators
-- UndecidableInstances
-- ViewPatterns
 
 ghc-options:
 - -g


### PR DESCRIPTION
I think it would be nice, for DX-y reasons, to define things like `default-extensions` and `ghc-options` centrally for this repo, rather than separately in each package's `package.yaml`.

This PR starts that process by adopting [mwb's strategy](https://github.com/MercuryTechnologies/mercury-web-backend/tree/master/hpack-common) of [including](https://github.com/MercuryTechnologies/mercury-web-backend/blob/4024c75d8c68c31c6f02c9a0fdc0ef960e723378/package.yaml#L1) an `hpack-common/default.yaml` into `package.yaml`s. To start, it only takes over `default-extensions`, though my intention is to add at least `ghc-options` as well.

Some examples of why I think this would be useful:
- We have a number of warnings like `missing-role-annotations` and `missing-poly-kind-signatures` in here that I believe are essentially spurious (in the sense that we don't intend to act on them). It would be nice to disable them, and in that case it would be nice to do that in one place (as [mwb does](https://github.com/MercuryTechnologies/mercury-web-backend/blob/master/hpack-common/ghc-options.yaml#L66) for those same warnings)
- I'm currently using hls in this repo mostly-successfully, but I'd love to get the `ghciwatch`/`static-ls` workflow set up in here eventually, which requires some particular compiler options. As above, it would be nice to configure that in one place
- `fourmolu` needs to know what extensions are active (to handle e.g. record dots correctly), so it's convenient to have that defined in a single place to make things like format-on-save work correctly. For example, in mwb's `run-format.sh`, [we rely on default extensions being defined in a single well-known location](https://github.com/MercuryTechnologies/mercury-web-backend/blob/4024c75d8c68c31c6f02c9a0fdc0ef960e723378/nix/packages/mercury/run-format.sh#L65-L67) (relative to repo root) so we can pass them on.