### PR TITLE
break out `startUpdate` vs `executeUpdate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ core/rust/lib*
 .devenv
 .idea/
 .pre-commit-config.yaml
-.helix
+.helix/
+.zed/

--- a/sdk/src/Temporal/Client/Types.hs
+++ b/sdk/src/Temporal/Client/Types.hs
@@ -181,6 +181,20 @@ data UpdateWorkflowInput = UpdateWorkflowInput
   }
 
 
+data UpdateHandle a = UpdateHandle
+  { updateHandleUpdateId :: UpdateId
+  , updateHandleWorkflowId :: WorkflowId
+  , updateHandleWorkflowRunId :: Maybe RunId
+  , updateHandleReadResult :: Payload -> IO a
+  , updateHandleWorkflowClient :: WorkflowClient
+  , updateHandleType :: Text
+  }
+
+
+instance Functor UpdateHandle where
+  fmap x y = y {updateHandleReadResult = fmap x . updateHandleReadResult y}
+
+
 data WorkflowExecutionStatus
   = Running
   | Completed
@@ -213,7 +227,7 @@ data ClientInterceptors = ClientInterceptors
   { start :: WorkflowType -> WorkflowId -> StartWorkflowOptions -> Vector Payload -> (WorkflowType -> WorkflowId -> StartWorkflowOptions -> Vector Payload -> IO (WorkflowHandle Payload)) -> IO (WorkflowHandle Payload)
   , queryWorkflow :: QueryWorkflowInput -> (QueryWorkflowInput -> IO (Either QueryRejected Payload)) -> IO (Either QueryRejected Payload)
   , signalWithStart :: SignalWithStartWorkflowInput -> (SignalWithStartWorkflowInput -> IO (WorkflowHandle Payload)) -> IO (WorkflowHandle Payload)
-  , updateWorkflow :: UpdateWorkflowInput -> (UpdateWorkflowInput -> IO Payload) -> IO Payload
+  , updateWorkflow :: UpdateWorkflowInput -> (UpdateWorkflowInput -> IO (UpdateHandle Payload)) -> IO (UpdateHandle Payload)
   -- TODO
   -- signal
   -- terminate

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -1553,6 +1553,51 @@ needsClient = do
       incompatibleReplayResult `shouldSatisfy` isLeft
 
   describe "Update" $ do
+    describe "startUpdate" $ do
+      -- All the tests that call executeUpdate indirectly exercise startUpdate, but confirm here that validation failures are
+      -- thrown immediately from startUpdate (without needing to wait for the update outcome)
+      it "propagates validation failures" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions {C.runTimeout = Just $ seconds 10, C.executionTimeout = Nothing, C.taskTimeout = Nothing}
+                  }
+          let updateOpts =
+                C.UpdateOptions
+                  { updateId = "start-update-with-a-validator-that-rejects"
+                  , updateHeaders = mempty
+                  }
+          ( useClient do
+              h <- C.start UpdateWithValidator "start-update-with-a-validator-that-rejects" opts
+              C.startUpdate h testUpdate updateOpts (-12)
+            )
+            `shouldThrow` \case
+              UpdateFailure _ -> True
+              _ -> False
+      it "propagates validation exceptions if the validator throws" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions {C.runTimeout = Just $ seconds 10, C.executionTimeout = Nothing, C.taskTimeout = Nothing}
+                  }
+          let updateOpts =
+                C.UpdateOptions
+                  { updateId = "start-update-with-a-validator-that-throws"
+                  , updateHeaders = mempty
+                  }
+          ( useClient do
+              h <- C.start UpdateWithValidator "start-update-with-a-validator-that-throws" opts
+              C.startUpdate h testUpdate updateOpts 5
+            )
+            `shouldThrow` \case
+              UpdateFailure _ -> True
+              _ -> False
     it "works with no validator" $ \TestEnv {..} -> do
       let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
             baseConf
@@ -1566,11 +1611,10 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "update-with-no-validator"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         (updateResult, workflowResult) <- useClient do
           h <- C.start UpdateWithoutValidator "update-with-no-validator" opts
-          updateResult <- C.update h testUpdate updateOpts 12
+          updateResult <- C.executeUpdate h testUpdate updateOpts 12
           workflowResult <- C.waitWorkflowResult h
           pure (updateResult, workflowResult)
         updateResult `shouldBe` 12
@@ -1588,11 +1632,10 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "update-with-a-validator"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         (updateResult, workflowResult) <- useClient do
           h <- C.start UpdateWithValidator "update-with-a-validator" opts
-          updateResult <- C.update h testUpdate updateOpts 12
+          updateResult <- C.executeUpdate h testUpdate updateOpts 12
           workflowResult <- C.waitWorkflowResult h
           pure (updateResult, workflowResult)
         updateResult `shouldBe` 12
@@ -1610,11 +1653,10 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "update-with-a-validator-that-rejects"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         ( useClient do
             h <- C.start UpdateWithValidator "update-with-a-validator-that-rejects" opts
-            C.update h testUpdate updateOpts (-12)
+            C.executeUpdate h testUpdate updateOpts (-12)
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
@@ -1632,11 +1674,10 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "update-with-a-validator-that-throws"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         ( useClient do
             h <- C.start UpdateWithValidator "update-with-a-validator-that-throws" opts
-            C.update h testUpdate updateOpts 5
+            C.executeUpdate h testUpdate updateOpts 5
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
@@ -1654,11 +1695,10 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "update-that-throws"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         ( useClient do
             h <- C.start UpdateThatThrows "update-that-throws" opts
-            C.update h testUpdate updateOpts 5
+            C.executeUpdate h testUpdate updateOpts 5
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
@@ -1693,12 +1733,11 @@ needsClient = do
             C.UpdateOptions
               { updateId = "update-args-do-not-parse"
               , updateHeaders = mempty
-              , waitPolicy = C.UpdateLifecycleStageCompleted
               }
       withWorker conf $ do
         ( useClient do
             h <- C.start wfRef "update-args-do-not-parse" opts
-            C.update h badUpdateRef updateOpts "ruhroh"
+            C.executeUpdate h badUpdateRef updateOpts "ruhroh"
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
@@ -1717,11 +1756,10 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "update-that-suspends"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         (updateResult, workflowResult) <- useClient do
-          h <- C.start UpdateWithValidatorThatSleeps "update-that-suspends" opts
-          updateResult <- C.update h testUpdate updateOpts 12
+          h <- C.start UpdateThatSleeps "update-that-suspends" opts
+          updateResult <- C.executeUpdate h testUpdate updateOpts 12
           workflowResult <- C.waitWorkflowResult h
           pure (updateResult, workflowResult)
         updateResult `shouldBe` 12
@@ -1739,14 +1777,11 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "no-update-if-workflow-throws-first"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         (eUpdateResult, eWorkflowResult) <- useClient do
           h <- C.start WorkflowThatThrowsBeforeTheUpdate "no-update-if-workflow-throws-first" opts
           liftIO $ threadDelay 1_000_000
-          liftIO $ putStrLn "BEFORE UPDATE"
-          updateResult <- Catch.try $ C.update h testUpdate updateOpts 12
-          liftIO $ putStrLn "AFTER UPDATE"
+          updateResult <- Catch.try $ C.executeUpdate h testUpdate updateOpts 12
           workflowResult <- Catch.try $ C.waitWorkflowResult h
           let _ = show (updateResult :: Either RpcError Int)
           let _ = show (workflowResult :: Either WorkflowExecutionClosed Int)
@@ -1770,12 +1805,11 @@ needsClient = do
               C.UpdateOptions
                 { updateId = "yes-update-if-workflow-throws-later"
                 , updateHeaders = mempty
-                , waitPolicy = C.UpdateLifecycleStageCompleted
                 }
         (eUpdateResult, eWorkflowResult) <- useClient do
           h <- C.start WorkflowThatThrowsAfterTheUpdate "yes-update-if-workflow-throws-later" opts
           liftIO $ threadDelay 1_000_000
-          updateResult <- Catch.try $ C.update h testUpdate updateOpts 12
+          updateResult <- Catch.try $ C.executeUpdate h testUpdate updateOpts 12
           workflowResult <- Catch.try $ C.waitWorkflowResult h
           let _ = show (updateResult :: Either RpcError Int)
           let _ = show (workflowResult :: Either WorkflowExecutionClosed Int)
@@ -1828,11 +1862,10 @@ updatesWithInterceptors = do
                 C.UpdateOptions
                   { updateId = "update-interceptors-are-called"
                   , updateHeaders = mempty
-                  , waitPolicy = C.UpdateLifecycleStageCompleted
                   }
           (updateResult, workflowResult) <- useClient do
             h <- C.start UpdateWithValidator "update-interceptors-are-called" opts
-            updateResult <- C.update h testUpdate updateOpts 12
+            updateResult <- C.executeUpdate h testUpdate updateOpts 12
             workflowResult <- C.waitWorkflowResult h
             pure (updateResult, workflowResult)
           updateResult `shouldBe` 12
@@ -1877,11 +1910,10 @@ updatesWithInterceptors = do
                 C.UpdateOptions
                   { updateId = "update-interceptors-get-expected-args"
                   , updateHeaders = mempty
-                  , waitPolicy = C.UpdateLifecycleStageCompleted
                   }
           (updateResult, workflowResult) <- useClient do
             h <- C.start UpdateWithValidator "update-interceptors-get-expected-args" opts
-            updateResult <- C.update h testUpdate updateOpts 12
+            updateResult <- C.executeUpdate h testUpdate updateOpts 12
             workflowResult <- C.waitWorkflowResult h
             pure (updateResult, workflowResult)
           updateResult `shouldBe` 12
@@ -1953,11 +1985,10 @@ updatesWithInterceptors = do
                 C.UpdateOptions
                   { updateId = "update-interceptors-are-called-in-expected-order"
                   , updateHeaders = mempty
-                  , waitPolicy = C.UpdateLifecycleStageCompleted
                   }
           (updateResult, workflowResult) <- useClient do
             h <- C.start UpdateWithValidator "update-interceptors-are-called-in-expected-order" opts
-            updateResult <- C.update h testUpdate updateOpts 12
+            updateResult <- C.executeUpdate h testUpdate updateOpts 12
             workflowResult <- C.waitWorkflowResult h
             pure (updateResult, workflowResult)
           updateResult `shouldBe` 12
@@ -1991,11 +2022,10 @@ updatesWithInterceptors = do
                 C.UpdateOptions
                   { updateId = "update-interceptors-can-modify-args"
                   , updateHeaders = mempty
-                  , waitPolicy = C.UpdateLifecycleStageCompleted
                   }
           (updateResult, workflowResult) <- useClient do
             h <- C.start UpdateWithValidator "update-interceptors-can-modify-args" opts
-            updateResult <- C.update h testUpdate updateOpts 12
+            updateResult <- C.executeUpdate h testUpdate updateOpts 12
             workflowResult <- C.waitWorkflowResult h
             pure (updateResult, workflowResult)
           updateResult `shouldBe` 24
@@ -2025,11 +2055,10 @@ updatesWithInterceptors = do
                 C.UpdateOptions
                   { updateId = "update-client-interceptors-can-modify-args"
                   , updateHeaders = mempty
-                  , waitPolicy = C.UpdateLifecycleStageCompleted
                   }
           (updateResult, workflowResult) <- useClient do
             h <- C.start UpdateWithValidator "update-client-interceptors-can-modify-args" opts
-            updateResult <- C.update h testUpdate updateOpts 12
+            updateResult <- C.executeUpdate h testUpdate updateOpts 12
             workflowResult <- C.waitWorkflowResult h
             pure (updateResult, workflowResult)
           updateResult `shouldBe` 24

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -1576,7 +1576,6 @@ needsClient = do
             )
             `shouldThrow` \case
               UpdateFailure _ -> True
-              _ -> False
       it "propagates validation exceptions if the validator throws" $ \TestEnv {..} -> do
         let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
               baseConf
@@ -1597,7 +1596,6 @@ needsClient = do
             )
             `shouldThrow` \case
               UpdateFailure _ -> True
-              _ -> False
     it "works with no validator" $ \TestEnv {..} -> do
       let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
             baseConf
@@ -1660,7 +1658,6 @@ needsClient = do
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
-            _ -> False
     it "propagates validation exceptions if the validator throws" $ \TestEnv {..} -> do
       let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
             baseConf
@@ -1681,7 +1678,6 @@ needsClient = do
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
-            _ -> False
     it "propogates update exceptions if the update throws" $ \TestEnv {..} -> do
       let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
             baseConf
@@ -1702,7 +1698,6 @@ needsClient = do
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
-            _ -> False
     it "should fail if the args don't parse correctly" $ \TestEnv {..} -> do
       -- state <- runIO $ newIORef (0 :: Int)
       let testUpdateFn :: Int -> W.Workflow Int
@@ -1741,8 +1736,6 @@ needsClient = do
           )
           `shouldThrow` \case
             UpdateFailure _ -> True
-            _ -> False
-
     it "works with an update that causes the workflow to suspend" $ \TestEnv {..} -> do
       let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) $ do
             baseConf

--- a/sdk/test/IntegrationSpec/Updates.hs
+++ b/sdk/test/IntegrationSpec/Updates.hs
@@ -97,8 +97,8 @@ updateWithValidatorThatThrows = provideCallStack do
 registerWorkflow 'updateWithValidatorThatThrows
 
 
-updateWithValidatorThatSleeps :: Workflow Int
-updateWithValidatorThatSleeps = provideCallStack do
+updateThatSleeps :: Workflow Int
+updateThatSleeps = provideCallStack do
   stateVar <- newStateVar (0 :: Int)
   let handleUpdate arg = do
         sleep $ seconds 1
@@ -111,7 +111,7 @@ updateWithValidatorThatSleeps = provideCallStack do
   readStateVar stateVar
 
 
-registerWorkflow 'updateWithValidatorThatSleeps
+registerWorkflow 'updateThatSleeps
 
 
 workflowThatThrowsBeforeTheUpdate :: Workflow Int


### PR DESCRIPTION
refactor `update` into:
- `startUpdate`, which returns an `UpdateHandle` _without_ waiting for the update to complete. but note that `startUpdate` _does_ wait for the validator (if any) to complete (i.e. that the update reaches the `ACCEPTED` stage) so that we can signal an `UpdateFailed` error for validator failures rather than an "update not found" `RpcError` (which is what would happen if we tried to poll for the outcome where the validator rejected the update). this is the same thing [the typescript sdk does](https://github.com/temporalio/sdk-typescript/blob/ea28266ae12280df4cd8da6a3ff168dd6b47e1f7/packages/client/src/workflow-client.ts#L1457).
- `waitForUpdateOutcome`, which, given an `UpdateHandle`, waits for it to complete and returns the result
- `executeUpdate`, which composes those two start the update and wait for its result (the same behavior as the original `update`)