### PR TITLE
[STAB-1051]: Update conflict policy & add test case

### DIFF
--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -594,7 +594,7 @@ startFromPayloads k@(KnownWorkflow codec _) wfId opts payloads = do
                 (fromMaybe WorkflowIdReusePolicyAllowDuplicateFailedOnly opts'.workflowIdReusePolicy)
             & WF.workflowIdConflictPolicy
               .~ workflowIdConflictPolicyToProto
-                (fromMaybe WorkflowIdConflictPolicyFail opts'.workflowIdConflictPolicy)
+                (fromMaybe WorkflowIdConflictPolicyUnspecified opts'.workflowIdConflictPolicy)
             & WF.maybe'retryPolicy .~ (retryPolicyToProto <$> opts'.retryPolicy)
             & WF.cronSchedule .~ fromMaybe "" opts'.cronSchedule
             & WF.memo .~ convertToProtoMemo opts'.memo

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -2450,6 +2450,23 @@ terminateTests = do
       h1.workflowHandleRunId `shouldNotBe` h2.workflowHandleRunId
       h1.workflowHandleWorkflowId `shouldBe` h2.workflowHandleWorkflowId
 
+    specify "Default conflict policy works with TerminateIfRunning reuse policy" $ \TestEnv {..} -> do
+      let wfId = WorkflowId "test-terminate-if-running-no-conflict-policy"
+          opts =
+            (C.startWorkflowOptions taskQueue)
+              { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyTerminateIfRunning
+              }
+
+      -- Start first workflow
+      h1 <- useClient (C.start testRefs.shouldRunWorkflowTest wfId opts)
+
+      -- Start second with same ID - should terminate first and start new
+      h2 <- useClient (C.start testRefs.shouldRunWorkflowTest wfId opts)
+
+      -- Should have different run IDs but same workflow ID
+      h1.workflowHandleRunId `shouldNotBe` h2.workflowHandleRunId
+      h1.workflowHandleWorkflowId `shouldBe` h2.workflowHandleWorkflowId
+
 -- describe "WorkflowClient" $ do
 --   specify "WorkflowExecutionAlreadyStartedError" pending
 --   specify "follows only own execution chain" pending


### PR DESCRIPTION
### Context

The `WorkflowIdConflictPolicy` previous change introduced a regression where workflows using `WorkflowIdReusePolicyTerminateIfRunning` began failing with:

```
Invalid WorkflowIDReusePolicy: WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING cannot be used together with a WorkflowIDConflictPolicy
```

### Root Cause

In `src/Temporal/Client.hs`, the default was set to `WorkflowIdConflictPolicyFail`. This sent a conflict policy for ALL workflows, even when not explicitly set. Since `TerminateIfRunning` is incompatible with any conflict policy, existing workflows broke.

### Solution

Changed default to `WorkflowIdConflictPolicyUnspecified`. Unspecified means "no policy set", which maintains backward compatibility.

### Testing

- Added regression test: "Default conflict policy works with TerminateIfRunning reuse policy"
- Verified test fails without fix, passes with fix
- All existing tests pass

### Links

[Linear Ticket](https://linear.app/mercury/issue/STAB-1051/support-workflow-id-conflict-policies-in-the-temporal-sdk)
[Previous PR](https://github.com/MercuryTechnologies/hs-temporal-sdk/pull/204)
[Postmortem ](https://www.notion.so/mercurytechnologies/enginc-345-temporal-workflows-using-terminate-if-running-id-reuse-policy-are-f-249951a7f21581509112cb91c77b8420?source=copy_link)