### PR TITLE
initial support for time-skipping

### DIFF
--- a/core/src/Temporal/Core/EphemeralServer.hs
+++ b/core/src/Temporal/Core/EphemeralServer.hs
@@ -144,14 +144,14 @@ shutdownEphemeralServer (EphemeralServer e) = withForeignPtr e $ \ep -> do
 -- TODO
 -- startDevServerWithOutput
 
-data TestServerConfig = TestServerConfig
+data TemporalTestServerConfig = TemporalTestServerConfig
   { exe :: EphemeralExe
   , port :: Maybe Word16
   , extraArgs :: [String]
   }
 
 
-deriveToJSON (defaultOptions {fieldLabelModifier = camelTo2 '_'}) ''TestServerConfig
+deriveToJSON (defaultOptions {fieldLabelModifier = camelTo2 '_'}) ''TemporalTestServerConfig
 
 
 foreign import ccall "hs_temporal_start_test_server"
@@ -161,7 +161,7 @@ foreign import ccall "hs_temporal_start_test_server"
     -> TokioCall (CArray Word8) EphemeralServer
 
 
-startTestServer :: Runtime -> TestServerConfig -> IO (Either ByteString EphemeralServer)
+startTestServer :: Runtime -> TemporalTestServerConfig -> IO (Either ByteString EphemeralServer)
 startTestServer r conf = withRuntime r $ \rp -> useAsCString (BL.toStrict $ encode conf) $ \cstr -> do
   res <-
     makeTokioAsyncCall

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,12 @@
               ./nix/devenv/temporal-dev-server.nix
               (pkgs.lib.modules.importApply ./nix/devenv/haskell.nix ghcVersion)
               ./nix/devenv/repo-wide-checks.nix
-              ({pkgs, ...}: {packages = [pkgs.temporal-test-server];})
+              # FIXME [aarch64-linux-temporal-test-server]
+              ({pkgs, ...}: {
+                packages = builtins.filter (pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform) [
+                  pkgs.temporal-test-server
+                ];
+              })
             ];
           };
         shells = inputs.nixpkgs.lib.genAttrs ghcVersions (version: mkShell version);

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
               ./nix/devenv/temporal-dev-server.nix
               (pkgs.lib.modules.importApply ./nix/devenv/haskell.nix ghcVersion)
               ./nix/devenv/repo-wide-checks.nix
-              ({pkgs, ...}: {packages = [self.packages.${pkgs.system}.temporal-test-server];})
+              ({pkgs, ...}: {packages = [pkgs.temporal-test-server];})
             ];
           };
         shells = inputs.nixpkgs.lib.genAttrs ghcVersions (version: mkShell version);
@@ -38,7 +38,7 @@
         haskellUtils.localPackageMatrix
         // {
           temporal-bridge = pkgs.temporal_bridge;
-          temporal-test-server = pkgs.callPackage ./nix/packages/temporal-test-server.nix { };
+          temporal-test-server = pkgs.temporal-test-server;
         }
     );
 
@@ -52,6 +52,7 @@
 
     overlays = {
       temporal-bridge = import ./nix/overlays/temporal-bridge/overlay.nix;
+      temporal-test-server = import ./nix/overlays/temporal-test-server.nix;
       # A top-level nixpkgs overlay that extends supported GHC package sets with
       # `hs-temporal-sdk` packages & any dependency modifications required for
       # development.

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -6,8 +6,6 @@ builds:
       # and it's too much of a hassle to selectively exclude them from our
       # `forAllSystems` package definition.
       - 'packages.aarch64-linux.temporal-test-server'
-      # `x86_64-darwin` isn't a supported architecture.
-      - 'packages.x86_64-darwin.*'
       # Unable to build because devenv is impure.
       - 'devShells.*.*'
       - 'packages.*.devenv-up'

--- a/nix/overlays/haskell/hs-temporal-sdk.nix
+++ b/nix/overlays/haskell/hs-temporal-sdk.nix
@@ -4,11 +4,12 @@
   stdenv,
   darwin,
   temporal-cli,
+  temporal-test-server,
   ...
 }:
 hfinal: hprev:
 let
