### PR TITLE
log when we start workflows and activities

### DIFF
--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -156,7 +156,7 @@ requireActivityNotRunning tt m = do
 applyActivityTaskStart :: (MonadUnliftIO m, MonadLogger m) => AT.ActivityTask -> TaskToken -> AT.Start -> ActivityWorkerM actEnv m ()
 applyActivityTaskStart tsk tt msg = do
   w <- ask
-  $logDebug $ "Starting activity: " <> T.pack (show tsk)
+  $logInfo $ "Starting activity: " <> T.pack (show tsk)
   requireActivityNotRunning tt $ do
     info <- activityInfoFromProto tt msg
     args <- processorDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.vec'input))

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -310,6 +310,7 @@ applyStartWorkflow :: ExecuteWorkflowInput -> (Vector Payload -> IO (Either Stri
 applyStartWorkflow execInput workflowFn = do
   inst <- ask
   let executeWorkflowBase input = runInstanceM inst $ do
+        $(logInfo) $ "Starting workflow: " <> input.executeWorkflowInputType
         eAct <- liftIO (workflowFn =<< processorDecodePayloads inst.payloadProcessor input.executeWorkflowInputArgs)
         case eAct of
           Left msg -> do


### PR DESCRIPTION
promote the `Starting activity:` log line to info, and add one for starting workflows

<img width="1383" height="109" alt="Screenshot 2025-08-25 at 3 15 58 PM" src="https://github.com/user-attachments/assets/b6c4447c-172b-4bf2-9740-25fc43f7f1a8" />
