### PR TITLE
Fix accidental signal dropping

### DIFF
--- a/nix/devenv/repo-wide-checks.nix
+++ b/nix/devenv/repo-wide-checks.nix
@@ -29,6 +29,7 @@
         [
           "^sdk/src/Temporal/Client/Namespace\\.hs"
           "^sdk/src/Temporal/Client/Workflow\\.hs"
+          "^sdk/src/Temporal/Workflow/Internal/Monad\\.hs" # CPP not supported by fourmolu
           "^sdk/test/Spec\\.hs"
         ]
         ++ attrs.excludes or [];

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -14,6 +14,7 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Kind
 import Data.Map.Strict (Map)
+import Data.Monoid (Endo (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -698,6 +699,10 @@ data WorkflowInstance = WorkflowInstance
   , workflowCommands :: {-# UNPACK #-} !(TVar (Reversed WorkflowCommand))
   , workflowSequenceMaps :: {-# UNPACK #-} !(TVar SequenceMaps)
   , workflowSignalHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (Vector Payload -> Workflow ())))
+  , -- | Signals that arrived before their handler was registered.
+    -- These are buffered and delivered when setSignalHandler is called.
+    -- Uses Endo for O(1) append (diff-list style).
+    workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
   , workflowQueryHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (QueryId -> Vector Payload -> Map Text Payload -> IO (Either SomeException Payload))))
   , workflowUpdateHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) WorkflowUpdateImplementation))
   , workflowCallStack :: {-# UNPACK #-} !(IORef CallStack)

--- a/sdk/src/Temporal/Workflow/Unsafe.hs
+++ b/sdk/src/Temporal/Workflow/Unsafe.hs
@@ -17,7 +17,7 @@ As such, these functions are not exported from the Temporal module to discourage
 inadvisable use.
 -}
 module Temporal.Workflow.Unsafe (
-  performUnsafeNonDeterministicIO
+  performUnsafeNonDeterministicIO,
 ) where
 
 import Control.Monad.IO.Class

--- a/sdk/test/ExceptionSpec.hs
+++ b/sdk/test/ExceptionSpec.hs
@@ -7,22 +7,28 @@ import qualified Temporal.Core.Client as Core
 import Temporal.Exception
 import Test.Hspec
 
+
 exampleError :: Core.RpcError
-exampleError = Core.RpcError
-  { Core.code = 6
-  , Core.message = "Workflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e."
-  , Core.details = "\b\ACK\DC2\154\SOHWorkflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e.\SUB\167\SOH\nWtype.googleapis.com/temporal.api.errordetails.v1.WorkflowExecutionAlreadyStartedFailure\DC2L\n$3f7d236b-fcda-4482-a02d-834c225e5e91\DC2$0195f782-4076-7e1f-8d9f-6567e745033e"
-  }
+exampleError =
+  Core.RpcError
+    { Core.code = 6
+    , Core.message = "Workflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e."
+    , Core.details = "\b\ACK\DC2\154\SOHWorkflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e.\SUB\167\SOH\nWtype.googleapis.com/temporal.api.errordetails.v1.WorkflowExecutionAlreadyStartedFailure\DC2L\n$3f7d236b-fcda-4482-a02d-834c225e5e91\DC2$0195f782-4076-7e1f-8d9f-6567e745033e"
+    }
+
 
 spec :: Spec
 spec = do
   describe "RpcError conversion" do
     specify "Core RpcError values should convert to useful Temporal.Exception.RpcError values" $ do
       let rpcError = coreRpcErrorToRpcError exampleError
-      rpcError.code `shouldBe` StatusAlreadyExists
-      rpcError.message `shouldBe` "Workflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e."
-      rpcError.details `shouldBe`
-        [ RpcErrorWorkflowExecutionAlreadyStarted $ defMessage
-          & field @"startRequestId" .~ "3f7d236b-fcda-4482-a02d-834c225e5e91"
-          & field @"runId" .~ "0195f782-4076-7e1f-8d9f-6567e745033e"
-        ]
+      rpcError . code `shouldBe` StatusAlreadyExists
+      rpcError . message `shouldBe` "Workflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e."
+      rpcError . details
+        `shouldBe` [ RpcErrorWorkflowExecutionAlreadyStarted $
+                      defMessage
+                        & field @"startRequestId"
+                        .~ "3f7d236b-fcda-4482-a02d-834c225e5e91"
+                        & field @"runId"
+                        .~ "0195f782-4076-7e1f-8d9f-6567e745033e"
+                   ]

--- a/sdk/test/ExceptionSpec.hs
+++ b/sdk/test/ExceptionSpec.hs
@@ -4,7 +4,12 @@ import Data.ProtoLens
 import Data.ProtoLens.Field (field)
 import Lens.Family2
 import qualified Temporal.Core.Client as Core
-import Temporal.Exception
+import Temporal.Exception (
+  RPCStatusCode (..),
+  RpcError (..),
+  RpcErrorDetails (..),
+  coreRpcErrorToRpcError,
+ )
 import Test.Hspec
 
 
