### PR TITLE
STAB-506: add first execution run ID to WorkflowHandle

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -154,6 +154,7 @@ tests:
       DurationSpec,
       IntegrationSpec,
       IntegrationSpec.HangingWorkflow,
+      IntegrationSpec.NoOpWorkflow,
       IntegrationSpec.TimeoutsInWorkflows,
       Common,
       THCompiles

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -33,7 +33,7 @@ module Temporal.Client (
   startWorkflowOptions,
   Temporal.Client.start,
   startFromPayloads,
-  WorkflowHandle,
+  WorkflowHandle (..),
   execute,
   waitWorkflowResult,
 
@@ -58,6 +58,7 @@ module Temporal.Client (
 
   -- * Producing handles for existing workflows
   getHandle,
+  GetHandleOptions (..),
 
   -- * Workflow history utilities
   fetchHistory,
@@ -255,7 +256,7 @@ This function will block until the workflow completes, and will return the resul
 or throw a 'WorkflowExecutionClosed' exception if the workflow was closed without returning a result.
 -}
 waitWorkflowResult :: (Typeable a, MonadIO m) => WorkflowHandle a -> m a
-waitWorkflowResult h@(WorkflowHandle readResult _ c wf r) = do
+waitWorkflowResult h@(WorkflowHandle readResult _ c wf r _) = do
   mev <- runReaderT (waitResult wf r c.clientConfig.namespace) c
   case mev of
     Nothing -> error "Unexpected empty history"
@@ -324,7 +325,7 @@ signal
   -> sig
   -> SignalOptions
   -> (SignalArgs sig :->: m ())
-signal (WorkflowHandle _ _t c wf r) (signalRef -> (KnownSignal sName sCodec)) opts = withArgs @(SignalArgs sig) @(m ()) sCodec $ \inputs -> liftIO $ do
+signal (WorkflowHandle _ _t c wf r _) (signalRef -> (KnownSignal sName sCodec)) opts = withArgs @(SignalArgs sig) @(m ()) sCodec $ \inputs -> liftIO $ do
   inputs' <- processorEncodePayloads c.clientConfig.payloadProcessor =<< liftIO (sequence inputs)
   hdrs <- processorEncodePayloads c.clientConfig.payloadProcessor opts.headers
   result <-
@@ -344,8 +345,8 @@ signal (WorkflowHandle _ _t c wf r) (signalRef -> (KnownSignal sName sCodec)) op
         -- & WF.control .~ _
         -- TODO put other useful headers in here
         & WF.header .~ headerToProto (fmap convertToProtoPayload hdrs)
-        -- FIXME: Can we just ignore this now that it's no longer present?
-        -- & WF.skipGenerateWorkflowTask .~ opts.skipGenerateWorkflowTask
+  -- FIXME: Can we just ignore this now that it's no longer present?
+  -- & WF.skipGenerateWorkflowTask .~ opts.skipGenerateWorkflowTask
   case result of
     Left err -> throwIO err
     Right _ -> pure ()
@@ -447,6 +448,15 @@ query h (queryRef -> KnownQuery qn codec) opts = withArgs @(QueryArgs query) @(m
       WorkflowExecutionStatus'Unrecognized _ -> UnknownStatus
 
 
+data GetHandleOptions = GetHandleOptions
+  { firstExecutionRunId :: Maybe RunId
+  -- ^ If specified, later calls referencing the handle may error if the (most recent | specified workflow
+  -- run id) is not part of the same execution chain as this id. Only some operations (namely terminate)
+  -- respect firstExecutionRunId, while others (e.g. signal and query) ignore it.
+  }
+  deriving stock (Eq, Show)
+
+
 {- | Sometimes you know that a Workflow exists or existed, but you didn't create the workflow from
 the current process or code path. In this case, you can use 'getHandle' to get a handle to the
 workflow so that you can interact with it.
@@ -459,8 +469,9 @@ getHandle
   => KnownWorkflow args a
   -> WorkflowId
   -> Maybe RunId
+  -> Maybe GetHandleOptions
   -> m (WorkflowHandle a)
-getHandle (KnownWorkflow {knownWorkflowCodec, knownWorkflowName}) wfId runId = do
+getHandle (KnownWorkflow {knownWorkflowCodec, knownWorkflowName}) wfId runId opts = do
   c <- askWorkflowClient
   pure $
     WorkflowHandle
@@ -471,6 +482,7 @@ getHandle (KnownWorkflow {knownWorkflowCodec, knownWorkflowName}) wfId runId = d
       , workflowHandleWorkflowId = wfId
       , workflowHandleRunId = runId
       , workflowHandleType = WorkflowType knownWorkflowName
+      , workflowHandleFirstExecutionRunId = (.firstExecutionRunId) =<< opts
       }
 
 
@@ -552,14 +564,16 @@ startFromPayloads k@(KnownWorkflow codec _) wfId opts payloads = do
     case res of
       Left err -> throwIO err
       Right swer ->
-        pure $
-          WorkflowHandle
-            { workflowHandleReadResult = pure
-            , workflowHandleType = WorkflowType $ knownWorkflowName k
-            , workflowHandleClient = c
-            , workflowHandleWorkflowId = wfId'
-            , workflowHandleRunId = Just (RunId $ swer ^. WF.runId)
-            }
+        let runId = RunId $ swer ^. WF.runId
+        in pure $
+            WorkflowHandle
+              { workflowHandleReadResult = pure
+              , workflowHandleType = WorkflowType $ knownWorkflowName k
+              , workflowHandleClient = c
+              , workflowHandleWorkflowId = wfId'
+              , workflowHandleRunId = Just runId
+              , workflowHandleFirstExecutionRunId = Just runId
+              }
   pure $
     wfH
       { workflowHandleReadResult = \a ->
@@ -687,6 +701,9 @@ signalWithStart (workflowRef -> k@(KnownWorkflow codec _)) wfId opts (signalRef 
                 , workflowHandleClient = c
                 , workflowHandleWorkflowId = opts'.signalWithStartWorkflowId
                 , workflowHandleRunId = Just (RunId $ swer ^. WF.runId)
+                , -- We don't know if this handle represents a new workflow or an already-running one, so we don't
+                  -- know if the current run ID is for its first execution or not
+                  workflowHandleFirstExecutionRunId = Nothing
                 }
       pure $
         wfH
@@ -700,9 +717,6 @@ signalWithStart (workflowRef -> k@(KnownWorkflow codec _)) wfId opts (signalRef 
 data TerminationOptions = TerminationOptions
   { terminationReason :: Text
   , terminationDetails :: [Payload]
-  , firstExecutionRunId :: Maybe RunId
-  -- ^ If set, this call will error if the (most recent | specified workflow run id in the WorkflowHandle) is not part of the same
-  -- execution chain as this id.
   }
 
 
@@ -729,7 +743,7 @@ terminate h req =
         & RR.details
           .~ (defMessage & Common.payloads .~ fmap convertToProtoPayload req.terminationDetails)
         & RR.identity .~ Core.identity (Core.clientConfig h.workflowHandleClient.clientCore)
-        & RR.firstExecutionRunId .~ maybe "" rawRunId req.firstExecutionRunId
+        & RR.firstExecutionRunId .~ maybe "" rawRunId h.workflowHandleFirstExecutionRunId
 
 
 data FollowOption = FollowRuns | ThisRunOnly

--- a/sdk/src/Temporal/Client/Types.hs
+++ b/sdk/src/Temporal/Client/Types.hs
@@ -144,6 +144,7 @@ data WorkflowHandle a = WorkflowHandle
   , workflowHandleClient :: WorkflowClient
   , workflowHandleWorkflowId :: WorkflowId
   , workflowHandleRunId :: Maybe RunId
+  , workflowHandleFirstExecutionRunId :: Maybe RunId
   }
 
 

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -145,7 +145,7 @@ test-suite temporal-sdk-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      Spec, ConcurrentAccessSpec, AsyncCompletionSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.TimeoutsInWorkflows, Common, THCompiles
+      Spec, ConcurrentAccessSpec, AsyncCompletionSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, Common, THCompiles
   hs-source-dirs:
       test
   default-extensions:

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -318,6 +318,7 @@ spec = do
               (Just $ seconds 2)
 
   aroundAll setup needsClient
+  aroundAll setup terminateTests
   where
     setup :: (TestEnv -> IO ()) -> IO ()
     setup go = do
@@ -967,163 +968,6 @@ needsClient = do
           useClient (C.execute parentWf.reference (W.WorkflowId parentId) opts)
             `shouldReturn` "Left ChildWorkflowCancelled"
 
-    describe "Terminate" $ do
-      describe "when neither runId nor firstExecutionRunId is provided" $ do
-        it "returns" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $ do
-            let opts =
-                  (C.startWorkflowOptions taskQueue)
-                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                    }
-            useClient $ do
-              C.start NoOpWorkflow "test-terminate-works-without-run-ids" opts
-              h <- C.getHandle (workflowRef NoOpWorkflow) "test-terminate-works-without-run-ids" Nothing Nothing
-              C.terminate
-                h {C.workflowHandleRunId = Nothing, C.workflowHandleFirstExecutionRunId = Nothing}
-                C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-      describe "when runId is provided without firstExecutionRunId" $ do
-        it "returns if runId matches a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $ do
-            let opts =
-                  (C.startWorkflowOptions taskQueue)
-                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                    }
-            useClient $ do
-              h <- C.start NoOpWorkflow "test-terminate-works-with-good-run-id" opts
-              h' <- C.getHandle (workflowRef NoOpWorkflow) "test-terminate-works-with-good-run-id" h.workflowHandleRunId Nothing
-              C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-        it "throws if runId does not match a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $
-            do
-              let opts =
-                    (C.startWorkflowOptions taskQueue)
-                      { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                      }
-              ( useClient $ do
-                  h <- C.start NoOpWorkflow "test-terminate-throws-with-bad-run-id" opts
-                  h' <- C.getHandle (workflowRef NoOpWorkflow) "test-terminate-throws-with-bad-run-id" (Just "bad-run-id") Nothing
-                  C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-                )
-              `shouldThrow` \case
-                RpcError {} -> True
-                _ -> False
-      describe "when firstExecutionRunId is provided without runId" $ do
-        it "returns if firstExecutionRunId matches a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $ do
-            let opts =
-                  (C.startWorkflowOptions taskQueue)
-                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                    }
-            useClient $ do
-              h <- C.start NoOpWorkflow "test-terminate-works-with-good-first-execution-run-id" opts
-              h' <-
-                C.getHandle
-                  (workflowRef NoOpWorkflow)
-                  "test-terminate-works-with-good-first-execution-run-id"
-                  Nothing
-                  $ Just C.GetHandleOptions {C.firstExecutionRunId = Just $ M.fromJust h.workflowHandleFirstExecutionRunId}
-              C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-        it "throws if firstExecutionRunId does not match a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $
-            do
-              let opts =
-                    (C.startWorkflowOptions taskQueue)
-                      { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                      }
-              ( useClient $ do
-                  h <- C.start NoOpWorkflow "test-terminate-throws-with-bad-first-execution-run-id" opts
-                  h' <-
-                    C.getHandle
-                      (workflowRef NoOpWorkflow)
-                      "test-terminate-throws-with-bad-first-execution-run-id"
-                      Nothing
-                      $ Just C.GetHandleOptions {C.firstExecutionRunId = Just "bad-first-execution-run-id"}
-                  C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-                )
-              `shouldThrow` \case
-                RpcError {} -> True
-                _ -> False
-      describe "when both runId and firstExecutionRunId are provided" $ do
-        it "returns if both runId and firstExecutionRunId match a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $ do
-            let opts =
-                  (C.startWorkflowOptions taskQueue)
-                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                    }
-            useClient $ do
-              h <- C.start NoOpWorkflow "test-terminate-works-with-good-run-id-bad-first-execution-run-id" opts
-              h' <-
-                C.getHandle
-                  (workflowRef NoOpWorkflow)
-                  "test-terminate-works-with-good-run-id-bad-first-execution-run-id"
-                  h.workflowHandleRunId
-                  $ Just
-                    C.GetHandleOptions
-                      { C.firstExecutionRunId = Just $ M.fromJust h.workflowHandleFirstExecutionRunId
-                      }
-              C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-        it "throws if runId does not match a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $ do
-            let opts =
-                  (C.startWorkflowOptions taskQueue)
-                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                    }
-            useClient
-              ( do
-                  h <- C.start NoOpWorkflow "test-terminate-works-with-bad-run-id-good-first-execution-run-id" opts
-                  h' <-
-                    C.getHandle
-                      (workflowRef NoOpWorkflow)
-                      "test-terminate-works-with-bad-run-id-good-first-execution-run-id"
-                      (Just "bad-run-id")
-                      ( Just
-                          C.GetHandleOptions
-                            { C.firstExecutionRunId = Just $ M.fromJust h.workflowHandleFirstExecutionRunId
-                            }
-                      )
-                  C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-              )
-              `shouldThrow` \case
-                RpcError {} -> True
-                _ -> False
-        it "throws if firstExecutionRunId does not match a workflow" $ \TestEnv {..} -> do
-          let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
-                baseConf
-          withWorker conf $
-            do
-              let opts =
-                    (C.startWorkflowOptions taskQueue)
-                      { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                      }
-              useClient
-                ( do
-                    h <- C.start NoOpWorkflow "test-terminate-throws-good-run-id-bad-first-execution-run-id" opts
-                    h' <-
-                      C.getHandle
-                        (workflowRef NoOpWorkflow)
-                        "test-terminate-throws-with-good-run-id-bad-first-execution-run-id"
-                        (Just $ M.fromJust h.workflowHandleRunId)
-                        (Just C.GetHandleOptions {C.firstExecutionRunId = Just "bad-first-execution-run-id"})
-                    C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
-                )
-              `shouldThrow` \case
-                RpcError {} -> True
-                _ -> False
-
     describe "Signals" $ do
       specify "send" $ const pending
       specify "interrupt" $ const pending
