### PR TITLE
reproduce signal delivery ordering misunderstanding

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -144,6 +144,7 @@ tests:
       - require-callstack
       - hs-opentelemetry-sdk
       - resourcet
+      - pqueue
     main: Main.hs
     source-dirs: test
     other-modules:

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -216,6 +216,7 @@ test-suite temporal-sdk-tests
     , monad-logger
     , mtl
     , network
+    , pqueue
     , proto-lens
     , proto-lens-protobuf-types
     , random

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -1539,6 +1539,33 @@ needsClient = do
             -- If order is wrong, we'd get [2, 1]
             lift $ C.waitWorkflowResult wfH `shouldReturn` [1, 2]
 
+      it "processes signals in order of delivery" $ \TestEnv {..} -> do
+        let conf = provideCallStack $ configure () (discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)) baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts =
+                      C.TimeoutOptions
+                        { C.runTimeout = Just $ seconds 4
+                        , C.executionTimeout = Nothing
+                        , C.taskTimeout = Nothing
+                        }
+                  }
+          useClient $ do
+            liftIO $ putStrLn "signalWithStart call"
+            wfH <-
+              C.signalWithStart
+                SignalEnqueuesItemWorkflow
+                "signalWithStartWithQueue"
+                opts
+                signalWithArgs
+                1
+ 
+            C.signal wfH signalWithArgs C.defaultSignalOptions 2
+            lift $ C.waitWorkflowResult wfH `shouldReturn` [1, 2]
+ 
+ 
   --     specify "works as intended and returns correct runId" pending
   describe "RetryPolicy" $ do
     specify "is used for retryable failures" $ \TestEnv {..} -> do


### PR DESCRIPTION
## description

this reproduces signal delivery ordering behavior we observed in production code, where `signalWithStart` followed by `signal` in short succession does not necessarily guarantee in-order modification of `StateVar`s.

signals _are_, however, processed in-order: if the signal handler gets the time at which it is processed with `Workflow.now` and uses that as a priority ordering key then things look the way that we expect them to.

---

https://github.com/MercuryTechnologies/hs-temporal-sdk/pull/251/commits/6c0e06bec32b35a81ca118276c52ba80c4532fc3 fails with the same thing we saw in prod:

<details> <summary> failure </summary>

```
Failures:

  test/IntegrationSpec.hs:1511:45:
  1) Integration, Regression tests, signalWithStart, processes signals in order of delivery
       expected: [1,2]
        but got: [2,1]

  To rerun use: --match "/Integration/Regression tests/signalWithStart/processes signals in order of delivery/"

Randomized with seed 1851790929

Finished in 2.1476 seconds
1 example, 1 failure
```

</details>

...but https://github.com/MercuryTechnologies/hs-temporal-sdk/pull/251/commits/2946fc5c2637f6199f994bccdeec6fafe230bb0e succeeds when it uses a priority queue to insert according to received timestamp:

<details> <summary> success </summary>

```
Finished in 2.1433 seconds
1 example, 0 failures
Test suite temporal-sdk-tests: PASS
```

</details>