### PR TITLE
Eliminate all panics from Rust FFI code

### DIFF
--- a/codec-encryption/temporal-codec-encryption.cabal
+++ b/codec-encryption/temporal-codec-encryption.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-codec-encryption
-version:        2025.10.1.0
+version:        2025.10.2.0
 category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com

--- a/codec-server/temporal-sdk-codec-server.cabal
+++ b/codec-server/temporal-sdk-codec-server.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-sdk-codec-server
-version:        2025.10.1.0
+version:        2025.10.2.0
 category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -46,10 +46,12 @@ struct ClientRetryConfig {
 
 fn client_config_to_options(
     client_config: ClientConfig,
-) -> Result<ClientOptions, ClientOptionsBuilderError> {
+) -> Result<ClientOptions, String> {
     let mut defaults = ClientOptionsBuilder::default();
+    let target_url = Url::parse(&client_config.target_url)
+        .map_err(|e| format!("Invalid URL: {}", e))?;
     let mut options_builder = defaults
-        .target_url(Url::parse(&client_config.target_url).unwrap())
+        .target_url(target_url)
         .client_name(client_config.client_name)
         .client_version(client_config.client_version)
         .identity(client_config.identity);
@@ -88,7 +90,7 @@ fn client_config_to_options(
         options_builder = options_builder.api_key(client_config.api_key)
     }
 
-    options_builder.build()
+    options_builder.build().map_err(|e| format!("Failed to build client options: {}", e))
 }
 
 #[repr(C)]
@@ -153,7 +155,10 @@ impl From<&RpcCall> for TemporalCall {
             req: unsafe {
                 let req_array = rpc_call.req;
                 let rust_vec = (*req_array).as_rust();
-                rust_vec.unwrap().clone()
+                rust_vec.unwrap_or_else(|e| {
+                    eprintln!("Failed to convert RPC request: {:?}", e);
+                    vec![]
+                }).clone()
             },
             retry: rpc_call.retry,
             metadata: unsafe { convert_hashmap(rpc_call.metadata) },
@@ -196,11 +201,20 @@ pub fn connect_client(
     config: ClientConfig,
     hs_callback: HsCallback<ClientRef, CArray<u8>>,
 ) {
-    let opts: ClientOptions = client_config_to_options(config).unwrap();
+    let opts_result = client_config_to_options(config);
     let runtime = runtime_ref.runtime.clone();
+
     runtime_ref
         .runtime
         .future_result_into_hs(hs_callback, async move {
+            let opts = opts_result.map_err(|e| {
+                let err_message = format!("Invalid client options: {}", e).into_bytes();
+                CArray::c_repr_of(err_message).unwrap_or_else(|conv_err| {
+                    eprintln!("Failed to convert error message: {:?}", conv_err);
+                    CArray { data_ptr: std::ptr::null_mut(), size: 0 }
+                })
+            })?;
+
             let retry_client_result = opts
                 .connect_no_namespace(runtime.core.as_ref().telemetry().get_metric_meter())
                 .await;
@@ -212,7 +226,10 @@ pub fn connect_client(
                 }),
                 Err(e) => {
                     let err_message = e.to_string().into_bytes();
-                    Err(CArray::c_repr_of(err_message).unwrap())
+                    Err(CArray::c_repr_of(err_message).unwrap_or_else(|conv_err| {
+                        eprintln!("Failed to convert error message: {:?}", conv_err);
+                        CArray { data_ptr: std::ptr::null_mut(), size: 0 }
+                    }))
                 }
             }
         })
@@ -233,7 +250,23 @@ pub unsafe extern "C" fn hs_temporal_connect_client(
 ) {
     let runtime_ref = unsafe { &*runtime_ref };
     let config_json = unsafe { CStr::from_ptr(config_json) };
-    let config: ClientConfig = serde_json::from_slice(config_json.to_bytes()).unwrap();
+    let config: ClientConfig = match serde_json::from_slice(config_json.to_bytes()) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Failed to parse client config: {}", e);
+            let err_message = format!("Failed to parse client config: {}", e).into_bytes();
+            let err_array = CArray::c_repr_of(err_message).unwrap_or_else(|conv_err| {
+                eprintln!("Failed to convert error message: {:?}", conv_err);
+                CArray { data_ptr: std::ptr::null_mut(), size: 0 }
+            });
+            unsafe {
+                *error_slot = err_array.into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            runtime_ref.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
     let hs_callback = runtime::HsCallback {
         cap,
         mvar,
@@ -294,10 +327,17 @@ impl From<String> for CRPCError {
     fn from(err: String) -> Self {
         CRPCError::c_repr_of(RPCError {
             code: 0,
-            message: err,
+            message: err.clone(),
             details: vec![],
         })
-        .unwrap()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to convert RPC error '{}': {:?}", err, e);
+            CRPCError {
+                code: 0,
+                message: std::ptr::null(),
+                details: std::ptr::null(),
+            }
+        })
     }
 }
 
@@ -308,7 +348,9 @@ impl From<String> for CRPCError {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hs_temporal_drop_rpc_error(error: *mut CRPCError) {
     unsafe {
-        CRPCError::drop_raw_pointer(error).unwrap();
+        if let Err(e) = CRPCError::drop_raw_pointer(error) {
+            eprintln!("Failed to drop RPC error: {:?}", e);
+        }
     }
 }
 
@@ -328,7 +370,14 @@ where
                 message: err.message().to_owned(),
                 details: err.details().into(),
             })
-            .unwrap())
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to convert RPC error: {:?}", e);
+                CRPCError {
+                    code: err.code() as u32,
+                    message: std::ptr::null(),
+                    details: std::ptr::null(),
+                }
+            }))
         }
     }
 }

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -156,7 +156,7 @@ impl From<&RpcCall> for TemporalCall {
                 let req_array = rpc_call.req;
                 let rust_vec = (*req_array).as_rust();
                 rust_vec.unwrap_or_else(|e| {
-                    eprintln!("Failed to convert RPC request: {:?}", e);
+                    eprintln!("Failed to convert Temporal client RPC request: {:?}", e);
                     vec![]
                 }).clone()
             },
