### PR TITLE
Remove `darwin.apple_sdk.frameworks`

### DIFF
--- a/nix/overlays/haskell/hs-temporal-sdk.nix
+++ b/nix/overlays/haskell/hs-temporal-sdk.nix
@@ -9,23 +9,13 @@
 }:
 hfinal: hprev:
 let
-  inherit (haskell.lib.compose) addTestToolDepends enableCabalFlag overrideCabal;
+  inherit (haskell.lib.compose) addTestToolDepends enableCabalFlag;
 in
 {
   temporal-api-protos = hfinal.callCabal2nix "temporal-api-protos" ../../../protos { };
 
   temporal-sdk-core = lib.pipe (hfinal.callCabal2nix "temporal-sdk-core" ../../../core { }) [
     (enableCabalFlag "external_lib")
-    (overrideCabal (_attrs: {
-      libraryFrameworkDepends = lib.optionals stdenv.hostPlatform.isDarwin (
-        with darwin.apple_sdk.frameworks;
-        [
-          CoreFoundation
-          Security
-          SystemConfiguration
-        ]
-      );
-    }))
   ];
 
   temporal-sdk = lib.pipe (hfinal.callCabal2nix "temporal-sdk" ../../../sdk { }) [


### PR DESCRIPTION
These are removed and no longer needed:

```
$ nix develop
trace: evaluation warning: darwin.apple_sdk_11_0.CoreFoundation: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
trace: evaluation warning: darwin.apple_sdk_11_0.Security: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
trace: evaluation warning: darwin.apple_sdk_11_0.SystemConfiguration: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
```

Related: #131