### PR TITLE
Bump Temporal SDK to pull in payload size failure changes

### DIFF
--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -480,18 +480,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,23 +831,25 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "governor"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if",
  "dashmap",
  "futures-sink",
  "futures-timer",
  "futures-util",
+ "getrandom 0.3.2",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand 0.9.1",
  "smallvec",
  "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -1225,15 +1227,6 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1320,9 +1313,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -1496,38 +1489,38 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
  "reqwest",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
  "http",
  "opentelemetry",
@@ -1536,28 +1529,30 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.17.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=e911383#e91138351a689cd21923c15eb48f5fbc95ded807"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "098a71a4430bb712be6130ed777335d2e5b19bc8566de5f2edddfce906def6ab"
 dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
- "protobuf",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.26.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1567,23 +1562,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -1765,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -1775,7 +1769,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1795,7 +1789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -1815,7 +1809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1878,9 +1872,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "quanta"
@@ -2173,7 +2181,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 [[package]]
 name = "rustfsm"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 dependencies = [
  "rustfsm_procmacro",
  "rustfsm_trait",
@@ -2182,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "rustfsm_procmacro"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 dependencies = [
  "derive_more",
  "proc-macro2",
@@ -2194,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "rustfsm_trait"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 
 [[package]]
 name = "rustix"
@@ -2511,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.32.1"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2549,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "temporal-client"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2564,7 +2572,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "parking_lot",
- "prost-types",
  "slotmap",
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
@@ -2580,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "temporal-sdk-core"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2599,7 +2606,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "itertools 0.13.0",
+ "itertools",
  "lru",
  "mockall",
  "opentelemetry",
@@ -2612,7 +2619,7 @@ dependencies = [
  "prometheus",
  "prost",
  "prost-wkt-types",
- "rand 0.8.5",
+ "rand 0.9.1",
  "reqwest",
  "ringbuf",
  "rustfsm",
@@ -2640,14 +2647,13 @@ dependencies = [
 [[package]]
 name = "temporal-sdk-core-api"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 dependencies = [
  "async-trait",
  "derive_builder",
  "derive_more",
  "opentelemetry",
  "prost",
- "prost-types",
  "serde_json",
  "temporal-sdk-core-protos",
  "thiserror 2.0.12",
@@ -2659,18 +2665,17 @@ dependencies = [
 [[package]]
 name = "temporal-sdk-core-protos"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#6e601115daa3b9ccaa9d0d383f926aaa5953ea3d"
+source = "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d"
 dependencies = [
  "anyhow",
  "base64",
  "derive_more",
  "prost",
  "prost-build",
- "prost-types",
  "prost-wkt",
  "prost-wkt-build",
  "prost-wkt-types",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/core/rust/Cargo.nix
+++ b/core/rust/Cargo.nix
@@ -1411,9 +1411,9 @@ rec {
       };
       "derive_more" = rec {
         crateName = "derive_more";
-        version = "1.0.0";
+        version = "2.0.1";
         edition = "2021";
-        sha256 = "01cd8pskdjg10dvfchi6b8a9pa1ja1ic0kbn45dl8jdyrfwrk6sa";
+        sha256 = "0y3n97cc7rsvgnj211p92y1ppzh6jzvq5kvk6340ghkhfp7l4ch9";
         authors = [
           "Jelte Fennema <github-tech@jeltef.nl>"
         ];
@@ -1456,9 +1456,9 @@ rec {
       };
       "derive_more-impl" = rec {
         crateName = "derive_more-impl";
-        version = "1.0.0";
+        version = "2.0.1";
         edition = "2021";
-        sha256 = "08mxyd456ygk68v5nfn4dyisn82k647w9ri2jl19dqpvmnp30wyb";
+        sha256 = "1wqxcb7d5lzvpplz9szp4rwy1r23f5wmixz0zd2vcjscqknji9mx";
         procMacro = true;
         libName = "derive_more_impl";
         authors = [
@@ -2494,9 +2494,9 @@ rec {
       };
       "governor" = rec {
         crateName = "governor";
-        version = "0.7.0";
+        version = "0.8.1";
         edition = "2018";
-        sha256 = "17qkr13r9h1ww865vxw3pyasayxmccb24x7ga4a552xpbmvalih7";
+        sha256 = "1sz8xc6qzfrfalrcfjjy1v1ahqnx1hswgh34j96v04275vnb94xy";
         authors = [
           "Andreas Fuchs <asf@boinkor.net>"
         ];
@@ -2528,6 +2528,11 @@ rec {
             features = [ "std" "sink" ];
           }
           {
+            name = "getrandom";
+            packageId = "getrandom 0.3.2";
+            features = [ "wasm_js" ];
+          }
+          {
             name = "no-std-compat";
             packageId = "no-std-compat";
             features = [ "alloc" ];
@@ -2554,7 +2559,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.8.5";
+            packageId = "rand 0.9.1";
             optional = true;
           }
           {
@@ -2564,6 +2569,10 @@ rec {
           {
             name = "spinning_top";
             packageId = "spinning_top";
+          }
+          {
+            name = "web-time";
+            packageId = "web-time";
           }
         ];
         features = {
@@ -3846,28 +3855,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" ];
       };
-      "itertools 0.13.0" = rec {
-        crateName = "itertools";
-        version = "0.13.0";
-        edition = "2018";
-        sha256 = "11hiy3qzl643zcigknclh446qb9zlg4dpdzfkjaa9q9fqpgyfgj1";
-        authors = [
-          "bluss"
-        ];
-        dependencies = [
-          {
-            name = "either";
-            packageId = "either";
-            usesDefaultFeatures = false;
-          }
-        ];
-        features = {
-          "default" = [ "use_std" ];
-          "use_std" = [ "use_alloc" "either/use_std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "use_alloc" "use_std" ];
-      };
-      "itertools 0.14.0" = rec {
+      "itertools" = rec {
         crateName = "itertools";
         version = "0.14.0";
         edition = "2018";
@@ -4096,9 +4084,9 @@ rec {
       };
       "lru" = rec {
         crateName = "lru";
-        version = "0.12.5";
+        version = "0.13.0";
         edition = "2015";
-        sha256 = "0f1a7cgqxbyhrmgaqqa11m3azwhcc36w0v5r4izgbhadl3sg8k13";
+        sha256 = "0ra4jcfgij99z02rg5zy292ncsybk0vn5zc7bmrv82igbzalhxr2";
         authors = [
           "Jerome Froelich <jeromefroelic@hotmail.com>"
         ];
@@ -4565,26 +4553,24 @@ rec {
       };
       "opentelemetry" = rec {
         crateName = "opentelemetry";
-        version = "0.26.0";
+        version = "0.29.1";
         edition = "2021";
-        sha256 = "05yd0ms1wqn28x8b1hshyr59lfmzsddnx5l080c5h6lxk767802p";
+        sha256 = "0v6ijlxs486yip2zbjdpgqc525q8l8k9s8ddz6b4ixvm4xz271wy";
         dependencies = [
           {
             name = "futures-core";
             packageId = "futures-core";
+            optional = true;
           }
           {
             name = "futures-sink";
             packageId = "futures-sink";
+            optional = true;
           }
           {
             name = "js-sys";
             packageId = "js-sys";
             target = { target, features }: (("wasm32" == target."arch" or null) && (!("wasi" == target."os" or null)));
-          }
-          {
-            name = "once_cell";
-            packageId = "once_cell";
           }
           {
             name = "pin-project-lite";
@@ -4593,24 +4579,37 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 1.0.69";
+            packageId = "thiserror 2.0.12";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "tracing";
+            packageId = "tracing";
+            optional = true;
             usesDefaultFeatures = false;
           }
         ];
         features = {
-          "default" = [ "trace" "metrics" "logs" ];
-          "logs_level_enabled" = [ "logs" ];
+          "default" = [ "trace" "metrics" "logs" "internal-logs" "futures" ];
+          "futures" = [ "futures-core" "futures-sink" "pin-project-lite" ];
+          "futures-core" = [ "dep:futures-core" ];
+          "futures-sink" = [ "dep:futures-sink" ];
+          "internal-logs" = [ "tracing" ];
           "pin-project-lite" = [ "dep:pin-project-lite" ];
-          "testing" = [ "trace" "metrics" ];
-          "trace" = [ "pin-project-lite" ];
+          "spec_unstable_logs_enabled" = [ "logs" ];
+          "testing" = [ "trace" ];
+          "thiserror" = [ "dep:thiserror" ];
+          "trace" = [ "futures" "thiserror" ];
+          "tracing" = [ "dep:tracing" ];
         };
-        resolvedDefaultFeatures = [ "default" "logs" "metrics" "pin-project-lite" "trace" ];
+        resolvedDefaultFeatures = [ "default" "futures" "futures-core" "futures-sink" "internal-logs" "logs" "metrics" "pin-project-lite" "thiserror" "trace" "tracing" ];
       };
       "opentelemetry-http" = rec {
         crateName = "opentelemetry-http";
-        version = "0.26.0";
+        version = "0.29.0";
         edition = "2021";
-        sha256 = "16abq6l64vy591y4j2xjxp2k1kfihn6ng05lgwk7r7d4x9m4jlb3";
+        sha256 = "1vf86z9d4dr9msck3k2xan9w5k35rfk9bylhpnav9d97p0rapms6";
         libName = "opentelemetry_http";
         dependencies = [
           {
@@ -4639,26 +4638,31 @@ rec {
             usesDefaultFeatures = false;
             features = [ "blocking" ];
           }
+          {
+            name = "tracing";
+            packageId = "tracing";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
         ];
         features = {
+          "default" = [ "internal-logs" ];
           "hyper" = [ "dep:http-body-util" "dep:hyper" "dep:hyper-util" "dep:tokio" ];
+          "internal-logs" = [ "tracing" "opentelemetry/internal-logs" ];
           "reqwest" = [ "dep:reqwest" ];
           "reqwest-rustls" = [ "reqwest" "reqwest/rustls-tls-native-roots" ];
           "reqwest-rustls-webpki-roots" = [ "reqwest" "reqwest/rustls-tls-webpki-roots" ];
+          "tracing" = [ "dep:tracing" ];
         };
-        resolvedDefaultFeatures = [ "reqwest" ];
+        resolvedDefaultFeatures = [ "default" "internal-logs" "reqwest" "tracing" ];
       };
       "opentelemetry-otlp" = rec {
         crateName = "opentelemetry-otlp";
-        version = "0.26.0";
+        version = "0.29.0";
         edition = "2021";
-        sha256 = "1gcn0r1cip9rg7pqpyhkx8q2aphxfg7yzh1hqwszdm1jn34gkq99";
+        sha256 = "0mjnx260qn4x1p9pyip35m7764kkszn087f0f6xcq5k9w07p56fq";
         libName = "opentelemetry_otlp";
         dependencies = [
-          {
-            name = "async-trait";
-            packageId = "async-trait";
-          }
           {
             name = "futures-core";
             packageId = "futures-core";
@@ -4703,7 +4707,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 1.0.69";
+            packageId = "thiserror 2.0.12";
             usesDefaultFeatures = false;
           }
           {
@@ -4719,6 +4723,12 @@ rec {
             optional = true;
             usesDefaultFeatures = false;
           }
+          {
+            name = "tracing";
+            packageId = "tracing";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
         ];
         devDependencies = [
           {
@@ -4727,20 +4737,26 @@ rec {
             usesDefaultFeatures = false;
             features = [ "macros" "rt-multi-thread" ];
           }
+          {
+            name = "tonic";
+            packageId = "tonic";
+            usesDefaultFeatures = false;
+            features = [ "server" ];
+          }
         ];
         features = {
-          "default" = [ "grpc-tonic" "trace" "metrics" "logs" ];
-          "experimental-internal-logs" = [ "tracing" ];
+          "default" = [ "http-proto" "reqwest-blocking-client" "trace" "metrics" "logs" "internal-logs" ];
           "grpc-tonic" = [ "tonic" "prost" "http" "tokio" "opentelemetry-proto/gen-tonic" ];
           "gzip-tonic" = [ "tonic/gzip" ];
           "http" = [ "dep:http" ];
           "http-json" = [ "serde_json" "prost" "opentelemetry-http" "opentelemetry-proto/gen-tonic-messages" "opentelemetry-proto/with-serde" "http" "trace" "metrics" ];
           "http-proto" = [ "prost" "opentelemetry-http" "opentelemetry-proto/gen-tonic-messages" "http" "trace" "metrics" ];
-          "integration-testing" = [ "tonic" "prost" "tokio/full" "trace" ];
+          "hyper-client" = [ "opentelemetry-http/hyper" ];
+          "integration-testing" = [ "tonic" "prost" "tokio/full" "trace" "logs" ];
+          "internal-logs" = [ "tracing" "opentelemetry/internal-logs" ];
           "logs" = [ "opentelemetry/logs" "opentelemetry_sdk/logs" "opentelemetry-proto/logs" ];
           "metrics" = [ "opentelemetry/metrics" "opentelemetry_sdk/metrics" "opentelemetry-proto/metrics" ];
           "opentelemetry-http" = [ "dep:opentelemetry-http" ];
-          "populate-logs-event-name" = [ "opentelemetry-proto/populate-logs-event-name" ];
           "prost" = [ "dep:prost" ];
           "reqwest" = [ "dep:reqwest" ];
           "reqwest-blocking-client" = [ "reqwest/blocking" "opentelemetry-http/reqwest" ];
@@ -4759,18 +4775,13 @@ rec {
           "tracing" = [ "dep:tracing" ];
           "zstd-tonic" = [ "tonic/zstd" ];
         };
-        resolvedDefaultFeatures = [ "default" "grpc-tonic" "http" "http-proto" "logs" "metrics" "opentelemetry-http" "prost" "reqwest" "reqwest-client" "tls" "tokio" "tonic" "trace" ];
+        resolvedDefaultFeatures = [ "default" "grpc-tonic" "http" "http-proto" "internal-logs" "logs" "metrics" "opentelemetry-http" "prost" "reqwest" "reqwest-blocking-client" "tls" "tokio" "tonic" "trace" "tracing" ];
       };
       "opentelemetry-prometheus" = rec {
         crateName = "opentelemetry-prometheus";
-        version = "0.17.0";
+        version = "0.29.1";
         edition = "2021";
-        workspace_member = null;
-        src = pkgs.fetchgit {
-          url = "https://github.com/open-telemetry/opentelemetry-rust.git";
-          rev = "e91138351a689cd21923c15eb48f5fbc95ded807";
-          sha256 = "1hnialssdng4hq19mldkvqlgpan8zg5jzrxdcx51b8yp35zylcra";
-        };
+        sha256 = "1aznvq3fkz6xxprfavanr2dv3rfj6mrpgv9hc6z15dqb8fj732h9";
         libName = "opentelemetry_prometheus";
         dependencies = [
           {
@@ -4794,18 +4805,24 @@ rec {
             packageId = "prometheus";
           }
           {
-            name = "protobuf";
-            packageId = "protobuf";
+            name = "tracing";
+            packageId = "tracing";
+            optional = true;
+            usesDefaultFeatures = false;
           }
         ];
         features = {
+          "default" = [ "internal-logs" ];
+          "internal-logs" = [ "tracing" ];
+          "tracing" = [ "dep:tracing" ];
         };
+        resolvedDefaultFeatures = [ "default" "internal-logs" "tracing" ];
       };
       "opentelemetry-proto" = rec {
         crateName = "opentelemetry-proto";
-        version = "0.26.1";
+        version = "0.29.0";
         edition = "2021";
-        sha256 = "0d4bbxfyjg9dnnm962574rvm8dqv76j4wg3yqajwrzdfwf69dly9";
+        sha256 = "1cq96c16hxsfvcd26ip1v3sg9952mi89snqdawc5whw14cjdlh4c";
         libName = "opentelemetry_proto";
         dependencies = [
           {
@@ -4832,11 +4849,13 @@ rec {
           }
         ];
         features = {
+          "base64" = [ "dep:base64" ];
           "default" = [ "full" ];
-          "full" = [ "gen-tonic" "trace" "logs" "metrics" "zpages" "with-serde" ];
-          "gen-tonic" = [ "gen-tonic-messages" "tonic/transport" ];
+          "full" = [ "gen-tonic" "trace" "logs" "metrics" "zpages" "with-serde" "internal-logs" ];
+          "gen-tonic" = [ "gen-tonic-messages" "tonic/channel" ];
           "gen-tonic-messages" = [ "tonic" "prost" ];
           "hex" = [ "dep:hex" ];
+          "internal-logs" = [ "tracing" ];
           "logs" = [ "opentelemetry/logs" "opentelemetry_sdk/logs" ];
           "metrics" = [ "opentelemetry/metrics" "opentelemetry_sdk/metrics" ];
           "prost" = [ "dep:prost" ];
@@ -4845,23 +4864,19 @@ rec {
           "testing" = [ "opentelemetry/testing" ];
           "tonic" = [ "dep:tonic" ];
           "trace" = [ "opentelemetry/trace" "opentelemetry_sdk/trace" ];
+          "tracing" = [ "dep:tracing" ];
           "with-schemars" = [ "schemars" ];
-          "with-serde" = [ "serde" "hex" ];
+          "with-serde" = [ "serde" "hex" "base64" ];
           "zpages" = [ "trace" ];
         };
         resolvedDefaultFeatures = [ "gen-tonic" "gen-tonic-messages" "logs" "metrics" "prost" "tonic" "trace" ];
       };
       "opentelemetry_sdk" = rec {
         crateName = "opentelemetry_sdk";
-        version = "0.26.0";
+        version = "0.29.0";
         edition = "2021";
-        sha256 = "1wv2r34p5pxbyd1pp19ary5wp3q2svxlpvi93brc3kf9ykcjginj";
+        sha256 = "02r99lz30zrb8870vivww8cvwhdi78v5fv5sq6mr8wyls4hzppmg";
         dependencies = [
-          {
-            name = "async-trait";
-            packageId = "async-trait";
-            optional = true;
-          }
           {
             name = "futures-channel";
             packageId = "futures-channel";
@@ -4882,10 +4897,6 @@ rec {
             optional = true;
           }
           {
-            name = "once_cell";
-            packageId = "once_cell";
-          }
-          {
             name = "opentelemetry";
             packageId = "opentelemetry";
           }
@@ -4896,10 +4907,10 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.8.5";
+            packageId = "rand 0.9.1";
             optional = true;
             usesDefaultFeatures = false;
-            features = [ "std" "std_rng" "small_rng" ];
+            features = [ "std" "std_rng" "small_rng" "os_rng" "thread_rng" ];
           }
           {
             name = "serde_json";
@@ -4908,7 +4919,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 1.0.69";
+            packageId = "thiserror 2.0.12";
             usesDefaultFeatures = false;
           }
           {
@@ -4923,34 +4934,43 @@ rec {
             packageId = "tokio-stream";
             optional = true;
           }
+          {
+            name = "tracing";
+            packageId = "tracing";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
         ];
         features = {
-          "async-std" = [ "dep:async-std" ];
-          "async-trait" = [ "dep:async-trait" ];
-          "default" = [ "trace" "metrics" "logs" ];
-          "experimental-internal-logs" = [ "tracing" ];
+          "default" = [ "trace" "metrics" "logs" "internal-logs" ];
+          "experimental_logs_batch_log_processor_with_async_runtime" = [ "logs" ];
+          "experimental_logs_concurrent_log_processor" = [ "logs" ];
+          "experimental_metrics_disable_name_validation" = [ "metrics" ];
+          "experimental_metrics_periodicreader_with_async_runtime" = [ "metrics" ];
+          "experimental_trace_batch_span_processor_with_async_runtime" = [ "trace" ];
           "glob" = [ "dep:glob" ];
           "http" = [ "dep:http" ];
+          "internal-logs" = [ "tracing" ];
           "jaeger_remote_sampler" = [ "trace" "opentelemetry-http" "http" "serde" "serde_json" "url" ];
-          "logs" = [ "opentelemetry/logs" "async-trait" "serde_json" ];
-          "logs_level_enabled" = [ "logs" "opentelemetry/logs_level_enabled" ];
-          "metrics" = [ "opentelemetry/metrics" "glob" "async-trait" ];
+          "logs" = [ "opentelemetry/logs" "serde_json" ];
+          "metrics" = [ "opentelemetry/metrics" "glob" ];
           "opentelemetry-http" = [ "dep:opentelemetry-http" ];
           "percent-encoding" = [ "dep:percent-encoding" ];
           "rand" = [ "dep:rand" ];
-          "rt-async-std" = [ "async-std" ];
-          "rt-tokio" = [ "tokio" "tokio-stream" ];
-          "rt-tokio-current-thread" = [ "tokio" "tokio-stream" ];
+          "rt-tokio" = [ "tokio" "tokio-stream" "experimental_async_runtime" ];
+          "rt-tokio-current-thread" = [ "tokio" "tokio-stream" "experimental_async_runtime" ];
           "serde" = [ "dep:serde" ];
           "serde_json" = [ "dep:serde_json" ];
-          "testing" = [ "opentelemetry/testing" "trace" "metrics" "logs" "rt-async-std" "rt-tokio" "rt-tokio-current-thread" "tokio/macros" "tokio/rt-multi-thread" ];
+          "spec_unstable_logs_enabled" = [ "logs" "opentelemetry/spec_unstable_logs_enabled" ];
+          "spec_unstable_metrics_views" = [ "metrics" ];
+          "testing" = [ "opentelemetry/testing" "trace" "metrics" "logs" "rt-tokio" "rt-tokio-current-thread" "tokio/macros" "tokio/rt-multi-thread" ];
           "tokio" = [ "dep:tokio" ];
           "tokio-stream" = [ "dep:tokio-stream" ];
-          "trace" = [ "opentelemetry/trace" "rand" "async-trait" "percent-encoding" ];
+          "trace" = [ "opentelemetry/trace" "rand" "percent-encoding" ];
           "tracing" = [ "dep:tracing" ];
           "url" = [ "dep:url" ];
         };
-        resolvedDefaultFeatures = [ "async-trait" "default" "glob" "logs" "metrics" "percent-encoding" "rand" "rt-tokio" "serde_json" "tokio" "tokio-stream" "trace" ];
+        resolvedDefaultFeatures = [ "default" "experimental_async_runtime" "glob" "internal-logs" "logs" "metrics" "percent-encoding" "rand" "rt-tokio" "serde_json" "spec_unstable_metrics_views" "tokio" "tokio-stream" "trace" "tracing" ];
       };
       "overload" = rec {
         crateName = "overload";
@@ -5391,9 +5411,9 @@ rec {
       };
       "prometheus" = rec {
         crateName = "prometheus";
-        version = "0.13.4";
+        version = "0.14.0";
         edition = "2018";
-        sha256 = "1lbymqdsh9v4zk4fjdq2gq6lbxspp1w3z2b9vfb7y7vp625c4crx";
+        sha256 = "0fpl98whrg5j4bpb3qfswii4yfa58zws7rl7rnd0m58bimnk599w";
         authors = [
           "overvenus@gmail.com"
           "siddontang@gmail.com"
@@ -5427,18 +5447,18 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 1.0.69";
+            packageId = "thiserror 2.0.12";
           }
         ];
         features = {
           "default" = [ "protobuf" ];
-          "gen" = [ "protobuf-codegen-pure" ];
+          "gen" = [ "protobuf-codegen" ];
           "libc" = [ "dep:libc" ];
           "nightly" = [ "libc" ];
           "process" = [ "libc" "procfs" ];
           "procfs" = [ "dep:procfs" ];
           "protobuf" = [ "dep:protobuf" ];
-          "protobuf-codegen-pure" = [ "dep:protobuf-codegen-pure" ];
+          "protobuf-codegen" = [ "dep:protobuf-codegen" ];
           "push" = [ "reqwest" "libc" "protobuf" ];
           "reqwest" = [ "dep:reqwest" ];
         };
@@ -5493,7 +5513,7 @@ rec {
           }
           {
             name = "itertools";
-            packageId = "itertools 0.14.0";
+            packageId = "itertools";
             usesDefaultFeatures = false;
             features = [ "use_alloc" ];
           }
@@ -5574,7 +5594,7 @@ rec {
           }
           {
             name = "itertools";
-            packageId = "itertools 0.14.0";
+            packageId = "itertools";
           }
           {
             name = "proc-macro2";
@@ -5765,19 +5785,48 @@ rec {
       };
       "protobuf" = rec {
         crateName = "protobuf";
-        version = "2.28.0";
-        edition = "2018";
-        sha256 = "154dfzjvxlpx37ha3cmp7fkhcsnyzbnfv7aisvz34x23k2gdjv8h";
+        version = "3.7.2";
+        edition = "2021";
+        sha256 = "1x4riz4znnjsqpdxnhxj0aq8rfivmbv4hfqmd3gbbn77v96isnnn";
         authors = [
           "Stepan Koltsov <stepan.koltsov@gmail.com>"
         ];
+        dependencies = [
+          {
+            name = "once_cell";
+            packageId = "once_cell";
+          }
+          {
+            name = "protobuf-support";
+            packageId = "protobuf-support";
+          }
+          {
+            name = "thiserror";
+            packageId = "thiserror 1.0.69";
+          }
+        ];
         features = {
           "bytes" = [ "dep:bytes" ];
-          "serde" = [ "dep:serde" ];
-          "serde_derive" = [ "dep:serde_derive" ];
           "with-bytes" = [ "bytes" ];
-          "with-serde" = [ "serde" "serde_derive" ];
         };
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "protobuf-support" = rec {
+        crateName = "protobuf-support";
+        version = "3.7.2";
+        edition = "2021";
+        sha256 = "1mnpn2q96bxm2vidh86m5p2x5z0z8rgfyixk1wlgjiqa3vrw4diy";
+        libName = "protobuf_support";
+        authors = [
+          "Stepan Koltsov <stepan.koltsov@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "thiserror";
+            packageId = "thiserror 1.0.69";
+          }
+        ];
+
       };
       "quanta" = rec {
         crateName = "quanta";
@@ -6970,12 +7019,12 @@ rec {
       "rustfsm" = rec {
         crateName = "rustfsm";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         authors = [
           "Spencer Judge <spencer@temporal.io>"
@@ -6995,12 +7044,12 @@ rec {
       "rustfsm_procmacro" = rec {
         crateName = "rustfsm_procmacro";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         procMacro = true;
         authors = [
@@ -7035,12 +7084,12 @@ rec {
       "rustfsm_trait" = rec {
         crateName = "rustfsm_trait";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         authors = [
           "Spencer Judge <spencer@temporal.io>"
@@ -7998,9 +8047,9 @@ rec {
       };
       "sysinfo" = rec {
         crateName = "sysinfo";
-        version = "0.32.1";
+        version = "0.33.1";
         edition = "2021";
-        sha256 = "1bzlj3afjz4ibdsfchjk1f4md6djffw668f3npiykwph38jcscsc";
+        sha256 = "00bcbj9rk39n07ylclj9klggkshxyianv2lfkpqnc6x0iqj5ij2g";
         authors = [
           "Guillaume Gomez <guillaume1.gomez@gmail.com>"
         ];
@@ -8131,12 +8180,12 @@ rec {
       "temporal-client" = rec {
         crateName = "temporal-client";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         libName = "temporal_client";
         authors = [
@@ -8198,10 +8247,6 @@ rec {
             packageId = "parking_lot";
           }
           {
-            name = "prost-types";
-            packageId = "prost-types";
-          }
-          {
             name = "slotmap";
             packageId = "slotmap";
           }
@@ -8252,12 +8297,12 @@ rec {
       "temporal-sdk-core" = rec {
         crateName = "temporal-sdk-core";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         libName = "temporal_sdk_core";
         authors = [
@@ -8344,7 +8389,7 @@ rec {
           }
           {
             name = "itertools";
-            packageId = "itertools 0.13.0";
+            packageId = "itertools";
           }
           {
             name = "lru";
@@ -8364,7 +8409,7 @@ rec {
             name = "opentelemetry-otlp";
             packageId = "opentelemetry-otlp";
             optional = true;
-            features = [ "tokio" "metrics" "tls" "http-proto" "reqwest-client" ];
+            features = [ "tokio" "metrics" "tls" "http-proto" "grpc-tonic" ];
           }
           {
             name = "opentelemetry-prometheus";
@@ -8375,7 +8420,7 @@ rec {
             name = "opentelemetry_sdk";
             packageId = "opentelemetry_sdk";
             optional = true;
-            features = [ "rt-tokio" "metrics" ];
+            features = [ "rt-tokio" "metrics" "spec_unstable_metrics_views" ];
           }
           {
             name = "parking_lot";
@@ -8405,7 +8450,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.8.5";
+            packageId = "rand 0.9.1";
           }
           {
             name = "reqwest";
@@ -8531,12 +8576,12 @@ rec {
       "temporal-sdk-core-api" = rec {
         crateName = "temporal-sdk-core-api";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         libName = "temporal_sdk_core_api";
         authors = [
@@ -8565,10 +8610,6 @@ rec {
           {
             name = "prost";
             packageId = "prost";
-          }
-          {
-            name = "prost-types";
-            packageId = "prost-types";
           }
           {
             name = "serde_json";
@@ -8603,12 +8644,12 @@ rec {
       "temporal-sdk-core-protos" = rec {
         crateName = "temporal-sdk-core-protos";
         version = "0.1.0";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-core";
-          rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d";
-          sha256 = "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a";
+          rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d";
+          sha256 = "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds";
         };
         libName = "temporal_sdk_core_protos";
         authors = [
@@ -8633,10 +8674,6 @@ rec {
             packageId = "prost";
           }
           {
-            name = "prost-types";
-            packageId = "prost-types";
-          }
-          {
             name = "prost-wkt";
             packageId = "prost-wkt";
           }
@@ -8646,7 +8683,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.8.5";
+            packageId = "rand 0.9.1";
             optional = true;
           }
           {

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-temporal-client = { git = "https://github.com/temporalio/sdk-core", rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d" }
-temporal-sdk-core = { git = "https://github.com/temporalio/sdk-core", rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d", features = ["ephemeral-server"] }
-temporal-sdk-core-api = { git = "https://github.com/temporalio/sdk-core", rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d" }
-temporal-sdk-core-protos = { git = "https://github.com/temporalio/sdk-core", rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d" }
-rustfsm = { git = "https://github.com/temporalio/sdk-core", rev = "6e601115daa3b9ccaa9d0d383f926aaa5953ea3d" }
+temporal-client = { git = "https://github.com/temporalio/sdk-core", rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d" }
+temporal-sdk-core = { git = "https://github.com/temporalio/sdk-core", rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d", features = ["ephemeral-server"] }
+temporal-sdk-core-api = { git = "https://github.com/temporalio/sdk-core", rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d" }
+temporal-sdk-core-protos = { git = "https://github.com/temporalio/sdk-core", rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d" }
+rustfsm = { git = "https://github.com/temporalio/sdk-core", rev = "8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d" }
 tokio = "~1.44"
 tokio-stream = "~0.1"
 tonic = "~0.12"
@@ -28,6 +28,6 @@ libc = "0.2.172"
 
 [profile.release]
 opt-level = 3
-debug = false
+debug = true
 lto = true
 incremental = true

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -28,6 +28,6 @@ libc = "0.2.172"
 
 [profile.release]
 opt-level = 3
-debug = true
+debug = false
 lto = true
 incremental = true

--- a/core/rust/crate-hashes.json
+++ b/core/rust/crate-hashes.json
@@ -1,10 +1,9 @@
 {
-  "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=e911383#opentelemetry-prometheus@0.17.0": "1hnialssdng4hq19mldkvqlgpan8zg5jzrxdcx51b8yp35zylcra",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#rustfsm@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#rustfsm_procmacro@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#rustfsm_trait@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#temporal-client@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#temporal-sdk-core-api@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#temporal-sdk-core-protos@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a",
-  "git+https://github.com/temporalio/sdk-core?rev=6e601115daa3b9ccaa9d0d383f926aaa5953ea3d#temporal-sdk-core@0.1.0": "1p0inavqz35kq6lkkkcsshw0s3dgg5dc9ca0ih8ghdryy03hyy9a"
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#rustfsm@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds",
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#rustfsm_procmacro@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds",
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#rustfsm_trait@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds",
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#temporal-client@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds",
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#temporal-sdk-core-api@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds",
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#temporal-sdk-core-protos@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds",
+  "git+https://github.com/temporalio/sdk-core?rev=8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d#temporal-sdk-core@0.1.0": "1qsrx0gh3ih2npyqmii6a9c1prl4dgqij43bfnjrypzchxhaq0ds"
 }


### PR DESCRIPTION
# Update Temporal SDK Core to latest version

This PR updates the Temporal SDK Core dependency to the latest version (8a4bd7fd73ddeedb28e1767ce4949a591a25cd2d) and adds support for several new features:

The main thing we're trying to pull in is a fix for STAB-866, but there's a lot of configuration bits that have been changed in the Core SDK, so I updated the config layers to try to account for most of what's changed that's _required_:

- Added worker versioning strategies with three options:
  - `NoVersioning`
  - `WorkerDeploymentBased`
  - `LegacyBuildIdBased`

These aren't really supported, in that I have no idea what'll happen if someone tries to use them.

- Improved poller behavior configuration with:
  - `SimpleMaximum` for basic concurrency control
  - `Autoscaling` for dynamic adjustment based on load

- Added new worker configuration options:
  - `ignoreEvictsOnShutdown`
  - `fetchingConcurrency`
  - `localTimeoutBufferForActivitiesMillis`