@@ -210,7 +210,7 @@ pub fn connect_client(
             let opts = opts_result.map_err(|e| {
                 let err_message = format!("Invalid client options: {}", e).into_bytes();
                 CArray::c_repr_of(err_message).unwrap_or_else(|conv_err| {
-                    eprintln!("Failed to convert error message: {:?}", conv_err);
+                    eprintln!("Failed to convert Temporal client error message: {:?}", conv_err);
                     CArray { data_ptr: std::ptr::null_mut(), size: 0 }
                 })
             })?;
@@ -227,7 +227,7 @@ pub fn connect_client(
                 Err(e) => {
                     let err_message = e.to_string().into_bytes();
                     Err(CArray::c_repr_of(err_message).unwrap_or_else(|conv_err| {
-                        eprintln!("Failed to convert error message: {:?}", conv_err);
+                        eprintln!("Failed to convert Temporal client error message: {:?}", conv_err);
                         CArray { data_ptr: std::ptr::null_mut(), size: 0 }
                     }))
                 }
@@ -253,10 +253,9 @@ pub unsafe extern "C" fn hs_temporal_connect_client(
     let config: ClientConfig = match serde_json::from_slice(config_json.to_bytes()) {
         Ok(cfg) => cfg,
         Err(e) => {
-            eprintln!("Failed to parse client config: {}", e);
             let err_message = format!("Failed to parse client config: {}", e).into_bytes();
             let err_array = CArray::c_repr_of(err_message).unwrap_or_else(|conv_err| {
-                eprintln!("Failed to convert error message: {:?}", conv_err);
+                eprintln!("Failed to convert Temporal client error message: {:?}", conv_err);
                 CArray { data_ptr: std::ptr::null_mut(), size: 0 }
             });
             unsafe {
@@ -331,7 +330,7 @@ impl From<String> for CRPCError {
             details: vec![],
         })
         .unwrap_or_else(|e| {
-            eprintln!("Failed to convert RPC error '{}': {:?}", err, e);
+            eprintln!("Failed to convert Temporal client RPC error '{}': {:?}", err, e);
             CRPCError {
                 code: 0,
                 message: std::ptr::null(),
@@ -349,7 +348,7 @@ impl From<String> for CRPCError {
 pub unsafe extern "C" fn hs_temporal_drop_rpc_error(error: *mut CRPCError) {
     unsafe {
         if let Err(e) = CRPCError::drop_raw_pointer(error) {
-            eprintln!("Failed to drop RPC error: {:?}", e);
+            eprintln!("Failed failed to drop Temporal client RPC error pointer: {:?}", e);
         }
     }
 }
@@ -364,14 +363,13 @@ where
     match res {
         Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
         Err(err) => {
-            eprintln!("Error: {:?}", err);
             Err(CRPCError::c_repr_of(RPCError {
                 code: err.code() as u32,
                 message: err.message().to_owned(),
                 details: err.details().into(),
             })
             .unwrap_or_else(|e| {
-                eprintln!("Failed to convert RPC error: {:?}", e);
+                eprintln!("Failed to convert Temporal client RPC error: {:?}", e);
                 CRPCError {
                     code: err.code() as u32,
                     message: std::ptr::null(),

--- a/core/rust/src/rpc.rs
+++ b/core/rust/src/rpc.rs
@@ -5,27 +5,32 @@ use temporal_client::OperatorService;
 use temporal_client::TestService;
 use temporal_client::WorkflowService;
 
+// Helper to create a CRPCError with a fallback if conversion fails
+fn make_rpc_error(err: String) -> CRPCError {
+    CRPCError::c_repr_of(RPCError {
+        code: 0,
+        message: err.clone(),
+        details: vec![],
+    })
+    .unwrap_or_else(|e| {
+        eprintln!("Failed to convert RPC error '{}': {:?}", err, e);
+        // Fallback: create an RPCError with empty message
+        CRPCError::c_repr_of(RPCError {
+            code: 0,
+            message: String::new(),
+            details: vec![],
+        })
+        .expect("Failed to create fallback RPC error")
+    })
+}
+
 macro_rules! rpc_call {
     ($retry_client:ident, $call:ident, $call_name:ident) => {{
         if $call.retry {
-            let req = rpc_req($call).map_err(|err| {
-                CRPCError::c_repr_of(RPCError {
-                    code: 0,
-                    message: err,
-                    details: vec![],
-                })
-                .unwrap()
-            })?;
+            let req = rpc_req($call).map_err(|err| make_rpc_error(err))?;
             rpc_resp($retry_client.$call_name(req).await)
         } else {
-            let req = rpc_req($call).map_err(|err| {
-                CRPCError::c_repr_of(RPCError {
-                    code: 0,
-                    message: err,
-                    details: vec![],
-                })
-                .unwrap()
-            })?;
+            let req = rpc_req($call).map_err(|err| make_rpc_error(err))?;
             rpc_resp($retry_client.into_inner().$call_name(req).await)
         }
     }};
@@ -57,7 +62,17 @@ pub unsafe extern "C" fn hs_count_workflow_executions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, count_workflow_executions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -88,7 +103,17 @@ pub unsafe extern "C" fn hs_create_schedule(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, create_schedule) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -119,7 +144,17 @@ pub unsafe extern "C" fn hs_delete_schedule(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, delete_schedule) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -150,7 +185,17 @@ pub unsafe extern "C" fn hs_deprecate_namespace(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, deprecate_namespace) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -181,7 +226,17 @@ pub unsafe extern "C" fn hs_describe_namespace(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, describe_namespace) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -212,7 +267,17 @@ pub unsafe extern "C" fn hs_describe_schedule(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, describe_schedule) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -243,7 +308,17 @@ pub unsafe extern "C" fn hs_describe_task_queue(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, describe_task_queue) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -274,7 +349,17 @@ pub unsafe extern "C" fn hs_describe_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, describe_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -305,7 +390,17 @@ pub unsafe extern "C" fn hs_get_cluster_info(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_cluster_info) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -336,7 +431,17 @@ pub unsafe extern "C" fn hs_get_search_attributes(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_search_attributes) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -367,7 +472,17 @@ pub unsafe extern "C" fn hs_get_system_info(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_system_info) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -398,7 +513,17 @@ pub unsafe extern "C" fn hs_get_worker_build_id_compatibility(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_worker_build_id_compatibility) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -429,7 +554,17 @@ pub unsafe extern "C" fn hs_get_workflow_execution_history(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_workflow_execution_history) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -460,7 +595,17 @@ pub unsafe extern "C" fn hs_get_workflow_execution_history_reverse(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_workflow_execution_history_reverse) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -491,7 +636,17 @@ pub unsafe extern "C" fn hs_list_archived_workflow_executions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_archived_workflow_executions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -522,7 +677,17 @@ pub unsafe extern "C" fn hs_list_closed_workflow_executions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_closed_workflow_executions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -553,7 +718,17 @@ pub unsafe extern "C" fn hs_list_namespaces(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_namespaces) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -584,7 +759,17 @@ pub unsafe extern "C" fn hs_list_open_workflow_executions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_open_workflow_executions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -615,7 +800,17 @@ pub unsafe extern "C" fn hs_list_schedule_matching_times(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_schedule_matching_times) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -646,7 +841,17 @@ pub unsafe extern "C" fn hs_list_schedules(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_schedules) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -677,7 +882,17 @@ pub unsafe extern "C" fn hs_list_task_queue_partitions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_task_queue_partitions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -708,7 +923,17 @@ pub unsafe extern "C" fn hs_list_workflow_executions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_workflow_executions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -739,7 +964,17 @@ pub unsafe extern "C" fn hs_patch_schedule(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, patch_schedule) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -770,7 +1005,17 @@ pub unsafe extern "C" fn hs_poll_activity_task_queue(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, poll_activity_task_queue) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -801,7 +1046,17 @@ pub unsafe extern "C" fn hs_poll_workflow_execution_update(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, poll_workflow_execution_update) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -832,7 +1087,17 @@ pub unsafe extern "C" fn hs_poll_workflow_task_queue(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, poll_workflow_task_queue) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -863,7 +1128,17 @@ pub unsafe extern "C" fn hs_query_workflow(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, query_workflow) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -894,7 +1169,17 @@ pub unsafe extern "C" fn hs_record_activity_task_heartbeat(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, record_activity_task_heartbeat) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -925,7 +1210,17 @@ pub unsafe extern "C" fn hs_record_activity_task_heartbeat_by_id(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, record_activity_task_heartbeat_by_id) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -956,7 +1251,17 @@ pub unsafe extern "C" fn hs_register_namespace(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, register_namespace) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -987,7 +1292,17 @@ pub unsafe extern "C" fn hs_request_cancel_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, request_cancel_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1018,7 +1333,17 @@ pub unsafe extern "C" fn hs_reset_sticky_task_queue(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, reset_sticky_task_queue) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1049,7 +1374,17 @@ pub unsafe extern "C" fn hs_reset_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, reset_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1080,7 +1415,17 @@ pub unsafe extern "C" fn hs_respond_activity_task_canceled(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_activity_task_canceled) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1111,7 +1456,17 @@ pub unsafe extern "C" fn hs_respond_activity_task_canceled_by_id(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_activity_task_canceled_by_id) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1142,7 +1497,17 @@ pub unsafe extern "C" fn hs_respond_activity_task_completed(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_activity_task_completed) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1173,7 +1538,17 @@ pub unsafe extern "C" fn hs_respond_activity_task_completed_by_id(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_activity_task_completed_by_id) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1204,7 +1579,17 @@ pub unsafe extern "C" fn hs_respond_activity_task_failed(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_activity_task_failed) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1235,7 +1620,17 @@ pub unsafe extern "C" fn hs_respond_activity_task_failed_by_id(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_activity_task_failed_by_id) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1266,7 +1661,17 @@ pub unsafe extern "C" fn hs_respond_query_task_completed(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_query_task_completed) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1297,7 +1702,17 @@ pub unsafe extern "C" fn hs_respond_workflow_task_completed(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_workflow_task_completed) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1328,7 +1743,17 @@ pub unsafe extern "C" fn hs_respond_workflow_task_failed(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, respond_workflow_task_failed) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1359,7 +1784,17 @@ pub unsafe extern "C" fn hs_scan_workflow_executions(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, scan_workflow_executions) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1390,7 +1825,17 @@ pub unsafe extern "C" fn hs_signal_with_start_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, signal_with_start_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1421,7 +1866,17 @@ pub unsafe extern "C" fn hs_signal_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, signal_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1452,7 +1907,17 @@ pub unsafe extern "C" fn hs_start_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, start_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1483,7 +1948,17 @@ pub unsafe extern "C" fn hs_terminate_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, terminate_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1514,7 +1989,17 @@ pub unsafe extern "C" fn hs_update_namespace(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, update_namespace) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1545,7 +2030,17 @@ pub unsafe extern "C" fn hs_update_schedule(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, update_schedule) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1576,7 +2071,17 @@ pub unsafe extern "C" fn hs_update_workflow_execution(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, update_workflow_execution) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1607,7 +2112,17 @@ pub unsafe extern "C" fn hs_update_worker_build_id_compatibility(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, update_worker_build_id_compatibility) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1638,7 +2153,17 @@ pub unsafe extern "C" fn hs_get_current_time(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, get_current_time) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1669,7 +2194,17 @@ pub unsafe extern "C" fn hs_lock_time_skipping(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, lock_time_skipping) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1700,7 +2235,17 @@ pub unsafe extern "C" fn hs_sleep_until(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, sleep_until) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1731,7 +2276,17 @@ pub unsafe extern "C" fn hs_sleep(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, sleep) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1762,7 +2317,17 @@ pub unsafe extern "C" fn hs_unlock_time_skipping_with_sleep(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, unlock_time_skipping_with_sleep) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1793,7 +2358,17 @@ pub unsafe extern "C" fn hs_unlock_time_skipping(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, unlock_time_skipping) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1824,7 +2399,17 @@ pub unsafe extern "C" fn hs_add_or_update_remote_cluster(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, add_or_update_remote_cluster) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1855,7 +2440,17 @@ pub unsafe extern "C" fn hs_add_search_attributes(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, add_search_attributes) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1886,7 +2481,17 @@ pub unsafe extern "C" fn hs_delete_namespace(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, delete_namespace) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1917,7 +2522,17 @@ pub unsafe extern "C" fn hs_list_clusters(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_clusters) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1948,7 +2563,17 @@ pub unsafe extern "C" fn hs_list_search_attributes(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, list_search_attributes) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -1979,7 +2604,17 @@ pub unsafe extern "C" fn hs_remove_remote_cluster(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, remove_remote_cluster) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });
@@ -2010,7 +2645,17 @@ pub unsafe extern "C" fn hs_remove_search_attributes(
     };
     client.runtime.future_result_into_hs(callback, async move {
         match rpc_call!(retry_client, call, remove_search_attributes) {
-            Ok(resp) => Ok(CArray::c_repr_of(resp).unwrap()),
+            Ok(resp) => CArray::c_repr_of(resp).map_err(|e| {
+                eprintln!("Failed to convert response to CArray: {:?}", e);
+                CRPCError::c_repr_of(RPCError {
+                    code: 0,
+                    message: format!("Failed to convert response: {:?}", e),
+                    details: vec![],
+                }).unwrap_or_else(|e| {
+                    eprintln!("Failed to convert error: {:?}", e);
+                    CRPCError::c_repr_of(RPCError { code: 0, message: String::new(), details: vec![] }).expect("Failed to create fallback RPC error")
+                })
+            }),
             Err(err) => Err(err),
         }
     });

--- a/core/rust/src/worker.rs
+++ b/core/rust/src/worker.rs
@@ -28,6 +28,21 @@ use crate::client;
 use crate::runtime::{self, Capability, HsCallback, MVar};
 use serde::{Deserialize, Serialize};
 
+// Helper macro to convert CWorkerError, falling back to a basic error on failure
+macro_rules! to_c_worker_error {
+    ($err:expr, $code:expr) => {{
+        let code_val = $code;
+        let err_val = $err;
+        CWorkerError::c_repr_of(err_val).unwrap_or_else(|e| {
+            eprintln!("Failed to convert worker error: {:?}", e);
+            CWorkerError {
+                code: code_val,
+                message: std::ptr::null(),
+            }
+        })
+    }};
+}
+
 pub struct WorkerRef {
     worker: Option<Arc<temporal_sdk_core::Worker>>,
     runtime: runtime::Runtime,
@@ -587,9 +602,61 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
     result_slot: *mut *mut WorkerRef,
     error_slot: *mut *mut CWorkerError,
 ) {
-    let client_ref = unsafe { client.as_ref() }.expect("client is null");
-    let config_json = unsafe { CArray::raw_borrow(config).unwrap() };
-    let config = serde_json::from_slice(&config_json.as_rust().unwrap().clone()).map_err(|err| {
+    let client_ref = match unsafe { client.as_ref() } {
+        Some(c) => c,
+        None => {
+            eprintln!("FATAL: client pointer is null");
+            unsafe {
+                *result_slot = std::ptr::null_mut();
+                *error_slot = std::ptr::null_mut();
+            }
+            return;
+        }
+    };
+
+    let config_json = match unsafe { CArray::raw_borrow(config) } {
+        Ok(json) => json,
+        Err(e) => {
+            eprintln!("Failed to borrow config: {:?}", e);
+            let worker_error = WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: format!("Failed to borrow config: {:?}", e),
+            };
+            unsafe {
+                *error_slot = CWorkerError::c_repr_of(worker_error)
+                    .unwrap_or_else(|e| {
+                        eprintln!("Failed to convert worker error: {:?}", e);
+                        CWorkerError { code: WorkerErrorCode::InvalidWorkerConfig, message: std::ptr::null() }
+                    })
+                    .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            return;
+        }
+    };
+
+    let config_vec = match config_json.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert config: {:?}", e);
+            let worker_error = WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: format!("Failed to convert config: {:?}", e),
+            };
+            unsafe {
+                *error_slot = CWorkerError::c_repr_of(worker_error)
+                    .unwrap_or_else(|e| {
+                        eprintln!("Failed to convert worker error: {:?}", e);
+                        CWorkerError { code: WorkerErrorCode::InvalidWorkerConfig, message: std::ptr::null() }
+                    })
+                    .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            return;
+        }
+    };
+
+    let config = serde_json::from_slice(&config_vec).map_err(|err| {
         WorkerError {
             code: WorkerErrorCode::InvalidWorkerConfig,
             message: format!("{}", err),
@@ -607,7 +674,10 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
                     eprintln!("Error: {:?}", worker_error);
                     unsafe {
                         *error_slot = CWorkerError::c_repr_of(worker_error)
-                            .unwrap()
+                            .unwrap_or_else(|e| {
+                                eprintln!("Failed to convert worker error: {:?}", e);
+                                CWorkerError { code: WorkerErrorCode::InitWorkerFailed, message: std::ptr::null() }
+                            })
                             .into_raw_pointer_mut()
                     };
                 }
@@ -617,7 +687,10 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
             eprintln!("Error: {:?}", worker_error);
             unsafe {
                 *error_slot = CWorkerError::c_repr_of(worker_error)
-                    .unwrap()
+                    .unwrap_or_else(|e| {
+                        eprintln!("Failed to convert worker error: {:?}", e);
+                        CWorkerError { code: WorkerErrorCode::InvalidWorkerConfig, message: std::ptr::null() }
+                    })
                     .into_raw_pointer_mut()
             };
         }
@@ -658,13 +731,55 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
     history_slot: *mut *mut HistoryPusher,
     error_slot: *mut *mut CWorkerError,
 ) {
-    let runtime_ref = unsafe { runtime.as_ref() }.expect("client is null");
-    let config_json = unsafe { CArray::raw_borrow(config).unwrap() };
-    let config =
-        serde_json::from_slice(&config_json.as_rust().unwrap()).map_err(|err| WorkerError {
-            code: WorkerErrorCode::InvalidWorkerConfig,
-            message: format!("{}", err),
-        });
+    let runtime_ref = match unsafe { runtime.as_ref() } {
+        Some(r) => r,
+        None => {
+            eprintln!("FATAL: runtime pointer is null");
+            unsafe {
+                *worker_slot = std::ptr::null_mut();
+                *history_slot = std::ptr::null_mut();
+                *error_slot = std::ptr::null_mut();
+            }
+            return;
+        }
+    };
+
+    let config_json = match unsafe { CArray::raw_borrow(config) } {
+        Ok(json) => json,
+        Err(e) => {
+            eprintln!("Failed to borrow config: {:?}", e);
+            let worker_error = WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: format!("Failed to borrow config: {:?}", e),
+            };
+            unsafe {
+                *error_slot = to_c_worker_error!(worker_error, WorkerErrorCode::InvalidWorkerConfig)
+                    .into_raw_pointer_mut();
+            }
+            return;
+        }
+    };
+
+    let config_vec = match config_json.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert config: {:?}", e);
+            let worker_error = WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: format!("Failed to convert config: {:?}", e),
+            };
+            unsafe {
+                *error_slot = to_c_worker_error!(worker_error, WorkerErrorCode::InvalidWorkerConfig)
+                    .into_raw_pointer_mut();
+            }
+            return;
+        }
+    };
+
+    let config = serde_json::from_slice(&config_vec).map_err(|err| WorkerError {
+        code: WorkerErrorCode::InvalidWorkerConfig,
+        message: format!("{}", err),
+    });
 
     match config {
         Ok(config) => {
@@ -676,8 +791,7 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
                 },
                 Err(worker_error) => {
                     unsafe {
-                        *error_slot = CWorkerError::c_repr_of(worker_error)
-                            .unwrap()
+                        *error_slot = to_c_worker_error!(worker_error, WorkerErrorCode::InitReplayWorkerFailed)
                             .into_raw_pointer_mut()
                     };
                 }
@@ -685,8 +799,7 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
         }
         Err(worker_error) => {
             unsafe {
-                *error_slot = CWorkerError::c_repr_of(worker_error)
-                    .unwrap()
+                *error_slot = to_c_worker_error!(worker_error, WorkerErrorCode::InvalidWorkerConfig)
                     .into_raw_pointer_mut()
             };
         }
@@ -695,7 +808,21 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
 
 impl WorkerRef {
     fn poll_workflow_activation(&self, hs: HsCallback<CArray<u8>, CWorkerError>) {
-        let worker = self.worker.as_ref().unwrap().clone();
+        let worker = match self.worker.as_ref() {
+            Some(w) => w.clone(),
+            None => {
+                eprintln!("Worker is None, returning error");
+                let error = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: "Worker has been finalized".to_string(),
+                    },
+                    WorkerErrorCode::SDKError
+                );
+                hs.put_failure(&self.runtime, error);
+                return;
+            }
+        };
         self.runtime.future_result_into_hs(hs, async move {
             let bytes = match worker.poll_workflow_activation().await {
                 Ok(act) => Ok(act.encode_to_vec()),
@@ -708,17 +835,38 @@ impl WorkerRef {
                     message: format!("{}", err),
                 }),
             };
-            Ok(
-                CArray::c_repr_of(bytes.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?)
-                    .unwrap(),
-            )
+            let c_bytes = bytes.map_err(|err| to_c_worker_error!(err, err.code))?;
+            CArray::c_repr_of(c_bytes).map_err(|e| {
+                eprintln!("Failed to convert bytes to CArray: {:?}", e);
+                to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: format!("Failed to convert bytes: {:?}", e),
+                    },
+                    WorkerErrorCode::SDKError
+                )
+            })
         })
     }
 
     fn poll_activity_task(&self, hs: HsCallback<CArray<u8>, CWorkerError>) {
-        let worker = self.worker.as_ref().unwrap().clone();
+        let worker = match self.worker.as_ref() {
+            Some(w) => w.clone(),
+            None => {
+                eprintln!("Worker is None, returning error");
+                let error = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: "Worker has been finalized".to_string(),
+                    },
+                    WorkerErrorCode::SDKError
+                );
+                hs.put_failure(&self.runtime, error);
+                return;
+            }
+        };
         self.runtime.future_result_into_hs(hs, async move {
-            let bytes = (match worker.poll_activity_task().await {
+            let bytes = match worker.poll_activity_task().await {
                 Ok(task) => Ok(task.encode_to_vec()),
                 Err(PollError::ShutDown) => Err(WorkerError {
                     code: WorkerErrorCode::PollShutdownError,
@@ -728,57 +876,106 @@ impl WorkerRef {
                     code: WorkerErrorCode::PollFailure,
                     message: format!("Poll failure: {}", err),
                 }),
+            };
+            let c_bytes = bytes.map_err(|err| to_c_worker_error!(err, err.code))?;
+            CArray::c_repr_of(c_bytes).map_err(|e| {
+                eprintln!("Failed to convert bytes to CArray: {:?}", e);
+                to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: format!("Failed to convert bytes: {:?}", e),
+                    },
+                    WorkerErrorCode::SDKError
+                )
             })
-            .map_err(|err| CWorkerError::c_repr_of(err).unwrap());
-            Ok(CArray::c_repr_of(bytes?).unwrap())
         })
     }
 
-    fn complete_workflow_activation(&self, hs: HsCallback<CUnit, CWorkerError>, proto: &[u8]) {
-        let worker = self.worker.as_ref().unwrap().clone();
+    fn complete_workflow_activation(
+        &self,
+        hs: HsCallback<CUnit, CWorkerError>,
+        proto: &[u8],
+    ) {
+        let worker = match self.worker.as_ref() {
+            Some(w) => w.clone(),
+            None => {
+                eprintln!("Worker is None, returning error");
+                let error = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: "Worker has been finalized".to_string(),
+                    },
+                    WorkerErrorCode::SDKError
+                );
+                hs.put_failure(&self.runtime, error);
+                return;
+            }
+        };
         let completion = WorkflowActivationCompletion::decode(proto);
         self.runtime.future_result_into_hs(hs, async move {
             let completion = completion.map_err(|err| {
-                CWorkerError::c_repr_of(WorkerError {
-                    code: WorkerErrorCode::InvalidProto,
-                    message: format!("Invalid proto: {}", err),
-                })
-                .unwrap()
+                to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Invalid proto: {}", err),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
             })?;
             worker
                 .complete_workflow_activation(completion)
                 .await
                 .map_err(|err| {
-                    CWorkerError::c_repr_of(WorkerError {
-                        code: WorkerErrorCode::CompletionFailure,
-                        message: format!("{}", err),
-                    })
-                    .unwrap()
+                    to_c_worker_error!(
+                        WorkerError {
+                            code: WorkerErrorCode::CompletionFailure,
+                            message: format!("{}", err),
+                        },
+                        WorkerErrorCode::CompletionFailure
+                    )
                 })?;
             Ok(CUnit {})
         })
     }
 
     fn complete_activity_task(&self, hs: HsCallback<CUnit, CWorkerError>, proto: &[u8]) {
-        let worker = self.worker.as_ref().unwrap().clone();
+        let worker = match self.worker.as_ref() {
+            Some(w) => w.clone(),
+            None => {
+                eprintln!("Worker is None, returning error");
+                let error = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: "Worker has been finalized".to_string(),
+                    },
+                    WorkerErrorCode::SDKError
+                );
+                hs.put_failure(&self.runtime, error);
+                return;
+            }
+        };
         let completion = ActivityTaskCompletion::decode(proto);
         self.runtime.future_result_into_hs(hs, async move {
             let completion = completion.map_err(|err| {
-                CWorkerError::c_repr_of(WorkerError {
-                    code: WorkerErrorCode::InvalidProto,
-                    message: format!("{}", err),
-                })
-                .unwrap()
+                to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("{}", err),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
             })?;
             worker
                 .complete_activity_task(completion)
                 .await
                 .map_err(|err| {
-                    CWorkerError::c_repr_of(WorkerError {
-                        code: WorkerErrorCode::CompletionFailure,
-                        message: format!("{}", err),
-                    })
-                    .unwrap()
+                    to_c_worker_error!(
+                        WorkerError {
+                            code: WorkerErrorCode::CompletionFailure,
+                            message: format!("{}", err),
+                        },
+                        WorkerErrorCode::CompletionFailure
+                    )
                 })?;
             Ok(CUnit {})
         })
@@ -847,21 +1044,42 @@ impl WorkerRef {
 
     fn request_workflow_eviction(&self, run_id: &str) {
         enter_sync!(self.runtime);
-        self.worker
-            .as_ref()
-            .unwrap()
-            .request_workflow_eviction(run_id);
+        if let Some(worker) = self.worker.as_ref() {
+            worker.request_workflow_eviction(run_id);
+        } else {
+            eprintln!("Worker is None, cannot request workflow eviction");
+        }
     }
 
     fn initiate_shutdown(&self) {
-        let worker = self.worker.as_ref().unwrap().clone();
-        worker.initiate_shutdown();
+        if let Some(worker) = self.worker.as_ref() {
+            let worker = worker.clone();
+            worker.initiate_shutdown();
+        } else {
+            eprintln!("Worker is None, cannot initiate shutdown");
+        }
     }
 
     fn finalize_shutdown(&mut self, hs: HsCallback<CUnit, CWorkerError>) {
         // Take the worker out of the option and leave None. This should be the
         // only reference remaining to the worker so try_unwrap will work.
-        let core_worker = match Arc::try_unwrap(self.worker.take().unwrap()) {
+        let worker_arc = match self.worker.take() {
+            Some(w) => w,
+            None => {
+                eprintln!("Worker is None, returning error");
+                let error = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::SDKError,
+                        message: "Worker has already been finalized".to_string(),
+                    },
+                    WorkerErrorCode::SDKError
+                );
+                hs.put_failure(&self.runtime, error);
+                return;
+            }
+        };
+
+        let core_worker = match Arc::try_unwrap(worker_arc) {
             Ok(core_worker) => Ok(core_worker),
             Err(arc) => Err(WorkerError {
                 code: WorkerErrorCode::SDKError,
@@ -877,7 +1095,7 @@ impl WorkerRef {
                     worker.finalize_shutdown().await;
                     Ok(CUnit {})
                 }
-                Err(err) => Err(CWorkerError::c_repr_of(err).unwrap()),
+                Err(err) => Err(to_c_worker_error!(err, err.code)),
             }
         })
     }
@@ -903,7 +1121,23 @@ pub unsafe extern "C" fn hs_temporal_validate_worker(
         result_slot,
     };
 
-    let w = worker.worker.as_ref().unwrap().clone();
+    let w = match worker.worker.as_ref() {
+        Some(w) => w.clone(),
+        None => {
+            eprintln!("Worker is None, returning error");
+            let error = CWorkerValidationError::c_repr_of(FormattedError {
+                message: "Worker has been finalized".to_string(),
+            })
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to convert validation error: {:?}", e);
+                CWorkerValidationError {
+                    message: std::ptr::null(),
+                }
+            });
+            hs.put_failure(&worker.runtime, error);
+            return;
+        }
+    };
     worker.runtime.future_result_into_hs(hs, async move {
         let result = w.validate().await;
         match result {
@@ -911,7 +1145,12 @@ pub unsafe extern "C" fn hs_temporal_validate_worker(
             Err(err) => Err(CWorkerValidationError::c_repr_of(FormattedError {
                 message: format!("{}", err),
             })
-            .unwrap()),
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to convert validation error: {:?}", e);
+                CWorkerValidationError {
+                    message: std::ptr::null(),
+                }
+            })),
         }
     })
 }