@@ -1693,6 +1537,166 @@ needsClient = do
 
       incompatibleReplayResult <- runReplayHistory globalRuntime incompatibleConf history
       incompatibleReplayResult `shouldSatisfy` isLeft
+
+
+terminateTests :: SpecWith TestEnv
+terminateTests = do
+  describe "Terminate" $ do
+    describe "when neither runId nor firstExecutionRunId is provided" $ do
+      it "returns" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient $ do
+            C.start NoOpWorkflow "test-terminate-works-without-run-ids" opts
+            h <- C.getHandle (workflowRef NoOpWorkflow) "test-terminate-works-without-run-ids" Nothing Nothing
+            C.terminate
+              h {C.workflowHandleRunId = Nothing, C.workflowHandleFirstExecutionRunId = Nothing}
+              C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+    describe "when runId is provided without firstExecutionRunId" $ do
+      it "returns if runId matches a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient $ do
+            h <- C.start NoOpWorkflow "test-terminate-works-with-good-run-id" opts
+            h' <- C.getHandle (workflowRef NoOpWorkflow) "test-terminate-works-with-good-run-id" h.workflowHandleRunId Nothing
+            C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+      it "throws if runId does not match a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $
+          do
+            let opts =
+                  (C.startWorkflowOptions taskQueue)
+                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                    }
+            ( useClient $ do
+                h <- C.start NoOpWorkflow "test-terminate-throws-with-bad-run-id" opts
+                h' <- C.getHandle (workflowRef NoOpWorkflow) "test-terminate-throws-with-bad-run-id" (Just "bad-run-id") Nothing
+                C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+              )
+            `shouldThrow` \case
+              RpcError {} -> True
+              _ -> False
+    describe "when firstExecutionRunId is provided without runId" $ do
+      it "returns if firstExecutionRunId matches a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient $ do
+            h <- C.start NoOpWorkflow "test-terminate-works-with-good-first-execution-run-id" opts
+            h' <-
+              C.getHandle
+                (workflowRef NoOpWorkflow)
+                "test-terminate-works-with-good-first-execution-run-id"
+                Nothing
+                $ Just C.GetHandleOptions {C.firstExecutionRunId = Just $ M.fromJust h.workflowHandleFirstExecutionRunId}
+            C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+      it "throws if firstExecutionRunId does not match a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $
+          do
+            let opts =
+                  (C.startWorkflowOptions taskQueue)
+                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                    }
+            ( useClient $ do
+                h <- C.start NoOpWorkflow "test-terminate-throws-with-bad-first-execution-run-id" opts
+                h' <-
+                  C.getHandle
+                    (workflowRef NoOpWorkflow)
+                    "test-terminate-throws-with-bad-first-execution-run-id"
+                    Nothing
+                    $ Just C.GetHandleOptions {C.firstExecutionRunId = Just "bad-first-execution-run-id"}
+                C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+              )
+            `shouldThrow` \case
+              RpcError {} -> True
+              _ -> False
+    describe "when both runId and firstExecutionRunId are provided" $ do
+      it "returns if both runId and firstExecutionRunId match a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient $ do
+            h <- C.start NoOpWorkflow "test-terminate-works-with-good-run-id-bad-first-execution-run-id" opts
+            h' <-
+              C.getHandle
+                (workflowRef NoOpWorkflow)
+                "test-terminate-works-with-good-run-id-bad-first-execution-run-id"
+                h.workflowHandleRunId
+                $ Just
+                  C.GetHandleOptions
+                    { C.firstExecutionRunId = Just $ M.fromJust h.workflowHandleFirstExecutionRunId
+                    }
+            C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+      it "throws if runId does not match a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient
+            ( do
+                h <- C.start NoOpWorkflow "test-terminate-works-with-bad-run-id-good-first-execution-run-id" opts
+                h' <-
+                  C.getHandle
+                    (workflowRef NoOpWorkflow)
+                    "test-terminate-works-with-bad-run-id-good-first-execution-run-id"
+                    (Just "bad-run-id")
+                    ( Just
+                        C.GetHandleOptions
+                          { C.firstExecutionRunId = Just $ M.fromJust h.workflowHandleFirstExecutionRunId
+                          }
+                    )
+                C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+            )
+            `shouldThrow` \case
+              RpcError {} -> True
+              _ -> False
+      it "throws if firstExecutionRunId does not match a workflow" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $
+          do
+            let opts =
+                  (C.startWorkflowOptions taskQueue)
+                    { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                    }
+            useClient
+              ( do
+                  h <- C.start NoOpWorkflow "test-terminate-throws-good-run-id-bad-first-execution-run-id" opts
+                  h' <-
+                    C.getHandle
+                      (workflowRef NoOpWorkflow)
+                      "test-terminate-throws-with-good-run-id-bad-first-execution-run-id"
+                      (Just $ M.fromJust h.workflowHandleRunId)
+                      (Just C.GetHandleOptions {C.firstExecutionRunId = Just "bad-first-execution-run-id"})
+                  C.terminate h' C.TerminationOptions {terminationReason = "testing", terminationDetails = []}
+              )
+            `shouldThrow` \case
+              RpcError {} -> True
+              _ -> False
 
 -- describe "WorkflowClient" $ do
 --   specify "WorkflowExecutionAlreadyStartedError" pending

