### PR TITLE
Set up support for cancelling, resetting, describing workflows

### DIFF
--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -42,6 +42,11 @@ module Temporal.Client (
   terminate,
   CancellationOptions (..),
   cancel,
+  ResetOptions (..),
+  ResetReapplyType (..),
+  ResetReapplyExcludeType (..),
+  EventId (..),
+  resetWorkflowExecution,
 
   -- * Querying Workflows
   QueryOptions (..),
@@ -69,6 +74,10 @@ module Temporal.Client (
   -- * Producing handles for existing workflows
   getHandle,
   GetHandleOptions (..),
+
+  -- * Workflow inspection
+  WorkflowExecutionDescription (..),
+  describeWorkflowExecution,
 
   -- * Workflow history utilities
   fetchHistory,
@@ -122,6 +131,7 @@ import Lens.Family2
 import qualified Proto.Temporal.Api.Common.V1.Message as CommonMsg
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Common
 import qualified Proto.Temporal.Api.Enums.V1.Query as Query
+import qualified Proto.Temporal.Api.Enums.V1.Reset as Reset
 import Proto.Temporal.Api.Enums.V1.TaskQueue (TaskQueueKind (..))
 import qualified Proto.Temporal.Api.Enums.V1.Update as Update
 import Proto.Temporal.Api.Enums.V1.Workflow (HistoryEventFilterType (..), WorkflowExecutionStatus (..))
@@ -152,7 +162,8 @@ import qualified Temporal.Client.TestService as TestService
 import Temporal.Client.Types
 import Temporal.Common
 import qualified Temporal.Core.Client as Core
-import Temporal.Core.Client.WorkflowService
+import Temporal.Core.Client.WorkflowService hiding (deleteWorkflowExecution, describeWorkflowExecution, resetWorkflowExecution)
+import qualified Temporal.Core.Client.WorkflowService as WS
 import Temporal.Duration (durationToProto)
 import Temporal.Exception
 import Temporal.Payload
@@ -848,6 +859,93 @@ cancel h req =
         & RR.firstExecutionRunId .~ maybe "" rawRunId h.workflowHandleFirstExecutionRunId
 
 
+{- | Reset a Workflow Execution to a previous point in its history.
+
+This operation allows you to "replay" a workflow from a specific point, which is useful
+for recovering from bad deployments or other issues. The workflow will be reset to the
+state immediately after the specified WorkflowTaskCompleted event.
+
+After reset, a new run will be created with a new Run ID but the same Workflow ID.
+-}
+resetWorkflowExecution :: (MonadIO m, HasWorkflowClient m) => WorkflowHandle a -> ResetOptions -> m (WorkflowHandle a)
+resetWorkflowExecution h opts = do
+  reqId <- liftIO UUID.nextRandom
+  let msg =
+        defMessage
+          & RR.namespace .~ rawNamespace h.workflowHandleClient.clientConfig.namespace
+          & RR.workflowExecution
+            .~ ( defMessage
+                  & Common.workflowId .~ rawWorkflowId h.workflowHandleWorkflowId
+                  & Common.runId .~ maybe "" rawRunId h.workflowHandleRunId
+               )
+          & RR.reason .~ opts.resetReason
+          & RR.workflowTaskFinishEventId .~ fromIntegral (rawEventId opts.resetToWorkflowTaskFinishEventId)
+          & RR.requestId .~ UUID.toText reqId
+          & RR.resetReapplyType .~ resetReapplyTypeToProto opts.resetReapplyType
+          & RR.vec'resetReapplyExcludeTypes .~ V.fromList (fmap resetReapplyExcludeTypeToProto opts.resetReapplyExcludeTypes)
+  res <-
+    liftIO $
+      WS.resetWorkflowExecution
+        h.workflowHandleClient.clientCore
+        msg
+  case res of
+    Left err -> throwIO $ Temporal.Exception.coreRpcErrorToRpcError err
+    Right response -> do
+      let newRunId = RunId $ response ^. RR.runId
+      pure $
+        h
+          { workflowHandleRunId = Just newRunId
+          , workflowHandleFirstExecutionRunId = Just newRunId
+          }
+  where
+    resetReapplyTypeToProto = \case
+      ResetReapplySignal -> Reset.RESET_REAPPLY_TYPE_SIGNAL
+      ResetReapplyNone -> Reset.RESET_REAPPLY_TYPE_NONE
+      ResetReapplyAllEligible -> Reset.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
+
+    resetReapplyExcludeTypeToProto = \case
+      ResetReapplyExcludeSignal -> Reset.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
+      ResetReapplyExcludeUpdate -> Reset.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
+      ResetReapplyExcludeNexus -> Reset.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
+      ResetReapplyExcludeCancelRequest -> Reset.RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
+
+
+{- | Get detailed information about a workflow execution.
+
+Returns comprehensive information about the workflow including its current status,
+pending operations, and configuration.
+-}
+describeWorkflowExecution :: (MonadIO m, HasWorkflowClient m) => WorkflowHandle a -> m WorkflowExecutionDescription
+describeWorkflowExecution h = do
+  res <-
+    liftIO $
+      WS.describeWorkflowExecution
+        h.workflowHandleClient.clientCore
+        msg
+  case res of
+    Left err -> throwIO $ Temporal.Exception.coreRpcErrorToRpcError err
+    Right response ->
+      pure $
+        WorkflowExecutionDescription
+          { workflowExecutionInfo = fromMaybe (error "Missing workflowExecutionInfo") (response ^. RR.maybe'workflowExecutionInfo)
+          , executionConfig = response ^. RR.maybe'executionConfig
+          , pendingActivities = response ^. RR.vec'pendingActivities
+          , pendingChildren = response ^. RR.vec'pendingChildren
+          , pendingWorkflowTask = response ^. RR.maybe'pendingWorkflowTask
+          , callbacks = response ^. RR.vec'callbacks
+          , pendingNexusOperations = response ^. RR.vec'pendingNexusOperations
+          }
+  where
+    msg =
+      defMessage
+        & RR.namespace .~ rawNamespace h.workflowHandleClient.clientConfig.namespace
+        & RR.execution
+          .~ ( defMessage
+                & Common.workflowId .~ rawWorkflowId h.workflowHandleWorkflowId
+                & Common.runId .~ maybe "" rawRunId h.workflowHandleRunId
+             )
+
+
 data FollowOption = FollowRuns | ThisRunOnly
 
 
@@ -1237,7 +1335,7 @@ checkWorkflowExecutionExists _wfRef wfId = do
                     & field @"workflowId" .~ rawWorkflowId wfId
                     & field @"runId" .~ ""
                  )
-    res <- Temporal.Core.Client.WorkflowService.describeWorkflowExecution c.clientCore req
+    res <- WS.describeWorkflowExecution c.clientCore req
     case res of
       Left err -> case err of
         Core.RpcError status _ _ | fromIntegral status == fromEnum StatusNotFound -> pure False

--- a/sdk/src/Temporal/Client/Types.hs
+++ b/sdk/src/Temporal/Client/Types.hs
@@ -11,6 +11,7 @@ import Data.Text (Text)
 import Data.Vector (Vector)
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift)
+import qualified Proto.Temporal.Api.Workflow.V1.Message as Workflow
 import Temporal.Common
 import Temporal.Core.Client (Client)
 import Temporal.Duration
@@ -340,6 +341,79 @@ data QueryRejected = QueryRejected
   { status :: WorkflowExecutionStatus
   }
   deriving stock (Read, Show, Eq, Ord)
+
+
+{- | Determines what events should be reapplied after a reset.
+
+When a workflow is reset, events that occurred after the reset point can optionally
+be reapplied to maintain continuity.
+-}
+data ResetReapplyType
+  = -- | Reapply only signal events
+    ResetReapplySignal
+  | -- | Do not reapply any events
+    ResetReapplyNone
+  | -- | Reapply all eligible events (signals, updates, etc.)
+    ResetReapplyAllEligible
+  deriving stock (Read, Show, Eq, Ord)
+
+
+{- | Specific event types to exclude from reapplication during reset.
+
+Use this to fine-tune which events should not be reapplied even if the
+ResetReapplyType would normally include them.
+-}
+data ResetReapplyExcludeType
+  = ResetReapplyExcludeSignal
+  | ResetReapplyExcludeUpdate
+  | ResetReapplyExcludeNexus
+  | ResetReapplyExcludeCancelRequest
+  deriving stock (Read, Show, Eq, Ord)
+
+
+{- | Options for resetting a workflow execution to a previous point.
+
+Resetting allows you to "replay" a workflow from a specific point, which is useful
+for recovering from bad deployments or other issues.
+-}
+data ResetOptions = ResetOptions
+  { resetReason :: Text
+  -- ^ Explanation for why the workflow is being reset
+  , resetToWorkflowTaskFinishEventId :: EventId
+  -- ^ The event ID of the WorkflowTaskCompleted event to reset to.
+  -- The workflow will be reset to the state immediately after this task completed.
+  , resetReapplyType :: ResetReapplyType
+  -- ^ Determines what events should be reapplied after the reset.
+  -- Defaults to 'ResetReapplySignal'.
+  , resetReapplyExcludeTypes :: [ResetReapplyExcludeType]
+  -- ^ Specific event types to exclude from reapplication.
+  -- Defaults to an empty list (no exclusions).
+  }
+  deriving stock (Read, Show, Eq, Ord)
+
+
+{- | Description of a workflow execution's current state.
+
+This provides detailed information about a running or completed workflow,
+including its configuration, current status, and any pending operations.
+-}
+data WorkflowExecutionDescription = WorkflowExecutionDescription
+  { workflowExecutionInfo :: Workflow.WorkflowExecutionInfo
+  -- ^ Core execution information (status, start/close times, type, task queue, etc.)
+  , executionConfig :: Maybe Workflow.WorkflowExecutionConfig
+  -- ^ The workflow's configuration (timeouts, task queue, retry policy, etc.)
+  , pendingActivities :: Vector Workflow.PendingActivityInfo
+  -- ^ Activities that are currently scheduled or running
+  , pendingChildren :: Vector Workflow.PendingChildExecutionInfo
+  -- ^ Child workflows that are currently running
+  , pendingWorkflowTask :: Maybe Workflow.PendingWorkflowTaskInfo
+  -- ^ Information about a pending workflow task, if any
+  , callbacks :: Vector Workflow.CallbackInfo
+  -- ^ Registered callbacks for this workflow
+  , pendingNexusOperations :: Vector Workflow.PendingNexusOperationInfo
+  -- ^ Pending Nexus operations
+  }
+  deriving stock (Show, Eq)
 
 
 data SignalWithStartWorkflowInput = SignalWithStartWorkflowInput

--- a/sdk/src/Temporal/Common.hs
+++ b/sdk/src/Temporal/Common.hs
@@ -52,6 +52,12 @@ newtype UpdateId = UpdateId {rawUpdateId :: Text}
   deriving newtype (Eq, Ord, Show, Hashable, IsString, ToJSON, ToJSONKey, FromJSON, FromJSONKey)
 
 
+-- | An Event ID refers to a specific event in a workflow's history
+newtype EventId = EventId {rawEventId :: Int}
+  deriving stock (Lift)
+  deriving newtype (Eq, Ord, Read, Show, Num, ToJSON, FromJSON)
+
+
 -- | A Namespace is a unit of isolation within the Temporal Platform
 newtype Namespace = Namespace {rawNamespace :: Text}
   deriving stock (Lift)


### PR DESCRIPTION
### TL;DR

Added new workflow management capabilities including cancellation, reset, and inspection functionality.

### What changed?

- Added `cancel` function to request cancellation of a workflow execution
- Added `resetWorkflowExecution` function
- Added `describeWorkflowExecution` function that returns detailed workflow information
- Added `WorkflowExecutionDescription` type to represent comprehensive workflow state

