### PR TITLE
feat(sdk): add 'MockActivityEnvironment'

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -151,5 +151,6 @@ tests:
       IntegrationSpec.NoOpWorkflow,
       IntegrationSpec.TimeoutsInWorkflows,
       IntegrationSpec.Updates,
+      MockActivityEnvironmentSpec,
       Common,
       THCompiles

--- a/sdk/src/Temporal/Activity.hs
+++ b/sdk/src/Temporal/Activity.hs
@@ -137,7 +137,7 @@ Heartbeats can contain payloads describing the Activity's current progress. If a
 rawHeartbeat :: V.Vector Payload -> Activity env ()
 rawHeartbeat baseDetails = do
   (TaskToken token) <- taskToken <$> askActivityInfo
-  worker <- askActivityWorker
+  recordHeartbeat <- askActivityRecordHeartbeat
   info <- askActivityInfo
   let details =
         defMessage
@@ -146,7 +146,7 @@ rawHeartbeat baseDetails = do
   -- TODO throw exception if this fails?
   void $ liftIO do
     writeIORef info.rawHeartbeatDetails baseDetails
-    recordActivityHeartbeat worker details
+    recordHeartbeat details
 
 
 getRawHeartbeat :: Activity env (V.Vector Payload)
@@ -211,7 +211,7 @@ provides a 'WorkflowClient' that can be used to accomplish that.
 activityWorkflowClient :: Activity env WorkflowClient
 activityWorkflowClient = Activity $ do
   e <- ask
