### PR TITLE
feat: aarch64 time-skipping server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,11 +23,8 @@
               ./nix/devenv/temporal-dev-server.nix
               (pkgs.lib.modules.importApply ./nix/devenv/haskell.nix ghcVersion)
               ./nix/devenv/repo-wide-checks.nix
-              # FIXME [aarch64-linux-temporal-test-server]
               ({pkgs, ...}: {
-                packages = builtins.filter (pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform) [
-                  pkgs.temporal-test-server
-                ];
+                packages = [ pkgs.temporal-test-server ];
               })
             ];
           };

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -2,10 +2,6 @@ builds:
   - include:
       - 'packages.*.*'
     exclude:
-      # Temporal doesn't distribute test server binaries for `aarch64-linux`,
-      # and it's too much of a hassle to selectively exclude them from our
-      # `forAllSystems` package definition.
-      - 'packages.aarch64-linux.temporal-test-server'
       # Unable to build because devenv is impure.
       - 'devShells.*.*'
       - 'packages.*.devenv-up'

--- a/nix/overlays/haskell/hs-temporal-sdk.nix
+++ b/nix/overlays/haskell/hs-temporal-sdk.nix
@@ -29,11 +29,10 @@ in
   ];
 
   temporal-sdk = lib.pipe (hfinal.callCabal2nix "temporal-sdk" ../../../sdk { }) [
-    # FIXME [aarch64-linux-temporal-test-server]
-    (addTestToolDepends (lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
+    (addTestToolDepends [
       temporal-cli
       temporal-test-server
-    ]))
+    ])
     (
       drv:
       drv.overrideAttrs (_: {

--- a/nix/overlays/temporal-test-server.nix
+++ b/nix/overlays/temporal-test-server.nix
@@ -1,3 +1,3 @@
 final: _prev: {
-  temporal-test-server = final.callPackage ../packages/temporal-test-server.nix { };
+  temporal-test-server = final.callPackage ../packages/temporal-test-server { };
 }

--- a/nix/packages/temporal-test-server/default.nix
+++ b/nix/packages/temporal-test-server/default.nix
@@ -8,22 +8,13 @@
 }: let
   # The 'temporal-test-server' is a component of the Java SDK, with compiled
   # artifacts distributed on each tagged release.
-  #
-  # Unfortunately they only publish x86_64 artifacts at the moment, which means
-  # 'aarch64-linux' is unsupported & 'aarch64-darwin' depends on Rosetta2 on
-  # the host machine.
-  osMap = {
-    "aarch64-darwin" = "macOS";
-    "x86_64-darwin" = "macOS";
-    "x86_64-linux" = "linux";
-  };
+  hashes = import ./hashes.nix;
 in
   stdenv.mkDerivation (finalAttrs: {
     pname = "temporal-test-server";
-    version = "1.29.0";
+    version = "1.30.1";
     src = fetchurl {
-      url = "https://github.com/temporalio/sdk-java/releases/download/v${finalAttrs.version}/temporal-test-server_${finalAttrs.version}_${builtins.getAttr stdenv.hostPlatform.system osMap}_amd64.tar.gz";
-      hash = if stdenv.hostPlatform.isDarwin then "sha256-0EO5nmotVM8RjVPjJfN3oK9pr+9e3oo23rBm65T4Cs4=" else "sha256-cE83Dp8ZFofpiDs6d7TyshUynylOYq1rsehHpw2i9Lk=";
+      inherit (hashes.${finalAttrs.version}.${stdenv.hostPlatform.system}) url hash;
     };
 
     nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
@@ -45,6 +36,6 @@ in
     meta = {
       description = "Temporal Test Workflow Server";
       homepage = "https://github.com/temporalio/sdk-java/tree/master/temporal-test-server";
-      platforms = builtins.attrNames osMap;
+      platforms = builtins.attrNames hashes.${finalAttrs.version};
     };
   })

--- a/nix/packages/temporal-test-server/hashes.nix
+++ b/nix/packages/temporal-test-server/hashes.nix
@@ -1,0 +1,20 @@
+{
+  "1.30.1" = {
+    "aarch64-darwin" = {
+      hash = "sha256-biihHvakSLwHQILAB6pLPTUVDq2rWvXorG/9C5NokIM=";
+      url = "https://github.com/temporalio/sdk-java/releases/download/v1.30.1/temporal-test-server_1.30.1_macOS_arm64.tar.gz";
+    };
+    "x86_64-darwin" = {
+      hash = "sha256-8dpryQanadAMHsMSfhfu9iTuz4ltL3bYdWicbNNGHps=";
+      url = "https://github.com/temporalio/sdk-java/releases/download/v1.30.1/temporal-test-server_1.30.1_macOS_amd64.tar.gz";
+    };
+    "aarch64-linux" = {
+      hash = "sha256-ievdfKpIjgz8NaH0+S/kwz26WE/g0eC9xIhajDkeNFc=";
+      url = "https://github.com/temporalio/sdk-java/releases/download/v1.30.1/temporal-test-server_1.30.1_linux_arm64.tar.gz";
+    };
+    "x86_64-linux" = {
+      hash = "sha256-9jrybBUT/4o8lowM876tHOGcKQqIjF+of0EbZdhNZ24=";
+      url = "https://github.com/temporalio/sdk-java/releases/download/v1.30.1/temporal-test-server_1.30.1_linux_amd64.tar.gz";
+    };
+  };
+}

--- a/nix/utils/matrix.nix
+++ b/nix/utils/matrix.nix
@@ -2,7 +2,6 @@
   systems = [
     "x86_64-linux"
     "aarch64-darwin"
-    # FIXME: re-enable this once we have aarch64 support for the time-skipping server.
     "aarch64-linux" 
   ];
 

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -424,29 +423,11 @@ spec = do
     aroundAllWith (flip $ setup mempty) terminateTests
     updatesWithInterceptors
 
--- FIXME [aarch64-linux-temporal-test-server]
---
--- Temporal's time-skipping test server is a sub-component of their Java SDK,
--- compiled to native code with GraalVM and (at the time of writing) only
--- distributed for x86_64 platforms.
---
--- Upstream has recently added support for building this executable on ARM64
--- platforms, but there is currently no ETA for a new release. macOS users can
--- invoke the x86_64 test server via Rosetta2, so in the meantime we'll treat
--- Linux ARM64 systems as only partially supported.
---
--- The rest of the SDK will still be tested, and should continue working as-
--- expected on Linux ARM64, but invoking 'withTestServer' with
--- 'enableTimeSkipping = True' will fail to find the appropriate executable
--- (unless you have manually configured your shell to provide a copy of the
--- x86_64 test server binary wrapped in some form of userspace emulation).
-#if !(defined(linux_HOST_OS) && defined(aarch64_HOST_ARCH))
   -- Whether time-skipping is enabled is global state in the test server (it's not tracked
   -- per workflow or anything) so we need to use around (rather than aroundAll) to get a
   -- distinct server for each test
   around withTimeSkippingServer $ do
     aroundWith (flip $ setupTimeSkipping mempty) needsTimeSkipping
-#endif
 
 
 type MyWorkflow a = W.RequireCallStack => W.Workflow a


### PR DESCRIPTION
## description

exactly what it says.

we should add an auto-update script that fetches hashes when we do a version bump.

also probably PR this to nixpkgs at some point.