### PR TITLE
Take a pass at surfacing payload size limits to users

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -67,6 +67,11 @@
     within: [
       Test.Main
     ]
+- ignore:
+    name: "Redundant bracket"
+    within: [
+      Test.IntegrationSpec.Helpers
+    ]
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~
 

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -36,6 +36,7 @@ module Temporal.Client (
   WorkflowHandle (..),
   execute,
   waitWorkflowResult,
+  WorkflowIdReusePolicy (..),
 
   -- * Closing Workflows
   TerminationOptions (..),

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -48,6 +48,7 @@ import DiscoverInstances (discoverInstances)
 import GHC.Generics
 import GHC.Stack (SrcLoc (..), callStack, fromCallSiteList)
 import IntegrationSpec.HangingWorkflow
+import IntegrationSpec.Helpers
 import IntegrationSpec.NoOpWorkflow
 import IntegrationSpec.TimeoutsInWorkflows
 import IntegrationSpec.Updates
@@ -150,69 +151,6 @@ instance ToApplicationFailure AnApplicationFailure where
       (Just $ seconds 1)
 
 
-configWithRetry :: PortNumber -> ClientConfig
-configWithRetry pn =
-  defaultClientConfig
-    { targetUrl = "http://localhost:" <> Text.pack (show pn)
-    , retryConfig =
-        Just $
-          ClientRetryConfig
-            { initialIntervalMillis = 500
-            , randomizationFactor = 0.2
-            , multiplier = 1.5
-            , maxIntervalMillis = 10_000
-            , maxRetries = 15
-            , maxElapsedTimeMillis = Just 60_000
-            }
-            -- , targetUrl = pack ("http://localhost:" <> show pn)
-    }
-
-
-mkWithWorker :: PortNumber -> WorkerConfig actEnv -> IO a -> IO a
-mkWithWorker pn conf m = do
-  let clientConfig_ = configWithRetry pn
-  c <- connectClient globalRuntime clientConfig_
-  bracket (startWorker c (conf {payloadProcessor = sillyEncryptionPayloadProcessor})) shutdown (const m)
-
-
--- Increment the bytestring words by 1 on encode, and decrement by 1 on decode
---
--- This is used to test that the payload processor is working correctly
-sillyEncryptionPayloadProcessor :: PayloadProcessor
-sillyEncryptionPayloadProcessor = PayloadProcessor incr decr
-  where
-    incr (Payload data_ meta) = pure $ Payload (BS.map (+ 1) data_) meta
-    decr (Payload data_ meta) = pure $ Right $ Payload (BS.map (\x -> x - 1) data_) meta
-
-
-makeClient :: PortNumber -> Interceptors env -> IO (C.WorkflowClient, Client)
-makeClient pn Interceptors {..} = do
-  let conf = configWithRetry pn
-  c <- connectClient globalRuntime conf
-  (,)
-    <$> C.workflowClient
-      c
-      ( C.WorkflowClientConfig
-          { namespace = "default"
-          , interceptors = clientInterceptors
-          , payloadProcessor = sillyEncryptionPayloadProcessor
-          }
-      )
-    <*> pure c
-
-
-uuidText :: IO Text
-uuidText = UUID.toText <$> UUID.nextRandom
-
-
-data TestEnv = TestEnv
-  { useClient :: forall a. ReaderT C.WorkflowClient IO a -> IO a
-  , baseConf :: ConfigM () ()
-  , taskQueue :: W.TaskQueue
-  , withWorker :: forall a. WorkerConfig () -> IO a -> IO a
-  }
-
-
 data TemporalWorkflowJobPayload = TemporalWorkflowJobPayload
   { workflowId :: W.WorkflowId
   , workflowType :: W.WorkflowType
@@ -230,50 +168,6 @@ instance ToJSON TemporalWorkflowJobPayload
 
 
 instance FromJSON TemporalWorkflowJobPayload
-
-
-withServer :: (PortNumber -> IO a) -> IO a
-withServer f = do
-  lookupEnv "HS_TEMPORAL_SDK_LOCAL_TEST_SERVER" >>= \case
-    Just _ -> f 7233
-    _ -> do
-      fp <- getFreePort
-      mTemporalPath <- findExecutable "temporal"
-      conf <- case mTemporalPath of
-        Nothing -> error "Could not find the 'temporal' executable in PATH"
-        Just temporalPath -> do
-          let serverConfig =
-                defaultTemporalDevServerConfig
-                  { port = Just $ fromIntegral fp
-                  , exe = ExistingPath temporalPath
-                  }
-          pure serverConfig
-      withDevServer globalRuntime conf $ \_ -> do
-        f fp
-
-
-setup :: Interceptors () -> PortNumber -> (TestEnv -> IO ()) -> IO ()
-setup additionalInterceptors fp go = do
-  otelInterceptors <- makeOpenTelemetryInterceptor
-  let interceptors = otelInterceptors <> additionalInterceptors
-  (client, coreClient) <- makeClient fp interceptors
-
-  SearchAttributes {customAttributes} <- either throwIO pure =<< listSearchAttributes coreClient (W.Namespace "default")
-  let allTestAttributes =
-        Map.fromList
-          [ ("attr1", Temporal.Operator.Bool)
-          , ("attr2", Temporal.Operator.Int)
-          ]
-  _ <- addSearchAttributes coreClient (W.Namespace "default") (allTestAttributes `Map.difference` customAttributes)
-
-  (conf, taskQueue) <- mkBaseConf interceptors
-  go
-    TestEnv
-      { useClient = flip runReaderT client
-      , withWorker = mkWithWorker fp
-      , baseConf = conf
-      , taskQueue
-      }
 
 
 spec :: Spec
@@ -526,19 +420,6 @@ testDefs = defs defaultCodec testImpls
 
 testConf :: Definitions ()
 testConf = collectTemporalDefinitions testDefs
-
-
-mkBaseConf :: Interceptors () -> IO (ConfigM () (), W.TaskQueue)
-mkBaseConf interceptors = do
-  taskQueue <- W.TaskQueue <$> uuidText
-  pure
-    ( do
-        setNamespace $ W.Namespace "default"
-        setTaskQueue taskQueue
-        addInterceptors interceptors
-        setLogger $ defaultOutput stdout
-    , taskQueue
-    )
 
 
 needsClient :: SpecWith TestEnv

--- a/sdk/test/IntegrationSpec/Helpers.hs
+++ b/sdk/test/IntegrationSpec/Helpers.hs
@@ -1,0 +1,179 @@
+module IntegrationSpec.Helpers where
+
+import Common
+import Control.Concurrent
+import Control.Exception
+import Control.Exception.Annotated
+import qualified Control.Exception.Annotated as Annotated
+import Control.Monad (replicateM, when)
+import qualified Control.Monad.Catch as Catch
+import Control.Monad.Logger
+import Control.Monad.Reader
+import Data.Aeson (FromJSON, ToJSON, Value, toJSON)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft, isRight)
+import Data.Foldable (traverse_)
+import Data.Functor
+import Data.IORef
+import Data.Int
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust, isJust)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time (Day (ModifiedJulianDay))
+import Data.Time.Clock (UTCTime)
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUID
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import DiscoverInstances (discoverInstances)
+import GHC.Generics
+import GHC.Stack (SrcLoc (..), callStack, fromCallSiteList)
+import Lens.Family2
+import OpenTelemetry.Trace
+import qualified Proto.Temporal.Api.Failure.V1.Message_Fields as Failure
+import Proto.Temporal.Api.History.V1.Message (WorkflowExecutionFailedEventAttributes (..))
+import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
+import RequireCallStack
+import System.Directory
+import System.Environment (lookupEnv)
+import System.IO
+import Temporal.Activity
+import Temporal.Bundle
+import Temporal.Bundle.TH
+import qualified Temporal.Client as C
+import Temporal.Contrib.OpenTelemetry
+import Temporal.Core.Client
+import Temporal.Duration
+import Temporal.EphemeralServer
+import Temporal.Exception
+import Temporal.Interceptor
+import Temporal.Operator (IndexedValueType (..), SearchAttributes (..), addSearchAttributes, listSearchAttributes)
+import Temporal.Payload
+import Temporal.SearchAttributes
+import Temporal.TH (ActivityFn, WorkflowFn, discoverDefinitions)
+import Temporal.Worker
+import qualified Temporal.Workflow as W
+import Temporal.Workflow.Unsafe (performUnsafeNonDeterministicIO)
+import Test.Hspec
+
+
+data TestEnv = TestEnv
+  { useClient :: forall a. ReaderT C.WorkflowClient IO a -> IO a
+  , baseConf :: ConfigM () ()
+  , taskQueue :: W.TaskQueue
+  , withWorker :: forall a. WorkerConfig () -> IO a -> IO a
+  }
+
+
+configWithRetry :: PortNumber -> ClientConfig
+configWithRetry pn =
+  defaultClientConfig
+    { targetUrl = "http://localhost:" <> Text.pack (show pn)
+    , retryConfig =
+        Just $
+          ClientRetryConfig
+            { initialIntervalMillis = 500
+            , randomizationFactor = 0.2
+            , multiplier = 1.5
+            , maxIntervalMillis = 10_000
+            , maxRetries = 15
+            , maxElapsedTimeMillis = Just 60_000
+            }
+            -- , targetUrl = pack ("http://localhost:" <> show pn)
+    }
+
+
+mkWithWorker :: PortNumber -> WorkerConfig actEnv -> IO a -> IO a
+mkWithWorker pn conf m = do
+  let clientConfig_ = configWithRetry pn
+  c <- connectClient globalRuntime clientConfig_
+  bracket (startWorker c (conf {payloadProcessor = sillyEncryptionPayloadProcessor})) shutdown (const m)
+
+
+-- Increment the bytestring words by 1 on encode, and decrement by 1 on decode
+--
+-- This is used to test that the payload processor is working correctly
+sillyEncryptionPayloadProcessor :: PayloadProcessor
+sillyEncryptionPayloadProcessor = PayloadProcessor incr decr
+  where
+    incr (Payload data_ meta) = pure $ Payload (BS.map (+ 1) data_) meta
+    decr (Payload data_ meta) = pure $ Right $ Payload (BS.map (\x -> x - 1) data_) meta
+
+
+makeClient :: PortNumber -> Interceptors env -> IO (C.WorkflowClient, Client)
+makeClient pn Interceptors {..} = do
+  let conf = configWithRetry pn
+  c <- connectClient globalRuntime conf
+  (,)
+    <$> C.workflowClient
+      c
+      ( C.WorkflowClientConfig
+          { namespace = "default"
+          , interceptors = clientInterceptors
+          , payloadProcessor = sillyEncryptionPayloadProcessor
+          }
+      )
+    <*> pure c
+
+
+uuidText :: IO Text
+uuidText = UUID.toText <$> UUID.nextRandom
+
+
+withServer :: (PortNumber -> IO a) -> IO a
+withServer f = do
+  lookupEnv "HS_TEMPORAL_SDK_LOCAL_TEST_SERVER" >>= \case
+    Just _ -> f 7233
+    _ -> do
+      fp <- getFreePort
+      mTemporalPath <- findExecutable "temporal"
+      conf <- case mTemporalPath of
+        Nothing -> error "Could not find the 'temporal' executable in PATH"
+        Just temporalPath -> do
+          let serverConfig =
+                defaultTemporalDevServerConfig
+                  { port = Just $ fromIntegral fp
+                  , exe = ExistingPath temporalPath
+                  }
+          pure serverConfig
+      withDevServer globalRuntime conf $ \_ -> do
+        f fp
+
+
+setup :: Interceptors () -> PortNumber -> (TestEnv -> IO ()) -> IO ()
+setup additionalInterceptors fp go = do
+  otelInterceptors <- makeOpenTelemetryInterceptor
+  let interceptors = otelInterceptors <> additionalInterceptors
+  (client, coreClient) <- makeClient fp interceptors
+
+  SearchAttributes {customAttributes} <- either throwIO pure =<< listSearchAttributes coreClient (W.Namespace "default")
+  let allTestAttributes =
+        Map.fromList
+          [ ("attr1", Temporal.Operator.Bool)
+          , ("attr2", Temporal.Operator.Int)
+          ]
+  _ <- addSearchAttributes coreClient (W.Namespace "default") (allTestAttributes `Map.difference` customAttributes)
+
+  (conf, taskQueue) <- mkBaseConf interceptors
+  go
+    TestEnv
+      { useClient = flip runReaderT client
+      , withWorker = mkWithWorker fp
+      , baseConf = conf
+      , taskQueue
+      }
+
+
+mkBaseConf :: Interceptors () -> IO (ConfigM () (), W.TaskQueue)
+mkBaseConf interceptors = do
+  taskQueue <- W.TaskQueue <$> uuidText
+  pure
+    ( do
+        setNamespace $ W.Namespace "default"
+        setTaskQueue taskQueue
+        addInterceptors interceptors
+        setLogger $ defaultOutput stdout
+    , taskQueue
+    )

