### PR TITLE
add workflow info to update/query inputs

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -146,7 +146,7 @@ makeOpenTelemetryInterceptor = do
                                 [
                                   [ ("temporal.workflow_id", toAttribute $ rawWorkflowId input.executeWorkflowInputInfo.workflowId)
                                   , ("temporal.run_id", toAttribute $ rawRunId input.executeWorkflowInputInfo.runId)
-                                  , ("temporal.workflow_type", toAttribute input.executeWorkflowInputType)
+                                  , ("temporal.workflow_type", toAttribute $ rawWorkflowType input.executeWorkflowInputType)
                                   , ("temporal.attempt", toAttribute input.executeWorkflowInputInfo.attempt)
                                   , ("temporal.namespace", toAttribute $ rawNamespace input.executeWorkflowInputInfo.namespace)
                                   , ("temporal.task_queue", toAttribute $ rawTaskQueue input.executeWorkflowInputInfo.taskQueue)
@@ -192,7 +192,7 @@ makeOpenTelemetryInterceptor = do
                                     input.executeWorkflowInputInfo.retryPolicy
                                 ]
                         }
-                inSpan'' tracer ("RunWorkflow:" <> input.executeWorkflowInputType) spanArgs $ \span -> do
+                inSpan'' tracer ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs $ \span -> do
                   execution <- next input
                   case execution of
                     WorkflowExitFailed e -> do

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -813,7 +813,7 @@ interceptorConvertChildWorkflowHandle h f =
 
 
 data ExecuteWorkflowInput = ExecuteWorkflowInput
-  { executeWorkflowInputType :: Text
+  { executeWorkflowInputType :: WorkflowType
   , executeWorkflowInputArgs :: Vector Payload
   , executeWorkflowInputHeaders :: Map Text Payload
   , executeWorkflowInputInfo :: Info
@@ -832,7 +832,7 @@ data HandleQueryInput = HandleQueryInput
   , handleQueryInputType :: Text
   , handleQueryInputArgs :: Vector Payload
   , handleQueryInputHeaders :: Map Text Payload
-  , handleQueryWorkflowType :: Text
+  , handleQueryWorkflowInfo :: Info
   }
 
 
@@ -841,7 +841,7 @@ data HandleUpdateInput = HandleUpdateInput
   , handleUpdateInputType :: Text
   , handleUpdateInputArgs :: Vector Payload
   , handleUpdateInputHeaders :: Map Text Payload
-  , handleUpdateWorkflowType :: Text
+  , handleUpdateWorkflowInfo :: Info
   }
 
 

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -298,7 +298,7 @@ setUpWorkflowExecution initializeWorkflow = do
 
   pure $
     ExecuteWorkflowInput
-      { executeWorkflowInputType = initializeWorkflow ^. Activation.workflowType
+      { executeWorkflowInputType = WorkflowType (initializeWorkflow ^. Activation.workflowType)
       , executeWorkflowInputArgs = fmap convertFromProtoPayload (initializeWorkflow ^. Command.vec'arguments)
       , executeWorkflowInputHeaders = fmap convertFromProtoPayload (initializeWorkflow ^. Activation.headers)
       , executeWorkflowInputInfo = info
@@ -319,7 +319,7 @@ applyStartWorkflow execInput workflowFn = do
             , rawTaskQueue input.executeWorkflowInputInfo.taskQueue
             , " "
             , "workflowType="
-            , input.executeWorkflowInputType
+            , rawWorkflowType input.executeWorkflowInputType
             , " "
             , "workflowId="
             , rawWorkflowId input.executeWorkflowInputInfo.workflowId
@@ -357,7 +357,7 @@ applyQueryWorkflow queryWorkflow = do
           , handleQueryInputType = queryWorkflow ^. Activation.queryType
           , handleQueryInputArgs = args
           , handleQueryInputHeaders = fmap convertFromProtoPayload (queryWorkflow ^. Activation.headers)
-          , handleQueryWorkflowType = rawWorkflowType instInfo.workflowType
+          , handleQueryWorkflowInfo = instInfo
           }
   res <- liftIO $ inst.inboundInterceptor.handleQuery baseInput $ \input -> do
     let handlerOrDefault =
@@ -463,7 +463,7 @@ applyDoUpdateWorkflow doUpdate = provideCallStack do
                     , handleUpdateInputType = doUpdate ^. Activation.name
                     , handleUpdateInputArgs = args
                     , handleUpdateInputHeaders = updateHeaders
-                    , handleUpdateWorkflowType = rawWorkflowType instInfo.workflowType
+                    , handleUpdateWorkflowInfo = instInfo
                     }
             let runUpdate = inst.inboundInterceptor.handleUpdate baseInput $ \input ->
                   updateImplementation input.handleUpdateId input.handleUpdateInputArgs input.handleUpdateInputHeaders


### PR DESCRIPTION
this will allow update and query interceptors to respond to things like the workflow type.

while i was there, i also changed `ExecuteWorkflowInput`'s `executeWorkflowInputType` field to be `WorkflowType`, for consistency with similar data.

<img width="880" height="131" alt="Screenshot 2025-09-08 at 3 09 04 PM" src="https://github.com/user-attachments/assets/b81b2581-bfd9-4119-9c50-9a559f5dddad" />