@@ -974,15 +1213,51 @@ pub unsafe extern "C" fn hs_temporal_worker_complete_workflow_activation(
     result_slot: *mut *mut CUnit,
 ) {
     let worker = unsafe { &*worker };
-    let proto: &CArray<u8> = unsafe { CArray::raw_borrow(proto).unwrap() };
-    let proto: &[u8] = &proto.as_rust().unwrap().clone();
+    let proto_array = match unsafe { CArray::raw_borrow(proto) } {
+        Ok(arr) => arr,
+        Err(e) => {
+            eprintln!("Failed to borrow proto: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to borrow proto: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            worker.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+    let proto_vec = match proto_array.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert proto: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to convert proto: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            worker.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
     let hs = HsCallback {
         mvar,
         cap,
         error_slot,
         result_slot,
     };
-    worker.complete_workflow_activation(hs, proto)
+    worker.complete_workflow_activation(hs, &proto_vec)
 }
 
 // TODO: [publish-crate]
@@ -999,15 +1274,51 @@ pub unsafe extern "C" fn hs_temporal_worker_complete_activity_task(
     result_slot: *mut *mut CUnit,
 ) {
     let worker = unsafe { &*worker };
-    let proto: &CArray<u8> = unsafe { CArray::raw_borrow(proto).unwrap() };
-    let proto: &[u8] = &proto.as_rust().unwrap().clone();
+    let proto_array = match unsafe { CArray::raw_borrow(proto) } {
+        Ok(arr) => arr,
+        Err(e) => {
+            eprintln!("Failed to borrow proto: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to borrow proto: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            worker.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+    let proto_vec = match proto_array.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert proto: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to convert proto: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            worker.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
     let hs = HsCallback {
         mvar,
         cap,
         error_slot,
         result_slot,
     };
-    worker.complete_activity_task(hs, proto)
+    worker.complete_activity_task(hs, &proto_vec)
 }
 
 // TODO: [publish-crate]
@@ -1069,16 +1380,50 @@ pub unsafe extern "C" fn hs_temporal_worker_record_activity_heartbeat(
     result_slot: *mut *mut CUnit,
 ) {
     let worker = unsafe { &*worker };
-    let proto: &CArray<u8> = unsafe { CArray::raw_borrow(proto).unwrap() };
-    let proto: &[u8] = &proto.as_rust().unwrap().clone();
-    let result = worker.record_activity_heartbeat(proto);
+    let proto_array = match unsafe { CArray::raw_borrow(proto) } {
+        Ok(arr) => arr,
+        Err(e) => {
+            eprintln!("Failed to borrow proto: {:?}", e);
+            let err = to_c_worker_error!(
+                WorkerError {
+                    code: WorkerErrorCode::InvalidProto,
+                    message: format!("Failed to borrow proto: {:?}", e),
+                },
+                WorkerErrorCode::InvalidProto
+            );
+            unsafe {
+                *error_slot = err.into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            return;
+        }
+    };
+    let proto_vec = match proto_array.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert proto: {:?}", e);
+            let err = to_c_worker_error!(
+                WorkerError {
+                    code: WorkerErrorCode::InvalidProto,
+                    message: format!("Failed to convert proto: {:?}", e),
+                },
+                WorkerErrorCode::InvalidProto
+            );
+            unsafe {
+                *error_slot = err.into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            return;
+        }
+    };
+    let result = worker.record_activity_heartbeat(&proto_vec);
     match result {
         Ok(_) => unsafe {
             *error_slot = std::ptr::null_mut();
             *result_slot = std::ptr::null_mut();
         },
         Err(err) => {
-            let err = CWorkerError::c_repr_of(err).unwrap();
+            let err = to_c_worker_error!(err, err.code);
             unsafe {
                 *error_slot = err.into_raw_pointer_mut();
                 *result_slot = std::ptr::null_mut();
@@ -1097,10 +1442,28 @@ pub unsafe extern "C" fn hs_temporal_worker_request_workflow_eviction(
     run_id: *const CArray<u8>,
 ) {
     let worker = unsafe { &*worker };
-    let run_id: &CArray<u8> = unsafe { CArray::raw_borrow(run_id).unwrap() };
-    let run_id: &[u8] = &run_id.as_rust().unwrap().clone();
-    let run_id: &str = unsafe { str::from_utf8_unchecked(run_id) };
-    worker.request_workflow_eviction(run_id)
+    let run_id_array = match unsafe { CArray::raw_borrow(run_id) } {
+        Ok(arr) => arr,
+        Err(e) => {
+            eprintln!("Failed to borrow run_id: {:?}", e);
+            return;
+        }
+    };
+    let run_id_vec = match run_id_array.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert run_id: {:?}", e);
+            return;
+        }
+    };
+    let run_id_str = match str::from_utf8(&run_id_vec) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Failed to convert run_id to UTF-8: {}", e);
+            return;
+        }
+    };
+    worker.request_workflow_eviction(run_id_str)
 }
 
 // TODO: [publish-crate]
@@ -1196,18 +1559,19 @@ impl HistoryPusher {
             })
         };
         self.runtime.future_result_into_hs(hs, async move {
-            let history = history.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?;
-            let tx = tx.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?;
+            let history = history.map_err(|err| to_c_worker_error!(err, err.code))?;
+            let tx = tx.map_err(|err| to_c_worker_error!(err, err.code))?;
 
             tx.send(HistoryForReplay::new(history, wfid))
                 .await
                 .map_err(|_| {
-                    CWorkerError::c_repr_of(WorkerError {
-                        code: WorkerErrorCode::SDKError,
-                        message: "Channel for history replay was dropped, this is an SDK bug."
-                            .to_string(),
-                    })
-                    .unwrap()
+                    to_c_worker_error!(
+                        WorkerError {
+                            code: WorkerErrorCode::SDKError,
+                            message: "Channel for history replay was dropped, this is an SDK bug.".to_string(),
+                        },
+                        WorkerErrorCode::SDKError
+                    )
                 })?;
             Ok(CUnit {})
         })
@@ -1233,14 +1597,107 @@ pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     result_slot: *mut *mut CUnit,
 ) {
     let history_pusher = unsafe { &mut *history_pusher };
-    let workflow_id: &CArray<u8> = unsafe { CArray::raw_borrow(workflow_id).unwrap() };
-    let workflow_id = workflow_id.as_rust().unwrap().clone();
-    let workflow_id: &str = unsafe { str::from_utf8_unchecked(&workflow_id) };
-    let history_proto: &CArray<u8> = unsafe { CArray::raw_borrow(history_proto).unwrap() };
-    let history_proto: &[u8] = &history_proto.as_rust().unwrap().clone();
+
+    let wf_id_array = match unsafe { CArray::raw_borrow(workflow_id) } {
+        Ok(arr) => arr,
+        Err(e) => {
+            eprintln!("Failed to borrow workflow_id: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to borrow workflow_id: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            history_pusher.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+    let wf_id_vec = match wf_id_array.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert workflow_id: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to convert workflow_id: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            history_pusher.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+    let wf_id_str = match str::from_utf8(&wf_id_vec) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Failed to convert workflow_id to UTF-8: {}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to convert workflow_id to UTF-8: {}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            history_pusher.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+
+    let history_array = match unsafe { CArray::raw_borrow(history_proto) } {
+        Ok(arr) => arr,
+        Err(e) => {
+            eprintln!("Failed to borrow history_proto: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to borrow history_proto: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            history_pusher.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+    let history_vec = match history_array.as_rust() {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            eprintln!("Failed to convert history_proto: {:?}", e);
+            unsafe {
+                *error_slot = to_c_worker_error!(
+                    WorkerError {
+                        code: WorkerErrorCode::InvalidProto,
+                        message: format!("Failed to convert history_proto: {:?}", e),
+                    },
+                    WorkerErrorCode::InvalidProto
+                )
+                .into_raw_pointer_mut();
+                *result_slot = std::ptr::null_mut();
+            }
+            history_pusher.runtime.put_mvar(cap, mvar);
+            return;
+        }
+    };
+
     history_pusher.push_history(
-        workflow_id,
-        history_proto,
+        wf_id_str,
+        &history_vec,
         HsCallback {
             mvar,
             cap,

--- a/core/rust/src/worker.rs
+++ b/core/rust/src/worker.rs
@@ -34,7 +34,7 @@ macro_rules! to_c_worker_error {
         let code_val = $code;
         let err_val = $err;
         CWorkerError::c_repr_of(err_val).unwrap_or_else(|e| {
-            eprintln!("Failed to convert worker error: {:?}", e);
+            eprintln!("Failed to convert Temporal worker error: {:?}", e);
             CWorkerError {
                 code: code_val,
                 message: std::ptr::null(),
@@ -605,7 +605,7 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
     let client_ref = match unsafe { client.as_ref() } {
         Some(c) => c,
         None => {
-            eprintln!("FATAL: client pointer is null");
+            eprintln!("FATAL: Temporal worker client pointer is null");
             unsafe {
                 *result_slot = std::ptr::null_mut();
                 *error_slot = std::ptr::null_mut();
@@ -617,7 +617,6 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
     let config_json = match unsafe { CArray::raw_borrow(config) } {
         Ok(json) => json,
         Err(e) => {
-            eprintln!("Failed to borrow config: {:?}", e);
             let worker_error = WorkerError {
                 code: WorkerErrorCode::InvalidWorkerConfig,
                 message: format!("Failed to borrow config: {:?}", e),
@@ -625,7 +624,7 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
             unsafe {
                 *error_slot = CWorkerError::c_repr_of(worker_error)
                     .unwrap_or_else(|e| {
-                        eprintln!("Failed to convert worker error: {:?}", e);
+                        eprintln!("Failed to convert Temporal worker error: {:?}", e);
                         CWorkerError { code: WorkerErrorCode::InvalidWorkerConfig, message: std::ptr::null() }
                     })
                     .into_raw_pointer_mut();
@@ -638,7 +637,6 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
     let config_vec = match config_json.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert config: {:?}", e);
             let worker_error = WorkerError {
                 code: WorkerErrorCode::InvalidWorkerConfig,
                 message: format!("Failed to convert config: {:?}", e),
@@ -646,7 +644,7 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
             unsafe {
                 *error_slot = CWorkerError::c_repr_of(worker_error)
                     .unwrap_or_else(|e| {
-                        eprintln!("Failed to convert worker error: {:?}", e);
+                        eprintln!("Failed to convert Temporal worker error: {:?}", e);
                         CWorkerError { code: WorkerErrorCode::InvalidWorkerConfig, message: std::ptr::null() }
                     })
                     .into_raw_pointer_mut();
@@ -671,11 +669,10 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
                     unsafe { *result_slot = Box::into_raw(Box::new(worker_ref)) };
                 }
                 Err(worker_error) => {
-                    eprintln!("Error: {:?}", worker_error);
                     unsafe {
                         *error_slot = CWorkerError::c_repr_of(worker_error)
                             .unwrap_or_else(|e| {
-                                eprintln!("Failed to convert worker error: {:?}", e);
+                                eprintln!("Failed to convert Temporal worker error: {:?}", e);
                                 CWorkerError { code: WorkerErrorCode::InitWorkerFailed, message: std::ptr::null() }
                             })
                             .into_raw_pointer_mut()
@@ -684,11 +681,10 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
             }
         }
         Err(worker_error) => {
-            eprintln!("Error: {:?}", worker_error);
             unsafe {
                 *error_slot = CWorkerError::c_repr_of(worker_error)
                     .unwrap_or_else(|e| {
-                        eprintln!("Failed to convert worker error: {:?}", e);
+                        eprintln!("Failed to convert Temporal worker error: {:?}", e);
                         CWorkerError { code: WorkerErrorCode::InvalidWorkerConfig, message: std::ptr::null() }
                     })
                     .into_raw_pointer_mut()
@@ -734,7 +730,7 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
     let runtime_ref = match unsafe { runtime.as_ref() } {
         Some(r) => r,
         None => {
-            eprintln!("FATAL: runtime pointer is null");
+            eprintln!("FATAL: Temporal replay worker runtime pointer is null");
             unsafe {
                 *worker_slot = std::ptr::null_mut();
                 *history_slot = std::ptr::null_mut();
@@ -747,7 +743,6 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
     let config_json = match unsafe { CArray::raw_borrow(config) } {
         Ok(json) => json,
         Err(e) => {
-            eprintln!("Failed to borrow config: {:?}", e);
             let worker_error = WorkerError {
                 code: WorkerErrorCode::InvalidWorkerConfig,
                 message: format!("Failed to borrow config: {:?}", e),
@@ -763,7 +758,6 @@ pub unsafe extern "C" fn hs_temporal_new_replay_worker(
     let config_vec = match config_json.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert config: {:?}", e);
             let worker_error = WorkerError {
                 code: WorkerErrorCode::InvalidWorkerConfig,
                 message: format!("Failed to convert config: {:?}", e),
@@ -811,7 +805,6 @@ impl WorkerRef {
         let worker = match self.worker.as_ref() {
             Some(w) => w.clone(),
             None => {
-                eprintln!("Worker is None, returning error");
                 let error = to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -837,7 +830,6 @@ impl WorkerRef {
             };
             let c_bytes = bytes.map_err(|err| to_c_worker_error!(err, err.code))?;
             CArray::c_repr_of(c_bytes).map_err(|e| {
-                eprintln!("Failed to convert bytes to CArray: {:?}", e);
                 to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -853,7 +845,6 @@ impl WorkerRef {
         let worker = match self.worker.as_ref() {
             Some(w) => w.clone(),
             None => {
-                eprintln!("Worker is None, returning error");
                 let error = to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -879,7 +870,6 @@ impl WorkerRef {
             };
             let c_bytes = bytes.map_err(|err| to_c_worker_error!(err, err.code))?;
             CArray::c_repr_of(c_bytes).map_err(|e| {
-                eprintln!("Failed to convert bytes to CArray: {:?}", e);
                 to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -899,7 +889,6 @@ impl WorkerRef {
         let worker = match self.worker.as_ref() {
             Some(w) => w.clone(),
             None => {
-                eprintln!("Worker is None, returning error");
                 let error = to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -942,7 +931,6 @@ impl WorkerRef {
         let worker = match self.worker.as_ref() {
             Some(w) => w.clone(),
             None => {
-                eprintln!("Worker is None, returning error");
                 let error = to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -1047,7 +1035,7 @@ impl WorkerRef {
         if let Some(worker) = self.worker.as_ref() {
             worker.request_workflow_eviction(run_id);
         } else {
-            eprintln!("Worker is None, cannot request workflow eviction");
+            eprintln!("Temporal worker is None, cannot request workflow eviction");
         }
     }
 
@@ -1056,7 +1044,7 @@ impl WorkerRef {
             let worker = worker.clone();
             worker.initiate_shutdown();
         } else {
-            eprintln!("Worker is None, cannot initiate shutdown");
+            eprintln!("Temporal worker is None, cannot initiate shutdown");
         }
     }
 
@@ -1066,7 +1054,6 @@ impl WorkerRef {
         let worker_arc = match self.worker.take() {
             Some(w) => w,
             None => {
-                eprintln!("Worker is None, returning error");
                 let error = to_c_worker_error!(
                     WorkerError {
                         code: WorkerErrorCode::SDKError,
@@ -1124,12 +1111,11 @@ pub unsafe extern "C" fn hs_temporal_validate_worker(
     let w = match worker.worker.as_ref() {
         Some(w) => w.clone(),
         None => {
-            eprintln!("Worker is None, returning error");
             let error = CWorkerValidationError::c_repr_of(FormattedError {
                 message: "Worker has been finalized".to_string(),
             })
             .unwrap_or_else(|e| {
-                eprintln!("Failed to convert validation error: {:?}", e);
+                eprintln!("Failed to convert Temporal worker validation error: {:?}", e);
                 CWorkerValidationError {
                     message: std::ptr::null(),
                 }
@@ -1146,7 +1132,7 @@ pub unsafe extern "C" fn hs_temporal_validate_worker(
                 message: format!("{}", err),
             })
             .unwrap_or_else(|e| {
-                eprintln!("Failed to convert validation error: {:?}", e);
+                eprintln!("Failed to convert Temporal worker validation error: {:?}", e);
                 CWorkerValidationError {
                     message: std::ptr::null(),
                 }
@@ -1216,7 +1202,6 @@ pub unsafe extern "C" fn hs_temporal_worker_complete_workflow_activation(
     let proto_array = match unsafe { CArray::raw_borrow(proto) } {
         Ok(arr) => arr,
         Err(e) => {
-            eprintln!("Failed to borrow proto: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1235,7 +1220,6 @@ pub unsafe extern "C" fn hs_temporal_worker_complete_workflow_activation(
     let proto_vec = match proto_array.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert proto: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1277,7 +1261,6 @@ pub unsafe extern "C" fn hs_temporal_worker_complete_activity_task(
     let proto_array = match unsafe { CArray::raw_borrow(proto) } {
         Ok(arr) => arr,
         Err(e) => {
-            eprintln!("Failed to borrow proto: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1296,7 +1279,6 @@ pub unsafe extern "C" fn hs_temporal_worker_complete_activity_task(
     let proto_vec = match proto_array.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert proto: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1383,7 +1365,6 @@ pub unsafe extern "C" fn hs_temporal_worker_record_activity_heartbeat(
     let proto_array = match unsafe { CArray::raw_borrow(proto) } {
         Ok(arr) => arr,
         Err(e) => {
-            eprintln!("Failed to borrow proto: {:?}", e);
             let err = to_c_worker_error!(
                 WorkerError {
                     code: WorkerErrorCode::InvalidProto,
@@ -1401,7 +1382,6 @@ pub unsafe extern "C" fn hs_temporal_worker_record_activity_heartbeat(
     let proto_vec = match proto_array.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert proto: {:?}", e);
             let err = to_c_worker_error!(
                 WorkerError {
                     code: WorkerErrorCode::InvalidProto,
@@ -1445,21 +1425,21 @@ pub unsafe extern "C" fn hs_temporal_worker_request_workflow_eviction(
     let run_id_array = match unsafe { CArray::raw_borrow(run_id) } {
         Ok(arr) => arr,
         Err(e) => {
-            eprintln!("Failed to borrow run_id: {:?}", e);
+            eprintln!("Failed to borrow Temporal run_id: {:?}", e);
             return;
         }
     };
     let run_id_vec = match run_id_array.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert run_id: {:?}", e);
+            eprintln!("Failed to convert Temporal run_id: {:?}", e);
             return;
         }
     };
     let run_id_str = match str::from_utf8(&run_id_vec) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Failed to convert run_id to UTF-8: {}", e);
+            eprintln!("Failed to convert Temporal run_id to UTF-8: {}", e);
             return;
         }
     };
@@ -1601,7 +1581,6 @@ pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     let wf_id_array = match unsafe { CArray::raw_borrow(workflow_id) } {
         Ok(arr) => arr,
         Err(e) => {
-            eprintln!("Failed to borrow workflow_id: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1620,7 +1599,6 @@ pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     let wf_id_vec = match wf_id_array.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert workflow_id: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1639,7 +1617,6 @@ pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     let wf_id_str = match str::from_utf8(&wf_id_vec) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Failed to convert workflow_id to UTF-8: {}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1659,7 +1636,6 @@ pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     let history_array = match unsafe { CArray::raw_borrow(history_proto) } {
         Ok(arr) => arr,
         Err(e) => {
-            eprintln!("Failed to borrow history_proto: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {
@@ -1678,7 +1654,6 @@ pub unsafe extern "C" fn hs_temporal_history_pusher_push_history(
     let history_vec = match history_array.as_rust() {
         Ok(v) => v.clone(),
         Err(e) => {
-            eprintln!("Failed to convert history_proto: {:?}", e);
             unsafe {
                 *error_slot = to_c_worker_error!(
                     WorkerError {

--- a/core/temporal-sdk-core.cabal
+++ b/core/temporal-sdk-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-sdk-core
-version:        2025.10.1.0
+version:        2025.10.2.0
 description:    Temporal is a durable execution system that transparently makes your code durable, fault-tolerant, and simple. This is the core FFI bindings for the high-level Temporal SDK. Note that it requires Rust/Cargo to build.
 category:       Concurrency
 author:         Ian Duncan

--- a/hpack-defaults.yaml
+++ b/hpack-defaults.yaml
@@ -1,6 +1,6 @@
 verbatim: { cabal-version: 3.0 }
 
-version:      2025.10.1.0
+version:      2025.10.2.0
 author:       Ian Duncan
 maintainer:   temporal@mercury.com
 license-file: LICENSE

--- a/optimal-codec/temporal-sdk-optimal-codec.cabal
+++ b/optimal-codec/temporal-sdk-optimal-codec.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-sdk-optimal-codec
-version:        2025.10.1.0
+version:        2025.10.2.0
 category:       Concurrency
 author:         Ian Duncan
 maintainer:     temporal@mercury.com

--- a/protos/package.yaml
+++ b/protos/package.yaml
@@ -1,7 +1,7 @@
 verbatim: { cabal-version: 3.0 }
 
 name:         temporal-api-protos
-version:      2025.10.1.0
+version:      2025.10.2.0
 author:       Ian Duncan
 maintainer:   temporal@mercury.com
 license-file: LICENSE

--- a/protos/temporal-api-protos.cabal
+++ b/protos/temporal-api-protos.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-api-protos
-version:        2025.10.1.0
+version:        2025.10.2.0
 description:    Temporal is a durable execution system that transparently makes your code durable, fault-tolerant, and simple. These are low-level protocol buffer definitions for the Temporal API.
 author:         Ian Duncan
 maintainer:     temporal@mercury.com

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           temporal-sdk
-version:        2025.10.1.0
+version:        2025.10.2.0
 description:    Temporal is a durable execution system that transparently makes your code durable, fault-tolerant, and simple. This is the high-level Temporal SDK that provides a higher-level API for building Temporal workflows and activities.
 category:       Concurrency
 author:         Ian Duncan


### PR DESCRIPTION
I've been bothered for a while that we're not necessarily handling failures in a way that Haskell can gracefully deal with in order to report things to sentry/whatever else. So, this does a pass to get rid of any spots under our control where Rust can chuck a wobbly.