### PR TITLE
Support base64-1.0

### DIFF
--- a/nix/overlays/haskell/deps.nix
+++ b/nix/overlays/haskell/deps.nix
@@ -6,6 +6,7 @@ in
 {
   if-instance = markUnbroken hprev.if-instance;
 } // (packageSourceOverrides {
+  base64 = "1.0";
   hs-opentelemetry-api = "0.1.0.0";
   hs-opentelemetry-exporter-in-memory = "0.0.1.3";
   hs-opentelemetry-exporter-otlp = "0.0.1.5";


### PR DESCRIPTION
This adds support for `base64`-1.0, which changes the type signatures of `encodeBase64` and `decodeBase64`.

Closes https://github.com/MercuryTechnologies/hs-temporal-sdk/issues/127