### PR TITLE
Overhaul the activity heartbeat primitives

### DIFF
--- a/sdk/src/Temporal/Activity/Types.hs
+++ b/sdk/src/Temporal/Activity/Types.hs
@@ -1,5 +1,6 @@
 module Temporal.Activity.Types where
 
+import Data.IORef (IORef)
 import Data.Map (Map)
 import Data.Text (Text)
 import Data.Time.Clock.System (SystemTime)
@@ -22,8 +23,9 @@ data ActivityInfo = ActivityInfo
   , activityId :: ActivityId
   , activityType :: Text
   , headerFields :: Map Text Payload
-  , -- input
-    heartbeatDetails :: Vector Payload
+  , rawHeartbeatDetails :: IORef (Vector Payload)
+  -- ^ Generally, you should use 'getHeartbeatDetails' to get the heartbeat details,
+  -- as that provides a simpler interface.
   , scheduledTime :: SystemTime
   , currentAttemptScheduledTime :: SystemTime
   , startedTime :: SystemTime
@@ -37,4 +39,4 @@ data ActivityInfo = ActivityInfo
   , isLocal :: Bool
   , taskToken :: TaskToken
   }
-  deriving stock (Show, Eq)
+  deriving stock (Eq)

--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -97,6 +97,7 @@ activityInfoFromProto tt msg = do
   w <- ask
   hdrs <- processorDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.headerFields))
   heartbeats <- processorDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.vec'heartbeatDetails))
+  heartbeatsRef <- newIORef heartbeats
   pure $
     ActivityInfo
       { workflowNamespace = Namespace $ msg ^. AT.workflowNamespace
@@ -106,7 +107,7 @@ activityInfoFromProto tt msg = do
       , activityId = ActivityId $ msg ^. AT.activityId
       , activityType = msg ^. AT.activityType
       , headerFields = hdrs
-      , heartbeatDetails = heartbeats
+      , rawHeartbeatDetails = heartbeatsRef
       , scheduledTime = msg ^. AT.scheduledTime . to timespecFromTimestamp
       , currentAttemptScheduledTime = msg ^. AT.currentAttemptScheduledTime . to timespecFromTimestamp
       , startedTime = msg ^. AT.startedTime . to timespecFromTimestamp

--- a/sdk/src/Temporal/Workflow/Types.hs
+++ b/sdk/src/Temporal/Workflow/Types.hs
@@ -145,7 +145,6 @@ data ExecuteActivityInput = ExecuteActivityInput
   , activityHeaders :: Map Text Payload
   , activityInfo :: ActivityInfo
   }
-  deriving stock (Show)
 
 
 -- | Controls at which point to report back when a child workflow is cancelled.

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -439,8 +439,8 @@ testImpls =
           $logDebug "waiting for activity"
           W.wait (h :: W.Task Int)
       , basicActivity = pure 1
-      , heartbeatWorks = do
-          heartbeat []
+      , heartbeatWorks = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
+          heartbeat ()
           liftIO $ threadDelay 1_000_000
           pure 1
       , runHeartbeat = do
@@ -640,8 +640,8 @@ needsClient = do
             `shouldReturn` 1
       specify "Immediate activity cancellation returns the expected result to workflows" $ \TestEnv {..} -> do
         let testActivity :: Activity () Int
-            testActivity = do
-              heartbeat []
+            testActivity = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
+              heartbeat ()
               pure 0
 
             testActivityAct :: ProvidedActivity () (Activity () Int)
@@ -674,9 +674,9 @@ needsClient = do
             `shouldReturn` 1
       specify "Activity cancellation on heartbeat returns the expected result to workflows" $ \TestEnv {..} -> do
         let testActivity :: Activity () Int
-            testActivity = do
+            testActivity = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
               liftIO $ threadDelay 2_000_000
-              heartbeat []
+              heartbeat ()
               pure 0
 
             testActivityAct :: ProvidedActivity () (Activity () Int)


### PR DESCRIPTION
### TL;DR

Improved heartbeat functionality in the Temporal SDK with a safer, more ergonomic API.

### What changed?

- Replaced the single `heartbeat` function with a more comprehensive API:
  - Added `withHeartbeat` - a higher-level function that provides type-safe encoding/decoding of heartbeat details
  - Added `rawHeartbeat` - a lower-level function for sending heartbeat details
  - Added `getRawHeartbeat` - a function to retrieve the current heartbeat details

- Modified the `ActivityInfo` structure:
  - Changed `heartbeatDetails` to `rawHeartbeatDetails` which is now an `IORef` to allow updating
  - Removed `Show` instance for types containing `IORef`s

- Updated all test cases to use the new heartbeat API

### Why make this change?

This change improves the heartbeat API by:

1. Making it safer to use with proper type encoding/decoding
2. Providing a clearer separation between high-level and low-level APIs
3. Adding the ability to read current heartbeat details, which is essential for activity recovery
4. Ensuring heartbeat details are properly updated and accessible throughout activity execution

The new API makes it easier to implement activities that need to track and recover their progress through heartbeats.