### PR TITLE
bring back logging changes

### DIFF
--- a/core/package.yaml
+++ b/core/package.yaml
@@ -48,6 +48,7 @@ library:
     - aeson
     - async
     - lens-family
+    - monad-logger
     - network-bsd
     - proto-lens
     - unliftio
@@ -57,4 +58,3 @@ library:
   when:
     - condition: os(darwin)
       frameworks: [Security, CoreFoundation, SystemConfiguration]
-

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -211,7 +211,7 @@ pub fn connect_client(
                     runtime,
                 }),
                 Err(e) => {
-                    eprintln!("Error: {:?}", e);
+                    eprintln!("Error connecting to Temporal server: {:?}", e);
                     let err_message = e.to_string().into_bytes();
                     Err(CArray::c_repr_of(err_message).unwrap())
                 }

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -211,7 +211,6 @@ pub fn connect_client(
                     runtime,
                 }),
                 Err(e) => {
-                    eprintln!("Error connecting to Temporal server: {:?}", e);
                     let err_message = e.to_string().into_bytes();
                     Err(CArray::c_repr_of(err_message).unwrap())
                 }

--- a/core/src/Temporal/Core/Client.hs
+++ b/core/src/Temporal/Core/Client.hs
@@ -258,13 +258,14 @@ connectClient rt conf = do
             case result of
               Left errFP -> do
                 err <- withForeignPtr errFP $ peek >=> cArrayToText
+                let err' = "Error connecting to Temporal server: " <> err
                 case retryConfig conf of
-                  Nothing -> putMVar clientPtrSlot (throw $ ClientConnectionError err)
+                  Nothing -> putMVar clientPtrSlot (throw $ ClientConnectionError err')
                   Just retryConf -> do
                     let delayMillis = fromIntegral (initialIntervalMillis retryConf) * multiplier retryConf ^ attempt
                         delayMicros = delayMillis * 1000
                     if (fmap fromIntegral (maxElapsedTimeMillis retryConf) < Just delayMillis) || (maxRetries retryConf <= attempt)
-                      then putMVar clientPtrSlot (throw $ ClientConnectionError err)
+                      then putMVar clientPtrSlot (throw $ ClientConnectionError err')
                       else do
                         threadDelay $ round delayMicros
                         go (attempt + 1)

--- a/core/src/Temporal/Core/Client.hs
+++ b/core/src/Temporal/Core/Client.hs
@@ -49,6 +49,7 @@ module Temporal.Core.Client (
 import Control.Concurrent
 import Control.Exception
 import Control.Monad
+import Control.Monad.Logger
 import Data.Aeson
 import Data.Aeson.TH
 import Data.ByteString (ByteString)
@@ -259,6 +260,7 @@ connectClient rt conf = do
               Left errFP -> do
                 err <- withForeignPtr errFP $ peek >=> cArrayToText
                 let err' = "Error connecting to Temporal server: " <> err
+                runStdoutLoggingT $ $(logWarn) err'
                 case retryConfig conf of
                   Nothing -> putMVar clientPtrSlot (throw $ ClientConnectionError err')
                   Just retryConf -> do

--- a/core/temporal-sdk-core.cabal
+++ b/core/temporal-sdk-core.cabal
@@ -88,6 +88,7 @@ library
     , bytestring
     , containers
     , lens-family
+    , monad-logger
     , mtl
     , network-bsd
     , proto-lens

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -171,7 +171,7 @@ configWithRetry pn =
 mkWithWorker :: PortNumber -> WorkerConfig actEnv -> IO a -> IO a
 mkWithWorker pn conf m = do
   let clientConfig_ = configWithRetry pn
-  c <- connectClient globalRuntime clientConfig_
+  c <- runStdoutLoggingT $ connectClient globalRuntime clientConfig_
   bracket (startWorker c (conf {payloadProcessor = sillyEncryptionPayloadProcessor})) shutdown (const m)
 
 
@@ -188,7 +188,7 @@ sillyEncryptionPayloadProcessor = PayloadProcessor incr decr
 makeClient :: PortNumber -> Interceptors env -> IO (C.WorkflowClient, Client)
 makeClient pn Interceptors {..} = do
   let conf = configWithRetry pn
-  c <- connectClient globalRuntime conf
+  c <- runStdoutLoggingT $ connectClient globalRuntime conf
   (,)
     <$> C.workflowClient
       c


### PR DESCRIPTION
we reverted this because we found that the commit that integrated it caused spurious test failures. in the meantime, we've determined those failures weren't related to this change (or temporal at all) and we can safely bring it back.