### PR TITLE
Support catching ApplicationFailure in Workflows for simpler cases

### DIFF
--- a/sdk/src/Temporal/Exception.hs
+++ b/sdk/src/Temporal/Exception.hs
@@ -404,7 +404,9 @@ applicationFailureToFailureProto appFailure =
          )
 
 
-instance Exception ApplicationFailure
+instance Exception ApplicationFailure where
+  fromException (SomeException e) =
+    cast e <|> (cause <$> cast e)
 
 
 class ToApplicationFailure e where


### PR DESCRIPTION
I wrote some code the other day where I tried catching an `ApplicationFailure`, but the exception thrown in the workflow was an `ActivityFailure`. Since the application failure is a field within the activity failure, this seems like a nice quality of life dynamic cast to support.