### PR TITLE
tweak HandleQueryInput

### DIFF
--- a/core/temporal-sdk-core.cabal
+++ b/core/temporal-sdk-core.cabal
@@ -39,7 +39,6 @@ flag external_lib
 library
   exposed-modules:
       Temporal.Core.Client
-      Temporal.Core.Client.HealthService
       Temporal.Core.Client.OperatorService
       Temporal.Core.Client.TestService
       Temporal.Core.Client.WorkflowService
@@ -48,6 +47,7 @@ library
       Temporal.Runtime
   other-modules:
       Temporal.Core.CTypes
+      Temporal.Core.Client.HealthService
       Temporal.Internal.FFI
   hs-source-dirs:
       src

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -11,13 +11,13 @@ import Control.Monad.Logger
 import Control.Monad.Reader
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
-import Data.Vault.Strict
 import Data.Kind
 import Data.Map.Strict (Map)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.Time.Clock.System (SystemTime)
+import Data.Vault.Strict
 import Data.Vector (Vector)
 import Data.Word (Word32)
 import GHC.Stack
@@ -810,7 +810,7 @@ data WorkflowExitVariant a
 
 
 data HandleQueryInput = HandleQueryInput
-  { handleQueryId :: Text
+  { handleQueryId :: QueryId
   , handleQueryInputType :: Text
   , handleQueryInputArgs :: Vector Payload
   , handleQueryInputHeaders :: Map Text Payload

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -31,6 +31,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Time.Clock.System (SystemTime (..))
+import Data.Vault.Strict (Vault)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import GHC.Stack (HasCallStack, emptyCallStack)
@@ -77,7 +78,6 @@ import Temporal.Workflow.Internal.Instance
 import Temporal.Workflow.Internal.Monad
 import Temporal.Workflow.Types
 import UnliftIO
-import Data.Vault.Strict (Vault)
 
 
 create
@@ -105,58 +105,57 @@ create
   payloadProcessor
   info
   start = do
+    $logDebug "Instantiating workflow instance"
+    workflowInstanceLogger <- askLoggerIO
+    workflowRandomnessSeed <- WorkflowGenM <$> newIORef (mkStdGen 0)
+    workflowNotifiedPatches <- newIORef mempty
+    workflowMemoizedPatches <- newIORef mempty
+    workflowSequences <-
+      newIORef
+        Sequences
+          { externalCancel = 1
+          , childWorkflow = 1
+          , externalSignal = 1
+          , timer = 1
+          , activity = 1
+          , condition = 1
+          , varId = 1
+          }
+    workflowTime <- newIORef $ MkSystemTime 0 0
+    workflowIsReplaying <- newIORef False
+    workflowSequenceMaps <- newTVarIO $ SequenceMaps mempty mempty mempty mempty mempty mempty
+    workflowCommands <- newTVarIO $ Reversed []
+    workflowSignalHandlers <- newIORef mempty
+    workflowCallStack <- newIORef emptyCallStack
+    workflowQueryHandlers <- newIORef mempty
+    workflowInstanceInfo <- newIORef info
+    workflowInstanceContinuationEnv <- ContinuationEnv <$> newIORef JobNil
+    workflowCancellationVar <- newIVar
+    activationChannel <- newTQueueIO
+    executionThread <- newIORef (error "Workflow thread not yet started")
+    -- The execution thread is funny because it needs access to the instance, but the instance
+    -- needs access to the execution thread. It's a bit of a circular dependency, but
+    -- pretty innocuous since writing to the executionThread var happens before anything else
+    -- is allowed to interact with the instance.
+    let inst = WorkflowInstance {..}
+    workerThread <- liftIO $ async $ runInstanceM inst $ do
+      $logDebug "Start workflow execution thread"
+      exec <- setUpWorkflowExecution start
+      res <- liftIO $ inboundInterceptor.executeWorkflow exec $ \exec' -> runInstanceM inst $ runTopLevel $ do
+        $logDebug "Executing workflow"
+        wf <- applyStartWorkflow exec' workflowFn
+        runWorkflowToCompletion wf
+      $logDebug "Workflow execution completed"
+      addCommand =<< convertExitVariantToCommand res
+      flushCommands
+      $logDebug "Handling leftover queries"
+      handleQueriesAfterCompletion
 
-  $logDebug "Instantiating workflow instance"
-  workflowInstanceLogger <- askLoggerIO
-  workflowRandomnessSeed <- WorkflowGenM <$> newIORef (mkStdGen 0)
-  workflowNotifiedPatches <- newIORef mempty
-  workflowMemoizedPatches <- newIORef mempty
-  workflowSequences <-
-    newIORef
-      Sequences
-        { externalCancel = 1
-        , childWorkflow = 1
-        , externalSignal = 1
-        , timer = 1
-        , activity = 1
-        , condition = 1
-        , varId = 1
-        }
-  workflowTime <- newIORef $ MkSystemTime 0 0
-  workflowIsReplaying <- newIORef False
-  workflowSequenceMaps <- newTVarIO $ SequenceMaps mempty mempty mempty mempty mempty mempty
-  workflowCommands <- newTVarIO $ Reversed []
-  workflowSignalHandlers <- newIORef mempty
-  workflowCallStack <- newIORef emptyCallStack
-  workflowQueryHandlers <- newIORef mempty
-  workflowInstanceInfo <- newIORef info
-  workflowInstanceContinuationEnv <- ContinuationEnv <$> newIORef JobNil
-  workflowCancellationVar <- newIVar
-  activationChannel <- newTQueueIO
-  executionThread <- newIORef (error "Workflow thread not yet started")
-  -- The execution thread is funny because it needs access to the instance, but the instance
-  -- needs access to the execution thread. It's a bit of a circular dependency, but
-  -- pretty innocuous since writing to the executionThread var happens before anything else
-  -- is allowed to interact with the instance.
-  let inst = WorkflowInstance {..}
-  workerThread <- liftIO $ async $ runInstanceM inst $ do
-    $logDebug "Start workflow execution thread"
-    exec <- setUpWorkflowExecution start
-    res <- liftIO $ inboundInterceptor.executeWorkflow exec $ \exec' -> runInstanceM inst $ runTopLevel $ do
-      $logDebug "Executing workflow"
-      wf <- applyStartWorkflow exec' workflowFn
-      runWorkflowToCompletion wf
-    $logDebug "Workflow execution completed"
-    addCommand =<< convertExitVariantToCommand res
-    flushCommands
-    $logDebug "Handling leftover queries"
-    handleQueriesAfterCompletion
-
-  -- If we have an exception crash the workflow thread, then we need to throw to the worker too,
-  -- otherwise it will just hang forever.
-  link workerThread
-  writeIORef executionThread workerThread
-  pure inst
+    -- If we have an exception crash the workflow thread, then we need to throw to the worker too,
+    -- otherwise it will just hang forever.
+    link workerThread
+    writeIORef executionThread workerThread
+    pure inst
 
 
 runWorkflowToCompletion :: HasCallStack => SuspendableWorkflowExecution Payload -> InstanceM Payload
@@ -330,13 +329,12 @@ applyQueryWorkflow queryWorkflow = do
   $logDebug $ Text.pack ("Applying query: " <> show (queryWorkflow ^. Activation.queryType))
   let processor = inst.payloadProcessor
   args <- processorDecodePayloads processor (fmap convertFromProtoPayload (queryWorkflow ^. Command.vec'arguments))
-  hdrs <- processorDecodePayloads processor (fmap convertFromProtoPayload (queryWorkflow ^. Activation.headers))
   let baseInput =
         HandleQueryInput
-          { handleQueryId = queryWorkflow ^. Activation.queryId
+          { handleQueryId = QueryId (queryWorkflow ^. Activation.queryId)
           , handleQueryInputType = queryWorkflow ^. Activation.queryType
           , handleQueryInputArgs = args
-          , handleQueryInputHeaders = hdrs
+          , handleQueryInputHeaders = fmap convertFromProtoPayload (queryWorkflow ^. Activation.headers)
           }
   res <- liftIO $ inst.inboundInterceptor.handleQuery baseInput $ \input -> do
     let handlerOrDefault =
@@ -348,7 +346,7 @@ applyQueryWorkflow queryWorkflow = do
       Just h ->
         liftIO $
           h
-            (QueryId input.handleQueryId)
+            input.handleQueryId
             input.handleQueryInputArgs
             input.handleQueryInputHeaders
   cmd <- case res of
@@ -364,7 +362,7 @@ applyQueryWorkflow queryWorkflow = do
       res' <- liftIO $ payloadProcessorEncode processor ok
       pure $
         defMessage
-          & Command.queryId .~ baseInput.handleQueryId
+          & Command.queryId .~ rawQueryId baseInput.handleQueryId
           & Command.succeeded
             .~ ( defMessage
                   & Command.response .~ convertToProtoPayload res'


### PR DESCRIPTION
make two changes related to `HandleQueryInput` that we identified while working on STAB-506 but aren't directly related to that work:
- wrap the query ID in our `QueryId` newtype
- _don't_ `processorDecodePayloads` the headers (the typescript sdk [does not](https://github.com/temporalio/sdk-typescript/blob/58df441411613f2b5160287fb9bbe908d775f117/packages/workflow/src/internals.ts#L669-L673))

most of the line count here actually came from the precommit hook - i'll call out which changes were directly mine vs not.