-  workflowClient (getWorkerClient e.activityWorker) $
+  workflowClient e.activityWorkerClient $
     WorkflowClientConfig
       { namespace = e.activityInfo.workflowNamespace
       , interceptors = e.activityClientInterceptors

--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -162,7 +162,14 @@ applyActivityTaskStart tsk tt msg = do
     args <- processorDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.vec'input))
     env <- readIORef w.activityEnv
     let
-      actEnv = ActivityEnv w.workerCore info w.clientInterceptors w.payloadProcessor
+      actEnv =
+        ActivityEnv
+          info
+          w.clientInterceptors
+          w.payloadProcessor
+          (Core.recordActivityHeartbeat w.workerCore)
+          (Core.getWorkerConfig w.workerCore)
+          (Core.getWorkerClient w.workerCore)
       input =
         ExecuteActivityInput
           args

--- a/sdk/src/Temporal/Testing/MockActivityEnvironment.hs
+++ b/sdk/src/Temporal/Testing/MockActivityEnvironment.hs
@@ -1,0 +1,125 @@
+module Temporal.Testing.MockActivityEnvironment (
+  MockActivityEnvironment (..),
+  runMockActivity,
+  mkMockActivityEnvironment,
+) where
+
+import Control.Exception (Exception (..), throw)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.IORef (newIORef)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock (UTCTime (..))
+import Data.Time.Clock.System (systemEpochDay, utcToSystemTime)
+import Temporal.Activity.Definition (Activity, ActivityEnv (..), runActivity)
+import Temporal.Activity.Types (ActivityInfo (..))
+import qualified Temporal.Core.Worker as Worker
+import qualified Temporal.Duration as Duration
+import Temporal.Payload (JSON (..), PayloadProcessor, mkPayloadProcessor)
+
+
+{- | Environment for testing a Temporal 'Activity'.
+
+This environment is used with 'runMockActivity' to execute activity code in
+in 'IO', without any associated Temporal runtime.
+
+__NOTE__: This type provides stubs for all 'Activity' functionality /except/
+for Temporal Worker Client calls; in the presence of these, the mocked
+environment will throw an impure exception.
+
+We may stub out this interface a little more in the future, but the client's
+API surface area is pretty large.
+-}
+data MockActivityEnvironment env = MockActivityEnvironment
+  { info :: {-# UNPACK #-} !ActivityInfo
+  , payloadProcessor :: {-# UNPACK #-} !PayloadProcessor
+  , recordHeartbeat :: Worker.ActivityHeartbeat -> IO (Either Worker.WorkerError ())
+  , workerConfig :: {-# UNPACK #-} !Worker.WorkerConfig
+  , env :: env
+  }
+
+
+{- | Run a Temporal 'Activity' in a mocked environment — without access to a
+Temporal runtime — and return its result in 'IO'.
+
+See 'MockActivityEnvironment' and 'mkMockActivityEnvironment' for additional
+usage details.
+
+__NOTE__: Any 'Activity' that makes Temporal Worker Client calls will throw
+an impure exception.
+-}
+runMockActivity :: MonadIO m => MockActivityEnvironment env -> Activity env a -> m a
+runMockActivity env activity = do
+  let
+    -- NOTE: 'IllegalWorkerClientException' is thrown lazily, and will only be
+    -- surfaced to the end-user if a call is made to 'askActivityClient'.
+    actEnv =
+      ActivityEnv
+        env.info
+        mempty
+        env.payloadProcessor
+        env.recordHeartbeat
+        env.workerConfig
+        (throw IllegalWorkerClientException)
+        env.env
+  liftIO $ runActivity actEnv activity
+
+
+{- | Create a 'MockActivityEnvironment' with reasonable defaults for testing:
+    * scheduled and started times set to the Unix Epoch
+    * all durations set to 1 second
+    * empty 'headerFields'
+    * no retry policy
+    * 'JSON' payload processor
+    * no-op 'recordHeartbeat' function
+    * default worker config
+
+These fields can be customized as-needed for testing purposes, this function
+is just meant to provide a starting point that (should) run most activities.
+-}
+mkMockActivityEnvironment :: MonadIO m => env -> m (MockActivityEnvironment env)
+mkMockActivityEnvironment env = do
+  rawHeartbeatDetails <- liftIO $ newIORef mempty
+  let info =
+        ActivityInfo
+          { activityId = "test"
+          , activityType = "unknown"
+          , attempt = 0
+          , currentAttemptScheduledTime = utcToSystemTime $ UTCTime systemEpochDay 0
+          , headerFields = Map.empty
+          , heartbeatTimeout = Nothing
+          , isLocal = False
+          , rawHeartbeatDetails
+          , retryPolicy = Nothing
+          , runId = "test-run"
+          , scheduleToCloseTimeout = Just $ Duration.seconds 1
+          , scheduledTime = utcToSystemTime $ UTCTime systemEpochDay 0
+          , startToCloseTimeout = Just $ Duration.seconds 1
+          , startedTime = utcToSystemTime $ UTCTime systemEpochDay 0
+          , taskToken = "test"
+          , workflowId = "test"
+          , workflowNamespace = "default"
+          , workflowType = "test"
+          }
+      payloadProcessor = mkPayloadProcessor JSON
+      recordHeartbeat _ = pure (Right ())
+      workerConfig = Worker.defaultWorkerConfig
+  pure
+    MockActivityEnvironment
+      { info
+      , payloadProcessor
+      , recordHeartbeat
+      , workerConfig
+      , env
+      }
+
+
+{- | Structured exception type indicating that the 'Activity' under test
+attempted to access a Temporal Worker, which we cannot support within
+'MockActivityEnvironment'.
+-}
+data IllegalWorkerClientException = IllegalWorkerClientException
+  deriving stock (Show)
+
+
+instance Exception IllegalWorkerClientException where
+  displayException e = show e <> ": Temporal Worker Client calls are not supported within 'MockActivityEnvironment'"

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -32,6 +32,7 @@ library
       Temporal.Payload
       Temporal.Replay
       Temporal.SearchAttributes
+      Temporal.Testing.MockActivityEnvironment
       Temporal.TH
       Temporal.Worker
       Temporal.Workflow
@@ -147,7 +148,7 @@ test-suite temporal-sdk-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      Spec, ConcurrentAccessSpec, AsyncCompletionSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, Common, THCompiles
+      Spec, ConcurrentAccessSpec, AsyncCompletionSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, MockActivityEnvironmentSpec, Common, THCompiles
   hs-source-dirs:
       test
   default-extensions:

--- a/sdk/test/MockActivityEnvironmentSpec.hs
+++ b/sdk/test/MockActivityEnvironmentSpec.hs
@@ -1,0 +1,49 @@
+module MockActivityEnvironmentSpec where
+
+import Control.Monad.Reader (ask)
+import Data.Text (Text)
+import Temporal.Activity (Activity, ActivityInfo (..), askActivityInfo, withHeartbeat)
+import Temporal.Payload (JSON (..))
+import Temporal.Testing.MockActivityEnvironment (MockActivityEnvironment (..), mkMockActivityEnvironment, runMockActivity)
+import Test.Hspec
+
+
+spec :: Spec
+spec = do
+  describe "MockActivityEnvironment" do
+    it "runs a simple activity" do
+      let act :: Int -> Activity () Int
+          act i = pure $ i + 1
+          n = 0
+      mock <- mkMockActivityEnvironment ()
+      result <- runMockActivity mock (act n)
+      result `shouldBe` (n + 1)
+
+    -- we don't check all the fields here, just a few that should be
+    -- initialized to reasonable defaults for testing
+    it "can retrieve mocked activity info" do
+      mock <- mkMockActivityEnvironment ()
+      actInfo <- runMockActivity mock askActivityInfo
+      actInfo.activityId `shouldBe` "test"
+      actInfo.attempt `shouldBe` 0
+      actInfo.workflowNamespace `shouldBe` "default"
+
+    it "runs an activity with a custom environment" do
+      let act :: Activity Int Int
+          act = ask
+          expected = 1
+      mock <- mkMockActivityEnvironment expected
+      result <- runMockActivity mock act
+      result `shouldBe` expected
+
+    it "runs an activity with heartbeating" do
+      let msg = "tear up the planks! here, here! it is the beating of this hideous heart!"
+          act :: Activity () Text
+          act = withHeartbeat JSON \beat readHeartbeat ->
+            readHeartbeat >>= \case
+              Nothing -> beat msg *> act
+              Just m -> pure m
+
+      mock <- mkMockActivityEnvironment ()
+      result <- runMockActivity mock act
+      result `shouldBe` msg


### PR DESCRIPTION
## description

* reduce coupling between the underlying Temporal runtime & the
  'ActivityEnv' type definition
  * we don't need a handle to the worker or runtime proper; all we
    really need is the client, a handle to some function that can make
    heartbeat calls, and the worker config
  * stubbing some of this out means that we can actually mock heartbeats
    and present a more self-contained interface for testing Activities
* implement 'MockActivityEnvironment' and helper functions to define
  a reasonable default mock environment for testing
* add a few tests to validate & demonstrate some basic functionality