### PR TITLE
Add support for activity environments being mappable.

### DIFF
--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -187,7 +187,7 @@ applyActivityTaskStart tsk tt msg = do
             case HashMap.lookup info.activityType w.definitions of
               Nothing -> throwIO $ RuntimeError ("Activity type not found: " <> T.unpack info.activityType)
               Just ActivityDefinition {..} ->
-                activityRun (actEnv env') input'
+                runReaderT (unActivity $ activityRun input') (actEnv env')
                   `finally` (takeMVar syncPoint *> atomically (modifyTVar' w.runningActivities (HashMap.delete tt)))
         completionMsg <- case ef >>= first (toException . ValueError) of
           Left err@(SomeException _wrappedErr) -> do

--- a/sdk/src/Temporal/Bundle.hs
+++ b/sdk/src/Temporal/Bundle.hs
@@ -293,15 +293,16 @@ instance
   defFromFunction _ codec name f =
     ActivityDefinition
       (Text.pack name)
-      ( \actEnv input -> do
+      ( \input -> do
           eAct <-
-            applyPayloads
-              codec
-              (Proxy @(ArgsOf original))
-              (Proxy @(Activity env (ResultOf (Activity env) original)))
-              f
-              input.activityArgs
-          traverse (runActivity actEnv >=> encode codec) eAct
+            liftIO $
+              applyPayloads
+                codec
+                (Proxy @(ArgsOf original))
+                (Proxy @(Activity env (ResultOf (Activity env) original)))
+                f
+                input.activityArgs
+          traverse (>>= (liftIO . encode codec)) eAct
       )
 
 

--- a/sdk/src/Temporal/Worker.hs
+++ b/sdk/src/Temporal/Worker.hs
@@ -37,6 +37,7 @@ module Temporal.Worker (
   WorkerConfig (..),
   Definitions (..),
   ToDefinitions (..),
+  mapDefinitionsEnv,
   ConfigM,
   configure,
 
@@ -179,6 +180,14 @@ data Definitions env = Definitions
   { workflowDefinitions :: {-# UNPACK #-} !(HashMap Text WorkflowDefinition)
   , activityDefinitions :: {-# UNPACK #-} !(HashMap Text (ActivityDefinition env))
   }
+
+
+{- | If you have a worker that needs to run activities derived from a larger environment context,
+you can apply this function to the definitions to get a new set of definitions that will run
+the activities in the right environment.
+-}
+mapDefinitionsEnv :: (env' -> env) -> Definitions env -> Definitions env'
+mapDefinitionsEnv f (Definitions w a) = Definitions w (fmap (mapActivityDefinitionEnv f) a)
 
 
 instance Semigroup (Definitions env) where


### PR DESCRIPTION
People occasionally ask about being able to use activities (and consequently, workflows,) from other packages. This should support that by making it possible for them to export `Definitions Foo` and convert them into e.g. `Definitions App` as long as there's a mapping from `App -> Foo`.