### PR TITLE
init `tcld` at 0.40.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
                 ./nix/devenv/temporal-bridge.nix
                 ./nix/devenv/temporal-dev-server.nix
                 (import ./nix/devenv/haskell.nix ghcVersion)
+                ({ pkgs, ... }: { packages = [self.packages.${pkgs.system}.tcld]; })
               ];
             };
           shells = inputs.nixpkgs.lib.genAttrs ghcVersions (version: mkShell version);
@@ -41,6 +42,7 @@
         in
         haskellUtils.localPackageMatrix
         // {
+          tcld = pkgs.callPackage ./nix/packages/tcld { };
           temporal-bridge = pkgs.temporal_bridge;
         }
       );

--- a/nix/packages/tcld/bash_autocomplete
+++ b/nix/packages/tcld/bash_autocomplete
@@ -1,0 +1,33 @@
+#! /bin/bash
+# based on https://github.com/urfave/cli/blob/v2.27.6/autocomplete/bash_autocomplete
+
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      _cli_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-bash-completion"
+    else
+      requestComp="${words[*]} --generate-bash-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete tcld

--- a/nix/packages/tcld/compgen.patch
+++ b/nix/packages/tcld/compgen.patch
@@ -1,0 +1,15 @@
+diff --git a/app/app.go b/app/app.go
+index 57a9b36fdb..96acf94dc1 100644
+--- a/app/app.go
++++ b/app/app.go
+@@ -28,6 +28,7 @@
+ 			EnableDebugLogsFlag,
+ 		},
+ 		Commands: params.Commands,
++		EnableBashCompletion: true,
+ 	}
+ 
+ 	return app, nil
+diff --git a/compgen.patch b/compgen.patch
+new file mode 100644
+index 0000000000..e69de29bb2

--- a/nix/packages/tcld/default.nix
+++ b/nix/packages/tcld/default.nix
@@ -1,0 +1,20 @@
+{ buildGoModule, fetchFromGitHub, lib, ... }:
+
+buildGoModule (finalAttrs: {
+  pname = "tcld";
+  version = "0.40.0";
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "tcld";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-bIJSvop1T3yiLs/LTgFxIMmObfkVfvvnONyY4Bsjj8g=";
+  };
+  vendorHash = "sha256-GOko8nboj7eN4W84dqP3yLD6jK7GA0bANV0Tj+1GpgY=";
+  ldFlags = ["-s" "-w"];
+
+  meta = {
+    description = "todo";
+    homepage = "https://www.github.com/temporalio/tcld";
+    license = lib.licenses.mit;
+  };
+})

--- a/nix/packages/tcld/default.nix
+++ b/nix/packages/tcld/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, lib, ... }:
+{ buildGoModule, fetchFromGitHub, lib, stdenvNoCC, installShellFiles, ... }:
 
 buildGoModule (finalAttrs: {
   pname = "tcld";
@@ -11,6 +11,16 @@ buildGoModule (finalAttrs: {
   };
   vendorHash = "sha256-GOko8nboj7eN4W84dqP3yLD6jK7GA0bANV0Tj+1GpgY=";
   ldFlags = ["-s" "-w"];
+
+  # TODO: PR upstream.
+  patches = [ ./compgen.patch ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd tcld --bash ${./bash_autocomplete}
+    installShellCompletion --cmd tcld --zsh ${./zsh_autocomplete}
+  '';
 
   meta = {
     description = "todo";

--- a/nix/packages/tcld/default.nix
+++ b/nix/packages/tcld/default.nix
@@ -22,6 +22,11 @@ buildGoModule (finalAttrs: {
     installShellCompletion --cmd tcld --zsh ${./zsh_autocomplete}
   '';
 
+
+  # NOTE: Test suite appears to require some form of (local) networking, which
+  # doesn't work with the Nix sandbox.
+  doCheck = false;
+
   meta = {
     description = "todo";
     homepage = "https://www.github.com/temporalio/tcld";

--- a/nix/packages/tcld/zsh_autocomplete
+++ b/nix/packages/tcld/zsh_autocomplete
@@ -1,0 +1,22 @@
+#compdef $PROG
+
+## based on https://github.com/urfave/cli/blob/v2.27.6/autocomplete/zsh_autocomplete
+
+_cli_zsh_autocomplete() {
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+}
+
+compdef _cli_zsh_autocomplete tcld


### PR DESCRIPTION
## description

we should upstream this to nixpkgs, but in the meantime it's handy to have this in the shell environment when interacting with Temporal Cloud