--- a/sdk/test/IntegrationSpec/NoOpWorkflow.hs
+++ b/sdk/test/IntegrationSpec/NoOpWorkflow.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
+
+module IntegrationSpec.NoOpWorkflow where
+
+import Control.Exception
+import Control.Monad
+import RequireCallStack (provideCallStack)
+import Temporal.Duration
+import Temporal.Payload
+import Temporal.TH
+import Temporal.Workflow
+
+
+noOpWorkflow :: Workflow ()
+noOpWorkflow = provideCallStack $ pure ()
+
+
+registerWorkflow 'noOpWorkflow


### PR DESCRIPTION
this is a pre-factor for STAB-506 (adding `update`) that i pulled out for easier review.

in the course of STAB-506, we noticed we were handling `firstExecutionRunId` (which we're currently taking as a parameter to `terminate` - the other main operation that, like `update`, supports it) differently than the typescript sdk (which takes it as an argument to `getHandle`, and then makes it a property on the workflow handle, such that later operations on that handle use it automatically[^1]).

so, adopt the typescript sdk's approach. in the main STAB-506 pr we can then build on this and have `update` function in the same way.

[^1]: well, some operations (like `signal` and `query`) just totally ignore it. i asked about this on the temporal slack and they said it's a known gap that was never prioritized.