### PR TITLE
add pure Payload ser/de functions for JSON codecs

### DIFF
--- a/sdk/src/Temporal/Exception.hs
+++ b/sdk/src/Temporal/Exception.hs
@@ -89,7 +89,6 @@ import qualified Proto.Temporal.Api.Failure.V1.Message as F
 import qualified Proto.Temporal.Api.Failure.V1.Message as Proto
 import qualified Proto.Temporal.Api.Failure.V1.Message_Fields as F
 import Proto.Temporal.Api.History.V1.Message
-import System.IO.Unsafe (unsafePerformIO)
 import Temporal.Common
 import Temporal.Core.Client (RpcError (..))
 import Temporal.Duration
@@ -500,7 +499,7 @@ mkApplicationFailure e@(SomeException e') = Prelude.foldr tryHandler (basicHandl
 
 
 annToPayload :: Annotation -> Payload
-annToPayload ann = unsafePerformIO $ encode JSON $ show ann
+annToPayload = encodeJSON . show
 
 
 annotationHandler :: Exception e => (e -> ApplicationFailure) -> AnnotatedException e -> ApplicationFailure


### PR DESCRIPTION
## description

there might be a better way to evolve the `Codec` API that can generalize over pure vs. impure codecs, but for now it feels like adding a pure helper that callers can use might be helpful.