### PR TITLE
convert the errors from Temporal.Operator

### DIFF
--- a/sdk/src/Temporal/Operator.hs
+++ b/sdk/src/Temporal/Operator.hs
@@ -10,6 +10,7 @@ module Temporal.Operator where
 
 import Control.Monad
 import Control.Monad.IO.Class
+import Data.Bifunctor (bimap)
 import Data.Map.Strict (Map)
 import Data.ProtoLens (Message (defMessage))
 import Data.Text (Text)
@@ -18,6 +19,7 @@ import qualified Proto.Temporal.Api.Enums.V1.Common as Proto
 import qualified Proto.Temporal.Api.Operatorservice.V1.RequestResponse_Fields as Proto
 import Temporal.Core.Client
 import qualified Temporal.Core.Client.OperatorService as Core
+import qualified Temporal.Exception
 import Temporal.SearchAttributes (SearchAttributeKey (..))
 import Temporal.SearchAttributes.Internal
 import Temporal.Workflow (Namespace (..))
@@ -67,10 +69,10 @@ searchAttributeTypeToProto = \case
   KeywordList -> Proto.INDEXED_VALUE_TYPE_KEYWORD_LIST
 
 
-listSearchAttributes :: MonadIO m => Client -> Namespace -> m (Either RpcError SearchAttributes)
+listSearchAttributes :: MonadIO m => Client -> Namespace -> m (Either Temporal.Exception.RpcError SearchAttributes)
 listSearchAttributes c (Namespace n) = do
   res <- liftIO $ Core.listSearchAttributes c (defMessage & Proto.namespace .~ n)
-  pure $ fmap convert res
+  pure $ bimap Temporal.Exception.coreRpcErrorToRpcError convert res
   where
     convert res =
       SearchAttributes
@@ -80,7 +82,7 @@ listSearchAttributes c (Namespace n) = do
         }
 
 
-addSearchAttributes :: MonadIO m => Client -> Namespace -> Map SearchAttributeKey IndexedValueType -> m (Either RpcError ())
+addSearchAttributes :: MonadIO m => Client -> Namespace -> Map SearchAttributeKey IndexedValueType -> m (Either Temporal.Exception.RpcError ())
 addSearchAttributes c (Namespace n) newAttrs = do
   if null newAttrs
     then pure $ Right ()
@@ -93,6 +95,6 @@ addSearchAttributes c (Namespace n) newAttrs = do
                 & Proto.namespace .~ n
                 & Proto.searchAttributes .~ converted
             )
-      pure $ void res
+      pure $ bimap Temporal.Exception.coreRpcErrorToRpcError (const ()) res
   where
     converted = rawKeys $ fmap searchAttributeTypeToProto newAttrs

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -258,7 +258,7 @@ setup additionalInterceptors fp go = do
   let interceptors = otelInterceptors <> additionalInterceptors
   (client, coreClient) <- makeClient fp interceptors
 
-  SearchAttributes {customAttributes} <- either (throwIO . coreRpcErrorToRpcError) pure =<< listSearchAttributes coreClient (W.Namespace "default")
+  SearchAttributes {customAttributes} <- either throwIO pure =<< listSearchAttributes coreClient (W.Namespace "default")
   let allTestAttributes =
         Map.fromList
           [ ("attr1", Temporal.Operator.Bool)


### PR DESCRIPTION
i caught that these are returning the lower-level "core" `RpcError` when trying to bump the library in our production backend.