### PR TITLE
Add explicit imports to Data.Text to allow building with Text 2.1.2+

### DIFF
--- a/sdk/src/Temporal/Common/Logging.hs
+++ b/sdk/src/Temporal/Common/Logging.hs
@@ -12,7 +12,7 @@ import Control.Monad.Logger (LogLevel (..), LogSource, LogStr, MonadLogger (..),
 import Data.Aeson (ToJSON (..))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encoding as A
-import Data.Text
+import Data.Text (Text, pack)
 import GHC.Stack (CallStack, HasCallStack, SrcLoc (..), callStack, getCallStack, withFrozenCallStack)
 import qualified Language.Haskell.TH as TH
 import Prelude hiding (log)

--- a/sdk/src/Temporal/Exception.hs
+++ b/sdk/src/Temporal/Exception.hs
@@ -72,7 +72,7 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Int
 import Data.ProtoLens (Message (..), decodeMessage, decodeMessageOrDie)
 import Data.ProtoLens.Field (field)
-import Data.Text
+import Data.Text (Text, breakOnEnd, pack)
 import Data.Typeable
 import Data.Vector (Vector)
 import qualified Data.Vector as V


### PR DESCRIPTION
Allows building with https://github.com/haskell/text/pull/608 which is needed for GHC 9.10.2+