--- a/sdk/test/IntegrationSpec/VeryLargeContentsSpec.hs
+++ b/sdk/test/IntegrationSpec/VeryLargeContentsSpec.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE TemplateHaskell #-}
+module IntegrationSpec.VeryLargeContentsSpec where
+
+import Control.Exception (SomeException (..), try)
+import Control.Monad
+import Data.Aeson
+import qualified Data.Text as T
+import Data.UUID (UUID)
+import qualified Data.UUID.V4 as UUID
+import DiscoverInstances (discoverInstances)
+import IntegrationSpec.Helpers
+import RequireCallStack
+import System.Random.Stateful
+import Temporal.Activity
+import qualified Temporal.Client as C
+import Temporal.Duration
+import Temporal.TH
+import Temporal.Worker
+import Temporal.Workflow
+import Test.Hspec
+
+
+{-
+   Temporal has limits of 2MB for a single payload, and 4MB for a single
+   gRPC request. At the time of writing, the Haskell SDK falls into a black
+   hole as soon as one of these limits is exceeded. The tests here are
+   exercising that the SDK actually surfaces errors in a fashion that is
+   comprehensible to the user.
+-}
+
+-- ~2.5 MB
+largePayload :: T.Text
+largePayload = T.replicate 2_500_000 "a"
+
+
+{- | We don't produce the input here, so we just have to prove that we can receive it or
+reject it gracefully
+-}
+largeInputWorkflow :: T.Text -> Workflow ()
+largeInputWorkflow _ = pure ()
+
+
+registerWorkflow 'largeInputWorkflow
+
+
+largeOutputWorkflow :: Workflow T.Text
+largeOutputWorkflow = pure largePayload
+
+
+registerWorkflow 'largeOutputWorkflow
+
+
+largeOutputActivity :: Activity () T.Text
+largeOutputActivity = do
+  pure largePayload
+
+
+registerActivity 'largeOutputActivity
+
+
+largeInputActivity :: T.Text -> Activity () ()
+largeInputActivity _ = pure ()
+
+
+registerActivity 'largeInputActivity
+
+
+bringRegisteredTemporalFunctionsIntoScope
+
+
+largeInputInvokingWorkflow :: Workflow ()
+largeInputInvokingWorkflow = provideCallStack do
+  let options = defaultStartActivityOptions $ StartToClose $ seconds 10
+  _ <- executeActivity LargeInputActivity options largePayload
+  pure ()
+
+
+registerWorkflow 'largeInputInvokingWorkflow
+
+
+largeOutputInvokingWorkflow :: Workflow ()
+largeOutputInvokingWorkflow = provideCallStack do
+  let options = defaultStartActivityOptions $ StartToClose $ seconds 10
+  _ <- executeActivity LargeOutputActivity options
+  pure ()
+
+
+registerWorkflow 'largeOutputInvokingWorkflow
+
+
+requestBodySizeExceedsLimitWorkflow :: Workflow ()
+requestBodySizeExceedsLimitWorkflow = provideCallStack do
+  let biggishChunk = T.replicate 1_000_000 "a"
+      options = defaultStartActivityOptions $ StartToClose $ seconds 10
+  hs <- replicateM 5 $ startActivity LargeInputActivity options biggishChunk
+  mapM_ wait hs
+  pure ()
+
+
+registerWorkflow 'requestBodySizeExceedsLimitWorkflow
+
+
+bringRegisteredTemporalFunctionsIntoScope
+
+
+spec :: Spec
+spec = aroundAll withServer $ aroundAllWith (flip $ setup mempty) do
+  let instances = provideCallStack $ discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)
+  fdescribe "Very large payloads" do
+    it "should return reasonable workflow failures on overly large inputs" $ \TestEnv {..} -> do
+      uuid <- WorkflowId <$> uuidText
+      let opts =
+            (C.startWorkflowOptions taskQueue)
+              { C.workflowIdReusePolicy = Just C.WorkflowIdReusePolicyTerminateIfRunning
+              }
+          wf = useClient $ C.execute LargeInputWorkflow uuid opts largePayload
+      x <- try wf
+      case x of
+        Left (SomeException e) -> do
+          print e
+          pure ()
+        Right _ -> error "Succeeded when we expected an error"
+    it "should return reasonable workflow failures on overly large outputs" $ \TestEnv {..} -> do
+      uuid <- WorkflowId <$> uuidText
+      let opts =
+            (C.startWorkflowOptions taskQueue)
+              { C.workflowIdReusePolicy = Just C.WorkflowIdReusePolicyTerminateIfRunning
+              }
+          wf = useClient $ C.execute LargeOutputWorkflow uuid opts
+          conf = configure () instances $ do
+            baseConf
+      withWorker conf $ do
+        wf `shouldThrow` \case
+          (SomeException _) -> True
+
+    it "should return reasonable activity failures on overly large inputs" $ \TestEnv {..} -> do
+      uuid <- WorkflowId <$> uuidText
+      let opts =
+            (C.startWorkflowOptions taskQueue)
+              { C.workflowIdReusePolicy = Just C.WorkflowIdReusePolicyTerminateIfRunning
+              }
+          wf = useClient $ C.execute LargeInputInvokingWorkflow uuid opts
+          conf = configure () instances $ do
+            baseConf
+      withWorker conf $ do
+        x <- try wf
+        case x of
+          Left (SomeException e) -> do
+            print e
+            pure ()
+          Right _ -> error "Succeeded when we expected an error"
+    it "should return reasonable activity failures on overly large outputs" $ \TestEnv {..} -> do
+      uuid <- WorkflowId <$> uuidText
+      let opts =
+            (C.startWorkflowOptions taskQueue)
+              { C.workflowIdReusePolicy = Just C.WorkflowIdReusePolicyTerminateIfRunning
+              }
+          wf = useClient $ C.execute LargeOutputInvokingWorkflow uuid opts
+          conf = configure () instances $ do
+            baseConf
+      withWorker conf $ do
+        x <- try wf
+        case x of
+          Left (SomeException e) -> do
+            print e
+            pure ()
+          Right _ -> error "Succeeded when we expected an error"
+    fit "should handle the situation where no one payload is too large, but collectively they are" $ \TestEnv {..} -> do
+      uuid <- WorkflowId <$> uuidText
+      let opts =
+            (C.startWorkflowOptions taskQueue)
+              { C.workflowIdReusePolicy = Just C.WorkflowIdReusePolicyTerminateIfRunning
+              }
+          wf = useClient $ C.execute RequestBodySizeExceedsLimitWorkflow uuid opts
+          conf = configure () instances $ do
+            baseConf
+      withWorker conf $ do
+        x <- try wf
+        case x of
+          Left (SomeException e) -> do
+            print e
+            pure ()
+          Right _ -> error "Succeeded when we expected an error"


### PR DESCRIPTION
### TL;DR

Partial support for handling large payloads gracefully in the Temporal SDK + some tests that just validate behaviour in general

### What changed?

- Added detection for gRPC message size limits (4MB) in workflow activation completions
- Created a new test module `IntegrationSpec/VeryLargeContentsSpec.hs` to test handling of large payloads
- Refactored test helpers into a separate module `IntegrationSpec/Helpers.hs`
- Exported `WorkflowIdReusePolicy` from the Client module
- Added additional debug logging for workflow activations
- Updated HLint configuration to ignore redundant brackets in test helpers

### How to test?

Run the new integration tests in `IntegrationSpec/VeryLargeContentsSpec.hs` which verify:
- Handling of large workflow inputs
- Handling of large workflow outputs
- Handling of large activity inputs
- Handling of large activity outputs
- Handling of multiple payloads that collectively exceed size limits (currently busted)

### Why make this change?

Temporal has limits of 2MB for a single payload and 4MB for a single gRPC request. Previously, the SDK would hang indefinitely when these limits were exceeded. This change ensures that the SDK surfaces appropriate errors when payload size limits are exceeded, providing better feedback to users and preventing workflows from getting stuck in an unrecoverable state.