### PR TITLE
chore(hpack): share more common fields

### DIFF
--- a/codec-encryption/package.yaml
+++ b/codec-encryption/package.yaml
@@ -1,13 +1,7 @@
-defaults: { local: ../hpack-defaults.yaml }
+<<: !include ../hpack-defaults.yaml
 
 name:         temporal-codec-encryption
-version:      "0.0.1.0"
-author:       Ian Duncan
-maintainer:   temporal@mercury.com
-license-file: LICENSE
-license:      BSD-3-Clause
 build-type:   Simple
-language:     Haskell2010
 
 dependencies:
 - base

--- a/codec-encryption/temporal-codec-encryption.cabal
+++ b/codec-encryption/temporal-codec-encryption.cabal
@@ -6,6 +6,7 @@ cabal-version: 3.0
 
 name:           temporal-codec-encryption
 version:        0.0.1.0
+category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com
 license:        BSD-3-Clause

--- a/codec-server/package.yaml
+++ b/codec-server/package.yaml
@@ -1,13 +1,7 @@
-defaults: { local: ../hpack-defaults.yaml }
+<<: !include ../hpack-defaults.yaml
 
 name:         temporal-sdk-codec-server
-version:      "0.0.1.0"
-author:       Ian Duncan
-maintainer:   temporal@mercury.com
-license-file: LICENSE
-license:      BSD-3-Clause
 build-type:   Simple
-language:     Haskell2010
 
 dependencies:
 - base

--- a/codec-server/temporal-sdk-codec-server.cabal
+++ b/codec-server/temporal-sdk-codec-server.cabal
@@ -6,6 +6,7 @@ cabal-version: 3.0
 
 name:           temporal-sdk-codec-server
 version:        0.0.1.0
+category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com
 license:        BSD-3-Clause

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,14 +1,8 @@
-defaults: { local: ../hpack-defaults.yaml }
+<<: !include ../hpack-defaults.yaml
 
 name:         temporal-sdk-core
-version:      0.1.0.0
-author:       Ian Duncan
-maintainer:   temporal@mercury.com
-license-file: LICENSE
-license:      BSD-3-Clause
 build-type:   Custom
-language:     Haskell2010
-category:     Concurrency
+
 extra-source-files:
   - rust/Cargo.toml
   - rust/Cargo.lock

--- a/core/temporal-sdk-core.cabal
+++ b/core/temporal-sdk-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-sdk-core
-version:        0.1.0.0
+version:        0.0.1.0
 category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com

--- a/hpack-defaults.yaml
+++ b/hpack-defaults.yaml
@@ -1,5 +1,13 @@
 verbatim: { cabal-version: 3.0 }
 
+version:      0.0.1.0
+author:       Ian Duncan
+maintainer:   temporal@mercury.com
+license-file: LICENSE
+license:      BSD-3-Clause
+language:     Haskell2010
+category:     Concurrency
+
 default-extensions:
   - BangPatterns
   - BlockArguments

--- a/optimal-codec/package.yaml
+++ b/optimal-codec/package.yaml
@@ -1,13 +1,7 @@
-defaults: { local: ../hpack-defaults.yaml }
+<<: !include ../hpack-defaults.yaml
 
 name:         temporal-sdk-optimal-codec
-version:      "0.0.1.0"
-author:       Ian Duncan
-maintainer:   temporal@mercury.com
-license-file: LICENSE
-license:      BSD-3-Clause
 build-type:   Simple
-language:     Haskell2010
 
 dependencies:
 - base

--- a/optimal-codec/temporal-sdk-optimal-codec.cabal
+++ b/optimal-codec/temporal-sdk-optimal-codec.cabal
@@ -6,6 +6,7 @@ cabal-version: 3.0
 
 name:           temporal-sdk-optimal-codec
 version:        0.0.1.0
+category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com
 license:        BSD-3-Clause

--- a/protos/package.yaml
+++ b/protos/package.yaml
@@ -1,7 +1,7 @@
 verbatim: { cabal-version: 3.0 }
 
 name:         temporal-api-protos
-version:      "1.0.0.0"
+version:      0.1.0.0
 author:       Ian Duncan
 maintainer:   temporal@mercury.com
 license-file: LICENSE

--- a/protos/temporal-api-protos.cabal
+++ b/protos/temporal-api-protos.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-api-protos
-version:        1.0.0.0
+version:        0.1.0.0
 author:         Ian Duncan
 maintainer:     temporal@mercury.com
 license:        BSD-3-Clause

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -1,13 +1,7 @@
-defaults: { local: ../hpack-defaults.yaml }
+<<: !include ../hpack-defaults.yaml
 
 name:         temporal-sdk
-version:      "0.0.1.0"
-author:       Ian Duncan
-maintainer:   temporal@mercury.com
-license-file: LICENSE
-license:      BSD-3-Clause
 build-type:   Simple
-language:     Haskell2010
 
 dependencies:
 - base

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -6,6 +6,7 @@ cabal-version: 3.0
 
 name:           temporal-sdk
 version:        0.0.1.0
+category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com
 license:        BSD-3-Clause


### PR DESCRIPTION
## description

also, revert back to @johnmastro's original approach of importing yaml fragments, since hpack's common fields doesn't support sharing everything we want to factor out (e.g. author, category, license, etc.).

also also, set the generated protobuf interface version to '0.1.0.0'.