-  inherit (haskell.lib.compose) addTestToolDepend enableCabalFlag overrideCabal;
+  inherit (haskell.lib.compose) addTestToolDepends enableCabalFlag overrideCabal;
 in
 {
   temporal-api-protos = hfinal.callCabal2nix "temporal-api-protos" ../../../protos { };
@@ -28,7 +29,7 @@ in
   ];
 
   temporal-sdk = lib.pipe (hfinal.callCabal2nix "temporal-sdk" ../../../sdk { }) [
-    (addTestToolDepend temporal-cli)
+    (addTestToolDepends [temporal-cli temporal-test-server])
     (
       drv:
       drv.overrideAttrs (_: {

--- a/nix/overlays/haskell/hs-temporal-sdk.nix
+++ b/nix/overlays/haskell/hs-temporal-sdk.nix
@@ -29,7 +29,11 @@ in
   ];
 
   temporal-sdk = lib.pipe (hfinal.callCabal2nix "temporal-sdk" ../../../sdk { }) [
-    (addTestToolDepends [temporal-cli temporal-test-server])
+    # FIXME [aarch64-linux-temporal-test-server]
+    (addTestToolDepends (lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
+      temporal-cli
+      temporal-test-server
+    ]))
     (
       drv:
       drv.overrideAttrs (_: {

--- a/nix/overlays/temporal-test-server.nix
+++ b/nix/overlays/temporal-test-server.nix
@@ -1,0 +1,3 @@
+final: _prev: {
+  temporal-test-server = final.callPackage ../packages/temporal-test-server.nix { };
+}

--- a/nix/packages/temporal-test-server.nix
+++ b/nix/packages/temporal-test-server.nix
@@ -1,6 +1,9 @@
 {
   stdenv,
   fetchurl,
+  lib,
+  autoPatchelfHook,
+  fixDarwinDylibNames,
   ...
 }: let
   # The 'temporal-test-server' is a component of the Java SDK, with compiled
@@ -23,10 +26,20 @@ in
       hash = if stdenv.hostPlatform.isDarwin then "sha256-0EO5nmotVM8RjVPjJfN3oK9pr+9e3oo23rBm65T4Cs4=" else "sha256-cE83Dp8ZFofpiDs6d7TyshUynylOYq1rsehHpw2i9Lk=";
     };
 
+    nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+      fixDarwinDylibNames
+    ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+      autoPatchelfHook
+    ];
+
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/bin
       mv temporal-test-server $out/bin/temporal-test-server
       chmod +x $out/bin/temporal-test-server
+
+      runHook postInstall
     '';
 
     meta = {

--- a/nix/utils/flake.nix
+++ b/nix/utils/flake.nix
@@ -12,6 +12,7 @@ let
           inherit system;
           overlays = [
             self.overlays.temporal-bridge
+            self.overlays.temporal-test-server
             self.overlays.haskell-development
           ];
         };

--- a/nix/utils/matrix.nix
+++ b/nix/utils/matrix.nix
@@ -1,9 +1,9 @@
 {
   systems = [
     "x86_64-linux"
-    "x86_64-darwin"
-    "aarch64-linux"
     "aarch64-darwin"
+    # FIXME: re-enable this once we have aarch64 support for the time-skipping server.
+    # "aarch64-linux" 
   ];
 
   ghcVersions = [

--- a/nix/utils/matrix.nix
+++ b/nix/utils/matrix.nix
@@ -3,7 +3,7 @@
     "x86_64-linux"
     "aarch64-darwin"
     # FIXME: re-enable this once we have aarch64 support for the time-skipping server.
-    # "aarch64-linux" 
+    "aarch64-linux" 
   ];
 
   ghcVersions = [

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -152,5 +152,6 @@ tests:
       IntegrationSpec.TimeoutsInWorkflows,
       IntegrationSpec.Updates,
       MockActivityEnvironmentSpec,
+      IntegrationSpec.TimeSkipping,
       Common,
       THCompiles

--- a/sdk/src/Temporal/Activity.hs
+++ b/sdk/src/Temporal/Activity.hs
@@ -216,6 +216,7 @@ activityWorkflowClient = Activity $ do
       { namespace = e.activityInfo.workflowNamespace
       , interceptors = e.activityClientInterceptors
       , payloadProcessor = e.activityPayloadProcessor
+      , enableTimeSkipping = False
       }
 
 

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -297,16 +297,14 @@ waitWorkflowResult h =
       else waitWorkflowResult' h
   where
     unlockTimeSkipping clientCore = do
-      let msg :: LockTimeSkippingRequest
-          msg = defMessage
-      putStrLn "!!! unlocking time skipping !!!"
-      res <- TestService.lockTimeSkipping clientCore msg
-      either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
-    lockTimeSkipping clientCore _ = do
       let msg :: UnlockTimeSkippingRequest
           msg = defMessage
-      putStrLn "!!! locking time skipping !!!"
       res <- TestService.unlockTimeSkipping clientCore msg
+      either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
+    lockTimeSkipping clientCore _ = do
+      let msg :: LockTimeSkippingRequest
+          msg = defMessage
+      res <- TestService.lockTimeSkipping clientCore msg
       either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
 
 

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -21,7 +21,7 @@ They are used to start new workflows and to signal existing workflows.
 -}
 module Temporal.Client (
   -- * Workflow Client
-  WorkflowClient,
+  WorkflowClient (..),
   workflowClient,
   WorkflowClientConfig (..),
   mkWorkflowClientConfig,
@@ -289,18 +289,11 @@ waitWorkflowResult h =
   if h.workflowHandleClient.clientConfig.enableTimeSkipping
     then
       liftIO $
-        Control.Exception.bracket
-          unlockTimeSkipping
-          lockTimeSkipping
-          (const $ waitWorkflowResult' h)
+        Control.Exception.bracket_
+          (TestService.unlockTimeSkipping h.workflowHandleClient.clientCore)
+          (TestService.lockTimeSkipping h.workflowHandleClient.clientCore)
+          (waitWorkflowResult' h)
     else waitWorkflowResult' h
-  where
-    unlockTimeSkipping = do
-      res <- TestService.unlockTimeSkipping h.workflowHandleClient.clientCore
-      either throwIO pure res
-    lockTimeSkipping _ = do
-      res <- TestService.lockTimeSkipping h.workflowHandleClient.clientCore
-      either throwIO pure res
 
 
 waitWorkflowResult' :: (Typeable a, MonadIO m) => WorkflowHandle a -> m a

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -307,10 +307,6 @@ waitWorkflowResult h =
       either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
 
 
-{- | Given a 'WorkflowHandle', wait for the workflow to complete and return the result.
-This function will block until the workflow completes, and will return the result of the workflow
-or throw a 'WorkflowExecutionClosed' exception if the workflow was closed without returning a result.
--}
 waitWorkflowResult' :: (Typeable a, MonadIO m) => WorkflowHandle a -> m a
 waitWorkflowResult' h@(WorkflowHandle readResult _ c wf r _) = do
   mev <- runReaderT (waitResult wf r c.clientConfig.namespace) c

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -143,10 +143,10 @@ import Proto.Temporal.Api.Workflowservice.V1.RequestResponse (
  )
 import qualified Proto.Temporal.Api.Workflowservice.V1.RequestResponse_Fields as RR
 import qualified Proto.Temporal.Api.Workflowservice.V1.RequestResponse_Fields as WF
+import qualified Temporal.Client.TestService as TestService
 import Temporal.Client.Types
 import Temporal.Common
 import qualified Temporal.Core.Client as Core
-import qualified Temporal.Core.Client.TestService as TestService
 import Temporal.Core.Client.WorkflowService
 import Temporal.Duration (durationToProto)
 import Temporal.Exception
@@ -296,15 +296,11 @@ waitWorkflowResult h =
     else waitWorkflowResult' h
   where
     unlockTimeSkipping = do
-      let msg :: UnlockTimeSkippingRequest
-          msg = defMessage
-      res <- TestService.unlockTimeSkipping h.workflowHandleClient.clientCore msg
-      either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
+      res <- TestService.unlockTimeSkipping h.workflowHandleClient.clientCore
+      either throwIO pure res
     lockTimeSkipping _ = do
-      let msg :: LockTimeSkippingRequest
-          msg = defMessage
-      res <- TestService.lockTimeSkipping h.workflowHandleClient.clientCore msg
-      either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
+      res <- TestService.lockTimeSkipping h.workflowHandleClient.clientCore
+      either throwIO pure res
 
 
 waitWorkflowResult' :: (Typeable a, MonadIO m) => WorkflowHandle a -> m a

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -80,6 +80,7 @@ module Temporal.Client (
 ) where
 
 import Conduit
+import qualified Control.Exception
 import Control.Monad
 import Control.Monad.Trans.Accum
 import Control.Monad.Trans.Cont
@@ -117,27 +118,35 @@ import Proto.Temporal.Api.History.V1.Message (History, HistoryEvent, HistoryEven
 import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
 import qualified Proto.Temporal.Api.Query.V1.Message_Fields as Query
 import qualified Proto.Temporal.Api.Taskqueue.V1.Message_Fields as TQ
+import Proto.Temporal.Api.Testservice.V1.RequestResponse (
+  LockTimeSkippingRequest,
+  LockTimeSkippingResponse,
+  UnlockTimeSkippingRequest,
+  UnlockTimeSkippingResponse,
+ )
 import qualified Proto.Temporal.Api.Update.V1.Message as Update
 import qualified Proto.Temporal.Api.Update.V1.Message_Fields as Update
+import Proto.Temporal.Api.Workflow.V1.Message (WorkflowExecutionInfo)
 import Proto.Temporal.Api.Workflowservice.V1.RequestResponse (
+  CountWorkflowExecutionsRequest,
+  CountWorkflowExecutionsResponse,
   GetWorkflowExecutionHistoryRequest,
   GetWorkflowExecutionHistoryResponse,
+  ListClosedWorkflowExecutionsRequest,
+  ListOpenWorkflowExecutionsRequest,
   PollWorkflowExecutionUpdateRequest,
   QueryWorkflowRequest,
   QueryWorkflowResponse,
+  ScanWorkflowExecutionsRequest,
   UpdateWorkflowExecutionRequest,
   UpdateWorkflowExecutionResponse,
-  ListClosedWorkflowExecutionsRequest,
-  ListOpenWorkflowExecutionsRequest,
-  ScanWorkflowExecutionsRequest,
-  CountWorkflowExecutionsRequest,
-  CountWorkflowExecutionsResponse,
  )
 import qualified Proto.Temporal.Api.Workflowservice.V1.RequestResponse_Fields as RR
 import qualified Proto.Temporal.Api.Workflowservice.V1.RequestResponse_Fields as WF
 import Temporal.Client.Types
 import Temporal.Common
 import qualified Temporal.Core.Client as Core
+import qualified Temporal.Core.Client.TestService as TestService
 import Temporal.Core.Client.WorkflowService
 import Temporal.Duration (durationToProto)
 import Temporal.Exception
@@ -147,7 +156,6 @@ import Temporal.Workflow (KnownQuery (..), KnownSignal (..), QueryRef (..))
 import Temporal.Workflow.Definition
 import UnliftIO
 import Unsafe.Coerce
-import Proto.Temporal.Api.Workflow.V1.Message (WorkflowExecutionInfo)
 
 
 ---------------------------------------------------------------------------------
@@ -277,7 +285,37 @@ This function will block until the workflow completes, and will return the resul
 or throw a 'WorkflowExecutionClosed' exception if the workflow was closed without returning a result.
 -}
 waitWorkflowResult :: (Typeable a, MonadIO m) => WorkflowHandle a -> m a
-waitWorkflowResult h@(WorkflowHandle readResult _ c wf r _) = do
+waitWorkflowResult h =
+  let c = h.workflowHandleClient
+  in if h.workflowHandleClient.clientConfig.enableTimeSkipping
+      then
+        liftIO $
+          Control.Exception.bracket
+            (unlockTimeSkipping c.clientCore)
+            (lockTimeSkipping c.clientCore)
+            (const $ waitWorkflowResult' h)
+      else waitWorkflowResult' h
+  where
+    unlockTimeSkipping clientCore = do
+      let msg :: LockTimeSkippingRequest
+          msg = defMessage
+      putStrLn "!!! unlocking time skipping !!!"
+      res <- TestService.lockTimeSkipping clientCore msg
+      either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
+    lockTimeSkipping clientCore _ = do
+      let msg :: UnlockTimeSkippingRequest
+          msg = defMessage
+      putStrLn "!!! locking time skipping !!!"
+      res <- TestService.unlockTimeSkipping clientCore msg
+      either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure res
+
+
+{- | Given a 'WorkflowHandle', wait for the workflow to complete and return the result.
+This function will block until the workflow completes, and will return the result of the workflow
+or throw a 'WorkflowExecutionClosed' exception if the workflow was closed without returning a result.
+-}
+waitWorkflowResult' :: (Typeable a, MonadIO m) => WorkflowHandle a -> m a
+waitWorkflowResult' h@(WorkflowHandle readResult _ c wf r _) = do
   mev <- runReaderT (waitResult wf r c.clientConfig.namespace) c
   case mev of
     Nothing -> error "Unexpected empty history"
@@ -747,9 +785,11 @@ cease execution. The workflow will not be given a chance to react to the termina
 terminate :: (MonadIO m) => WorkflowHandle a -> TerminationOptions -> m ()
 terminate h req =
   void do
-    res <- liftIO $ terminateWorkflowExecution
-      h.workflowHandleClient.clientCore
-      msg
+    res <-
+      liftIO $
+        terminateWorkflowExecution
+          h.workflowHandleClient.clientCore
+          msg
     case res of
       Left err -> throwIO $ Temporal.Exception.coreRpcErrorToRpcError err
       Right _ -> pure ()
@@ -918,6 +958,7 @@ listOpenWorkflowExecutions baseReq = askWorkflowClient >>= \c -> go c (baseReq &
           unless (x ^. field @"nextPageToken" == "") do
             go c (req & field @"nextPageToken" .~ (x ^. field @"nextPageToken"))
 
+
 listClosedWorkflowExecutions :: (MonadIO m, HasWorkflowClient m) => ListClosedWorkflowExecutionsRequest -> ConduitT i WorkflowExecutionInfo m ()
 listClosedWorkflowExecutions baseReq = askWorkflowClient >>= \c -> go c (baseReq & field @"namespace" .~ rawNamespace c.clientConfig.namespace)
   where
@@ -929,6 +970,7 @@ listClosedWorkflowExecutions baseReq = askWorkflowClient >>= \c -> go c (baseReq
           yieldMany (x ^. field @"vec'executions")
           unless (x ^. field @"nextPageToken" == "") do
             go c (req & field @"nextPageToken" .~ (x ^. field @"nextPageToken"))
+
 
 -- TODO, replace with newer listWorkflowExecutions API, this is deprecated in the proto
 scanWorkflowExecutions
@@ -946,15 +988,18 @@ scanWorkflowExecutions baseReq = askWorkflowClient >>= \c -> go c (baseReq & fie
           unless (x ^. field @"nextPageToken" == "") do
             go c (req & field @"nextPageToken" .~ (x ^. field @"nextPageToken"))
 
+
 countWorkflowExecutions
   :: (MonadIO m, HasWorkflowClient m)
   => CountWorkflowExecutionsRequest
   -> m CountWorkflowExecutionsResponse
-countWorkflowExecutions baseReq = askWorkflowClient >>= \c -> liftIO do
-  res <- Temporal.Core.Client.WorkflowService.countWorkflowExecutions c.clientCore baseReq
-  case res of
-    Left err -> throwIO $ Temporal.Exception.coreRpcErrorToRpcError err
-    Right x -> pure x
+countWorkflowExecutions baseReq =
+  askWorkflowClient >>= \c -> liftIO do
+    res <- Temporal.Core.Client.WorkflowService.countWorkflowExecutions c.clientCore baseReq
+    case res of
+      Left err -> throwIO $ Temporal.Exception.coreRpcErrorToRpcError err
+      Right x -> pure x
+
 
 data UpdateLifecycleStage
   = UpdateLifecycleStageUnspecified

--- a/sdk/src/Temporal/Client/TestService.hs
+++ b/sdk/src/Temporal/Client/TestService.hs
@@ -1,0 +1,97 @@
+module Temporal.Client.TestService (
+  getCurrentTime,
+  unlockTimeSkipping,
+  lockTimeSkipping,
+  sleepUntil,
+  sleep,
+  unlockTimeSkippingWithSleep,
+) where
+
+import Data.Bifunctor (bimap)
+import Data.Int (Int32 (..), Int64 (..))
+import Data.ProtoLens.Message
+import Data.Time.Clock (UTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
+import Lens.Family2
+import qualified Proto.Google.Protobuf.Timestamp as TS
+import qualified Proto.Google.Protobuf.Timestamp_Fields as TS (nanos, seconds)
+import Proto.Temporal.Api.Testservice.V1.RequestResponse (
+  GetCurrentTimeResponse,
+  LockTimeSkippingRequest,
+  SleepRequest,
+  SleepUntilRequest,
+  UnlockTimeSkippingRequest,
+ )
+import qualified Proto.Temporal.Api.Testservice.V1.RequestResponse_Fields as Fields
+import Temporal.Core.Client (Client)
+import qualified Temporal.Core.Client.TestService
+import Temporal.Duration (Duration (..), durationToProto)
+import qualified Temporal.Exception
+
+
+getCurrentTime :: Client -> IO (Either Temporal.Exception.RpcError UTCTime)
+getCurrentTime client = do
+  res <- Temporal.Core.Client.TestService.getCurrentTime client
+  case res of
+    Left err -> pure $ Left $ Temporal.Exception.coreRpcErrorToRpcError err
+    Right val ->
+      let time = val ^. Fields.time
+      in pure $ Right $ convertTimestampToUTCTime time
+
+
+unlockTimeSkipping :: Client -> IO (Either Temporal.Exception.RpcError ())
+unlockTimeSkipping client = do
+  let msg :: UnlockTimeSkippingRequest
+      msg = defMessage
+  res <- Temporal.Core.Client.TestService.unlockTimeSkipping client msg
+  pure $ bimap Temporal.Exception.coreRpcErrorToRpcError (const ()) res
+
+
+lockTimeSkipping :: Client -> IO (Either Temporal.Exception.RpcError ())
+lockTimeSkipping client = do
+  let msg :: LockTimeSkippingRequest
+      msg = defMessage
+  res <- Temporal.Core.Client.TestService.lockTimeSkipping client msg
+  pure $ bimap Temporal.Exception.coreRpcErrorToRpcError (const ()) res
+
+
+sleepUntil :: Client -> UTCTime -> IO (Either Temporal.Exception.RpcError ())
+sleepUntil client time = do
+  let msg :: SleepUntilRequest
+      msg = defMessage & Fields.timestamp .~ convertUTCTimeToTimestamp time
+  res <- Temporal.Core.Client.TestService.sleepUntil client msg
+  pure $ bimap Temporal.Exception.coreRpcErrorToRpcError (const ()) res
+
+
+sleep :: Client -> Duration -> IO (Either Temporal.Exception.RpcError ())
+sleep client duration = do
+  let msg :: SleepRequest
+      msg = defMessage & Fields.duration .~ durationToProto duration
+  res <- Temporal.Core.Client.TestService.sleep client msg
+  pure $ bimap Temporal.Exception.coreRpcErrorToRpcError (const ()) res
+
+
+unlockTimeSkippingWithSleep :: Client -> Duration -> IO (Either Temporal.Exception.RpcError ())
+unlockTimeSkippingWithSleep client duration = do
+  let msg :: SleepRequest
+      msg = defMessage & Fields.duration .~ durationToProto duration
+  res <- Temporal.Core.Client.TestService.unlockTimeSkippingWithSleep client msg
+  pure $ bimap Temporal.Exception.coreRpcErrorToRpcError (const ()) res
+
+
+convertTimestampToUTCTime :: TS.Timestamp -> UTCTime
+convertTimestampToUTCTime ts =
+  let seconds = fromIntegral (ts ^. TS.seconds) :: Integer
+      nanos = fromIntegral (ts ^. TS.nanos) :: Integer
+      posixTime = fromRational $ toRational seconds + toRational nanos / 1_000_000_000
+  in posixSecondsToUTCTime posixTime
+
+
+convertUTCTimeToTimestamp :: UTCTime -> TS.Timestamp
+convertUTCTimeToTimestamp time =
+  let posix = toRational (utcTimeToPOSIXSeconds time)
+      seconds = floor posix :: Int64
+      nanos = floor ((posix - toRational seconds) * 1_000_000_000) :: Int32
+  in defMessage
+      & TS.seconds .~ seconds
+      & TS.nanos .~ nanos

--- a/sdk/src/Temporal/Client/Types.hs
+++ b/sdk/src/Temporal/Client/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Temporal.Client.Types where
 
@@ -117,6 +118,8 @@ data WorkflowClientConfig = WorkflowClientConfig
   -- ^ The payload processor to be used by the client.
   --
   -- This can be used to apply encryption and compression to payloads.
+  , enableTimeSkipping :: !Bool
+  -- ^ Whether to enable "time-skipping" for testing.
   }
 
 
@@ -129,7 +132,14 @@ mkWorkflowClientConfig ns =
     { namespace = ns
     , interceptors = mempty
     , payloadProcessor = PayloadProcessor pure (pure . Right)
+    , enableTimeSkipping = False
     }
+
+
+mkTimeSkippingWorkflowClientConfig :: Namespace -> WorkflowClientConfig
+mkTimeSkippingWorkflowClientConfig ns =
+  let c = mkWorkflowClientConfig ns
+  in c {enableTimeSkipping = True}
 
 
 data WorkflowClient = WorkflowClient

--- a/sdk/src/Temporal/EphemeralServer.hs
+++ b/sdk/src/Temporal/EphemeralServer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 {- |
 Module: Temporal.EphemeralServer
 Description: Run an Temporal server in a programatically for testing and development.
@@ -18,6 +20,7 @@ module Temporal.EphemeralServer (
   EphemeralExe (..),
   SDKDefault (..),
   TemporalDevServerConfig (..),
+  TemporalTestServerConfig (..),
   defaultTemporalDevServerConfig,
   EphemeralServer,
   shutdownEphemeralServer,
@@ -48,7 +51,7 @@ withDevServer rt conf =
     (\e -> liftIO (shutdownEphemeralServer e) >>= either (throwIO . EphemeralServerError) pure)
 
 
-withTestServer :: MonadUnliftIO m => Runtime -> TestServerConfig -> (EphemeralServer -> m a) -> m a
+withTestServer :: MonadUnliftIO m => Runtime -> TemporalTestServerConfig -> (EphemeralServer -> m a) -> m a
 withTestServer rt conf =
   bracket
     (liftIO (startTestServer rt conf) >>= either (throwIO . EphemeralServerError) pure)
@@ -97,7 +100,7 @@ launchTestServer rt extraArgs = do
   bimap EphemeralServerError (\srv -> (freePort, srv)) <$> startTestServer rt (hackyConfig freePort)
   where
     hackyConfig port =
-      TestServerConfig
+      TemporalTestServerConfig
         { exe = CachedDownload (Default $ SDKDefault "community-haskell" "0.1.0.0") Nothing Nothing
         , port = Just $ fromIntegral port
         , extraArgs

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -23,6 +23,7 @@ library
       Temporal.Client
       Temporal.Client.Namespace
       Temporal.Client.Schedule
+      Temporal.Client.TestService
       Temporal.Contrib.OpenTelemetry
       Temporal.Duration
       Temporal.EphemeralServer
@@ -148,7 +149,7 @@ test-suite temporal-sdk-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      Spec, ConcurrentAccessSpec, AsyncCompletionSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, MockActivityEnvironmentSpec, Common, THCompiles
+      Spec, ConcurrentAccessSpec, AsyncCompletionSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, THCompiles
   hs-source-dirs:
       test
   default-extensions:

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -1868,7 +1868,7 @@ needsClient = do
 
 needsTimeSkipping :: SpecWith TestEnv
 needsTimeSkipping = do
-  fdescribe "Workflow" $ do
+  describe "Workflow" $ do
     it "should run a workflow" $ \TestEnv {..} -> do
       let conf = configure () testConf $ do
             baseConf

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -423,11 +424,29 @@ spec = do
     aroundAllWith (flip $ setup mempty) terminateTests
     updatesWithInterceptors
 
+-- FIXME [aarch64-linux-temporal-test-server]
+--
+-- Temporal's time-skipping test server is a sub-component of their Java SDK,
+-- compiled to native code with GraalVM and (at the time of writing) only
+-- distributed for x86_64 platforms.
+--
+-- Upstream has recently added support for building this executable on ARM64
+-- platforms, but there is currently no ETA for a new release. macOS users can
+-- invoke the x86_64 test server via Rosetta2, so in the meantime we'll treat
+-- Linux ARM64 systems as only partially supported.
+--
+-- The rest of the SDK will still be tested, and should continue working as-
+-- expected on Linux ARM64, but invoking 'withTestServer' with
+-- 'enableTimeSkipping = True' will fail to find the appropriate executable
+-- (unless you have manually configured your shell to provide a copy of the
+-- x86_64 test server binary wrapped in some form of userspace emulation).
+#if !(defined(linux_HOST_OS) && defined(aarch64_HOST_ARCH))
   -- Whether time-skipping is enabled is global state in the test server (it's not tracked
   -- per workflow or anything) so we need to use around (rather than aroundAll) to get a
   -- distinct server for each test
   around withTimeSkippingServer $ do
     aroundWith (flip $ setupTimeSkipping mempty) needsTimeSkipping
+#endif
 
 
 type MyWorkflow a = W.RequireCallStack => W.Workflow a

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -313,7 +313,6 @@ setupTimeSkipping additionalInterceptors fp go = do
   otelInterceptors <- makeOpenTelemetryInterceptor
   let interceptors = otelInterceptors <> additionalInterceptors
   (client, _) <- makeTimeSkippingClient fp interceptors
-
   (conf, taskQueue) <- mkBaseConf interceptors
   go
     TestEnv
@@ -423,6 +422,9 @@ spec = do
     aroundAllWith (flip $ setup mempty) terminateTests
     updatesWithInterceptors
 
+  -- Whether time-skipping is enabled is global state in the test server (it's not tracked
+  -- per workflow or anything) so we need to use around (rather than aroundAll) to get a
+  -- distinct server for each test
   around withTimeSkippingServer $ do
     aroundWith (flip $ setupTimeSkipping mempty) needsTimeSkipping
 

--- a/sdk/test/IntegrationSpec/TimeSkipping.hs
+++ b/sdk/test/IntegrationSpec/TimeSkipping.hs
@@ -18,16 +18,13 @@ import Temporal.Duration
 import Temporal.Payload
 import Temporal.TH
 import Temporal.Workflow
-import Temporal.Workflow.Unsafe
 
 
 variableSleepWorkflow :: Int -> Workflow Int
 variableSleepWorkflow n = provideCallStack do
   a <- now
-  performUnsafeNonDeterministicIO $ putStrLn $ "!!! Starting sleep at " ++ show a
   sleep $ seconds $ fromIntegral n
   b <- now
-  performUnsafeNonDeterministicIO $ putStrLn $ "!!! Starting sleep at " ++ show b
   pure n
 
 

--- a/sdk/test/IntegrationSpec/TimeSkipping.hs
+++ b/sdk/test/IntegrationSpec/TimeSkipping.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
+
+module IntegrationSpec.TimeSkipping where
+
+import Control.Exception
+import Control.Monad
+import Control.Monad.Logger
+import qualified Data.Text as T
+import RequireCallStack (provideCallStack)
+import Temporal.Duration
+import Temporal.Payload
+import Temporal.TH
+import Temporal.Workflow
+import Temporal.Workflow.Unsafe
+
+
+variableSleepWorkflow :: Int -> Workflow Int
+variableSleepWorkflow n = provideCallStack do
+  a <- now
+  performUnsafeNonDeterministicIO $ putStrLn $ "!!! Starting sleep at " ++ show a
+  sleep $ seconds $ fromIntegral n
+  b <- now
+  performUnsafeNonDeterministicIO $ putStrLn $ "!!! Starting sleep at " ++ show b
+  pure n
+
+
+registerWorkflow 'variableSleepWorkflow

--- a/sdk/test/IntegrationSpec/TimeSkipping.hs
+++ b/sdk/test/IntegrationSpec/TimeSkipping.hs
@@ -22,10 +22,17 @@ import Temporal.Workflow
 
 variableSleepWorkflow :: Int -> Workflow Int
 variableSleepWorkflow n = provideCallStack do
-  a <- now
   sleep $ seconds $ fromIntegral n
-  b <- now
   pure n
 
 
 registerWorkflow 'variableSleepWorkflow
+
+
+variableSleepFromChildWorkflow :: Int -> Workflow Int
+variableSleepFromChildWorkflow n = provideCallStack do
+  void $ executeChildWorkflow VariableSleepWorkflow defaultChildWorkflowOptions n
+  pure n
+
+
+registerWorkflow 'variableSleepFromChildWorkflow


### PR DESCRIPTION
# Context

Add initial support for time-skipping in tests, including both automatic and manual time-skipping.

This _only_ works if you're using the `temporal-test-server` that temporal ships with their Java SDK. Thanks to @jkachmar, we're installing this in the nix shell automatically, with the caveat that we can't currently support `aarch64-linux`. All we need to unblock us there is for Temporal to publish a new release of the Java SDK, which Joe has asked them to do. But, we're mostly in their hands regarding timing. If you try to time-skip against a different server, you'll get a `TimeSkippingNotSupported` exception.

# Usage

## Automatic time skipping

In our integration tests here, we have helpers to wire this up automatically, and in particular it's done transparently for anything in the `needsTimeSkipping` spec.

The way this works to use it outside our integration tests is:
- You start the test server on some known port, like `temporal-test-server 7234`
- Make a workflow client pointed at the right port, with time-skipping enabled (example below)
- And that's it - when a caller waits for a result (including via `execute`), we automatically enable time-skipping, fly through any timers etc to get the result immediately, and then re-disable time skipping

An example of constructing a time-skipping client:
```haskell
-- Make sure we're talking to the special test server we started
let coreClientConfig = defaultClientConfig { targetUrl = "http://localhost:7234" }
coreClient <- runStdoutLoggingT $ connectClient runtime coreClientConfig
-- Enable time-skipping in the workflow client
client <- workflowClient coreClient (mkTimeSkippingWorkflowClientConfig  namespace)
```

## Manual time skipping

You can also use functions like `TestService.unlockTimeSkippingWithSleep` to manually jump over an explicitly specified amount of time. You still need to use `temporal-test-server` for this, but do not need to construct the client with `enableTimeSkipping = True`.