@@ -22,9 +27,9 @@ spec = do
   describe "RpcError conversion" do
     specify "Core RpcError values should convert to useful Temporal.Exception.RpcError values" $ do
       let rpcError = coreRpcErrorToRpcError exampleError
-      rpcError . code `shouldBe` StatusAlreadyExists
-      rpcError . message `shouldBe` "Workflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e."
-      rpcError . details
+      rpcError.code `shouldBe` StatusAlreadyExists
+      rpcError.message `shouldBe` "Workflow execution is already running. WorkflowId: zendesk/organization/c4e43516-a488-11eb-bbd4-1b5d0069e6eb, RunId: 0195f782-4076-7e1f-8d9f-6567e745033e."
+      rpcError.details
         `shouldBe` [ RpcErrorWorkflowExecutionAlreadyStarted $
                       defMessage
                         & field @"startRequestId"

--- a/sdk/test/IntegrationSpec/Signals.hs
+++ b/sdk/test/IntegrationSpec/Signals.hs
@@ -53,3 +53,75 @@ signalWithArgsWorkflow init = provideCallStack do
 
 
 registerWorkflow 'signalWithArgsWorkflow
+
+
+-- | Signal for testing buffering behavior
+signalBufferingSignal :: KnownSignal '[Int]
+signalBufferingSignal = KnownSignal "signalBuffering" JSON
+
+
+{- | This workflow tests signal buffering behavior.
+
+When used with signalWithStart, the signal arrives in the same activation
+as the workflow start. The signal should be buffered until the handler
+is registered (which happens when the workflow code executes setSignalHandler).
+
+Without buffering, the signal would be dropped and waitCondition would hang forever.
+-}
+signalBufferingWorkflow :: Workflow Int
+signalBufferingWorkflow = provideCallStack do
+  $(logDebug) "Starting signalBufferingWorkflow"
+  -- Create state var to track received signals
+  signalsReceived <- newStateVar ([] :: [Int])
+
+  -- Register signal handler - this is where buffered signals should be delivered
+  $(logDebug) "About to register signal handler"
+  setSignalHandler signalBufferingSignal $ \value -> do
+    $(logDebug) "Signal handler invoked"
+    modifyStateVar signalsReceived (value :)
+
+  $(logDebug) "Signal handler registered, now waiting for condition"
+  -- Wait for at least one signal to be received
+  -- Without buffering, this will hang forever because the signal was dropped
+  waitCondition $ do
+    signals <- readStateVar signalsReceived
+    pure $ not (null signals)
+
+  $(logDebug) "Condition satisfied, returning"
+  -- Return the sum of received signal values
+  signals <- readStateVar signalsReceived
+  pure $ sum signals
+
+
+registerWorkflow 'signalBufferingWorkflow
+
+
+{- | Tests that multiple buffered signals are delivered in FIFO order.
+
+This workflow waits for 2 signals and returns them in the order received.
+The test sends signals with values [1, 2] and expects them back in that order,
+verifying that buffered signals maintain their arrival order.
+-}
+signalOrderingWorkflow :: Workflow [Int]
+signalOrderingWorkflow = provideCallStack do
+  $(logDebug) "Starting signalOrderingWorkflow"
+  -- Append to the end to preserve order
+  signalsReceived <- newStateVar ([] :: [Int])
+
+  $(logDebug) "About to register signal handler"
+  setSignalHandler signalBufferingSignal $ \value -> do
+    $(logDebug) "Signal handler invoked"
+    -- Append to end to maintain FIFO order
+    modifyStateVar signalsReceived (<> [value])
+
+  $(logDebug) "Signal handler registered, waiting for 2 signals"
+  -- Wait for at least 2 signals
+  waitCondition $ do
+    signals <- readStateVar signalsReceived
+    pure $ length signals >= 2
+
+  $(logDebug) "Received 2 signals, returning"
+  readStateVar signalsReceived
+
+
+registerWorkflow 'signalOrderingWorkflow


### PR DESCRIPTION
### TL;DR

Implement signal buffering to ensure signals sent before handlers are registered aren't lost.

### What changed?

- Added signal buffering functionality to store signals that arrive before their handlers are registered
- Modified `WorkflowInstance` to include a new `workflowBufferedSignals` field that uses a diff-list (via `Endo`) for efficient appending
- Updated `setSignalHandler` to process any buffered signals when a handler is registered
- Changed signal/update injection to use FIFO ordering to preserve arrival order
- Added integration tests to verify signal buffering works correctly and maintains FIFO order

### How to test?

Two new integration tests were added:
1. `buffers signals until handler is registered` - Tests that signals sent via `signalWithStart` are properly buffered and processed
2. `delivers buffered signals in FIFO order` - Verifies that multiple buffered signals are delivered in the correct order (first-in, first-out)

### Why make this change?

Previously, signals that arrived before their handlers were registered would be dropped, causing workflows to potentially miss important signals. This behavior was inconsistent with other SDKs like TypeScript. 

This change ensures signals are properly buffered and delivered when handlers are registered, matching the behavior of other Temporal SDKs and providing a more reliable developer experience.