### PR TITLE
Implement local activity support

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -312,6 +312,16 @@ makeOpenTelemetryInterceptor = do
                   ctxt <- getContext
                   hdrs <- inject headersPropagator ctxt headers
                   next wfName $ StartChildWorkflowOptions {headers = hdrs, ..}
+            , scheduleLocalActivity = \input next -> do
+                let StartLocalActivityOptions {..} = input.localOptions
+                    spanArgs =
+                      defaultSpanArguments
+                        { kind = Client
+                        }
+                inSpan'' tracer ("StartLocalActivity:" <> input.localActivityType) spanArgs $ \_ -> do
+                  ctxt <- getContext
+                  hdrs <- inject headersPropagator ctxt headers
+                  next $ input {localOptions = StartLocalActivityOptions {headers = hdrs, ..}}
             }
       , activityInboundInterceptors =
           ActivityInboundInterceptor

--- a/sdk/src/Temporal/Interceptor.hs
+++ b/sdk/src/Temporal/Interceptor.hs
@@ -55,6 +55,7 @@ module Temporal.Interceptor (
   HandleUpdateInput (..),
   WorkflowOutboundInterceptor (..),
   ActivityInput (..),
+  LocalActivityInput (..),
   ActivityInboundInterceptor (..),
   ExecuteActivityInput (..),
   ActivityOutboundInterceptor (..),

--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -117,6 +117,7 @@ module Temporal.Workflow (
   StartLocalActivityOptions (..),
   defaultStartLocalActivityOptions,
   startLocalActivity,
+  executeLocalActivity,
 
   -- ** Child workflow operations
   -- $childWorkflow
@@ -320,6 +321,7 @@ import Temporal.Activity.Definition (ActivityRef (..), KnownActivity (..))
 import Temporal.Common
 import qualified Temporal.Common.Logging as Logging
 import Temporal.Common.TimeoutType
+import qualified Proto.Google.Protobuf.Timestamp as Timestamp
 import Temporal.Duration (Duration (..), diffSystemTime, durationFromProto, durationToProto, nanoseconds, seconds)
 import Temporal.Exception
 import Temporal.Payload
@@ -791,151 +793,129 @@ executeChildWorkflow (workflowRef -> k@(KnownWorkflow codec _)) opts = withWorkf
   waitChildWorkflowResult h
 
 
-data StartLocalActivityOptions = StartLocalActivityOptions
-  { activityId :: Maybe ActivityId
-  , scheduleToCloseTimeout :: Maybe Duration
-  -- ^ Indicates how long the caller is willing to wait for local activity completion. Limits how
-  -- long retries will be attempted. When not specified defaults to the workflow execution
-  -- timeout (which may be unset).
-  , scheduleToStartTimeout :: Maybe Duration
-  -- ^ Limits time the local activity can idle internally before being executed. That can happen if
-  -- the worker is currently at max concurrent local activity executions. This timeout is always
-  -- non retryable as all a retry would achieve is to put it back into the same queue. Defaults
-  -- to `schedule_to_close_timeout` if not specified and that is set. Must be <=
-  -- `schedule_to_close_timeout` when set, otherwise, it will be clamped down.
-  , startToCloseTimeout :: Maybe Duration
-  -- ^ Maximum time the local activity is allowed to execute after the task is dispatched. This
-  -- timeout is always retryable. Either or both of `schedule_to_close_timeout` and this must be
-  -- specified. If set, this must be <= `schedule_to_close_timeout`, otherwise, it will be
-  -- clamped down.
-  , retryPolicy :: Maybe RetryPolicy
-  -- ^ Specify a retry policy for the local activity. By default local activities will be retried
-  -- indefinitely.
-  , localRetryThreshold :: Maybe Duration
-  -- ^ If the activity is retrying and backoff would exceed this value, lang will be told to
-  -- schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
-  -- core. Defaults to 1 minute.
-  , cancellationType :: ActivityCancellationType
-  -- ^ Defines how the workflow will wait (or not) for cancellation of the activity to be
-  -- confirmed. Lang should default this to `WAIT_CANCELLATION_COMPLETED`, even though proto
-  -- will default to `TRY_CANCEL` automatically.
-  , headers :: Map Text Payload
-  }
-
-
-{- |
-Default options for starting a local activity.
-
-@
-'StartLocalActivityOptions'
-  { activityId = 'Nothing'
-  , scheduleToCloseTimeout = 'Nothing'
-  , scheduleToStartTimeout = 'Nothing'
-  , startToCloseTimeout = 'Nothing'
-  , retryPolicy = 'Nothing'
-  , localRetryThreshold = 'Nothing'
-  , cancellationType = 'ActivityCancellationWaitCancellationCompleted'
-  , headers = 'mempty'
-  }
-@
--}
-defaultStartLocalActivityOptions :: StartLocalActivityOptions
-defaultStartLocalActivityOptions =
-  StartLocalActivityOptions
-    { activityId = Nothing
-    , scheduleToCloseTimeout = Nothing
-    , scheduleToStartTimeout = Nothing
-    , startToCloseTimeout = Nothing
-    , retryPolicy = Nothing
-    , localRetryThreshold = Nothing
-    , cancellationType = ActivityCancellationWaitCancellationCompleted
-    , headers = mempty
-    }
-
-
-startLocalActivity
-  :: forall act
-   . (RequireCallStack, ActivityRef act)
-  => act
+startLocalActivityFromPayloads
+  :: forall args result
+   . RequireCallStack
+  => KnownActivity args result
   -> StartLocalActivityOptions
-  -> (ActivityArgs act :->: Workflow (Task (ActivityResult act)))
-startLocalActivity (activityRef -> KnownActivity codec n) opts = withWorkflowArgs @(ActivityArgs act) @(Task (ActivityResult act)) codec $ \typedPayloads -> do
+  -> Vector Payload
+  -> Workflow (Task result)
+startLocalActivityFromPayloads (KnownActivity codec name) opts typedPayloads = do
   updateCallStackW
   originalTime <- time
-  ilift $ do
-    inst <- ask
-    encodedPayloads <- processorEncodePayloads inst.payloadProcessor typedPayloads
-    let ps = fmap convertToProtoPayload encodedPayloads
-    s@(Sequence actSeq) <- nextActivitySequence
+  cancelledRef <- ilift $ liftIO $ newIORef False
+  rawTask <- scheduleLocalActivityAttempt name opts typedPayloads 0 (timespecToTimestamp originalTime) cancelledRef
+  pure
+    ( rawTask
+        `bindTask` ( \payload -> Workflow $ \_ -> do
+                      result <- liftIO $ decode codec payload
+                      case result of
+                        Left err -> pure $ Throw $ toException $ ValueError err
+                        Right val -> pure $ Done val
+                   )
+    )
+
+
+-- | Schedule a single local activity attempt. Returns a Task that resolves with
+-- the raw Payload on success. On DoBackoff, sleeps for the backoff duration and
+-- recursively re-schedules with updated attempt/originalScheduleTime, creating
+-- the server-side timer that core expects for long backoffs.
+--
+-- The @cancelledRef@ is shared across all retry attempts so that
+-- 'cancelAction' on the outermost 'Task' can signal cancellation to the
+-- DoBackoff retry loop.
+scheduleLocalActivityAttempt
+  :: RequireCallStack
+  => Text
+  -> StartLocalActivityOptions
+  -> Vector Payload
+  -> Word32
+  -> Timestamp.Timestamp
+  -> IORef Bool
+  -> Workflow (Task Payload)
+scheduleLocalActivityAttempt name opts typedPayloads attemptNum origSchedTime cancelledRef = ilift $ do
+  runInIO <- askRunInIO
+  inst <- ask
+  s@(Sequence actSeq) <- nextActivitySequence
+  let intercept :: LocalActivityInput -> (LocalActivityInput -> IO (Task Payload)) -> IO (Task Payload)
+      intercept = inst.outboundInterceptor.scheduleLocalActivity
+  liftIO $ intercept (LocalActivityInput name typedPayloads opts s) $ \localInput -> runInIO $ do
     resultSlot <- newTrackedIVar
     atomically $ modifyTVar' inst.workflowSequenceMaps $ \seqMaps ->
       seqMaps {activities = HashMap.insert s resultSlot (activities seqMaps)}
-    -- TODO, seems like `attempt` and `originalScheduledTime`
-    -- imply that we are in charge of retrying local activities ourselves?
-    let actId = maybe (Text.pack $ show actSeq) rawActivityId opts.activityId
+    let localOpts = localInput.localOptions
+    hdrs <- processorEncodePayloads inst.payloadProcessor localOpts.headers
+    args <- processorEncodePayloads inst.payloadProcessor localInput.localArgs
+    let actId = maybe (Text.pack $ show actSeq) rawActivityId localOpts.activityId
         cmd =
           defMessage
             & Command.scheduleLocalActivity
               .~ ( defMessage
                     & Command.seq .~ actSeq
                     & Command.activityId .~ actId
-                    & Command.activityType .~ n
-                    -- & attempt .~ _
-                    -- & headers .~ _
-                    & Command.originalScheduleTime .~ timespecToTimestamp originalTime
-                    & Command.vec'arguments .~ ps
-                    & Command.maybe'scheduleToCloseTimeout .~ (durationToProto <$> opts.scheduleToCloseTimeout)
-                    & Command.maybe'scheduleToStartTimeout .~ (durationToProto <$> opts.scheduleToStartTimeout)
-                    & Command.maybe'startToCloseTimeout .~ (durationToProto <$> opts.startToCloseTimeout)
-                    & Command.maybe'retryPolicy .~ (retryPolicyToProto <$> opts.retryPolicy)
-                    & Command.maybe'localRetryThreshold .~ (durationToProto <$> opts.localRetryThreshold)
-                    & Command.cancellationType .~ activityCancellationTypeToProto opts.cancellationType
+                    & Command.activityType .~ localInput.localActivityType
+                    & Command.headers .~ fmap convertToProtoPayload hdrs
+                    & Command.attempt .~ attemptNum
+                    & Command.originalScheduleTime .~ origSchedTime
+                    & Command.vec'arguments .~ fmap convertToProtoPayload args
+                    & Command.maybe'scheduleToCloseTimeout .~ (durationToProto <$> localOpts.scheduleToCloseTimeout)
+                    & Command.maybe'scheduleToStartTimeout .~ (durationToProto <$> localOpts.scheduleToStartTimeout)
+                    & Command.maybe'startToCloseTimeout .~ (durationToProto <$> localOpts.startToCloseTimeout)
+                    & Command.maybe'retryPolicy .~ (retryPolicyToProto <$> localOpts.retryPolicy)
+                    & Command.maybe'localRetryThreshold .~ (durationToProto <$> localOpts.localRetryThreshold)
+                    & Command.cancellationType .~ activityCancellationTypeToProto localOpts.cancellationType
                  )
     addCommand cmd
     pure $
       Task
         { waitAction = do
             res <- getIVar resultSlot
-            Workflow $ \_ -> case res ^. Activation.result . ActivityResult.maybe'status of
-              Nothing -> error "Activity result missing status"
+            case res ^. Activation.result . ActivityResult.maybe'status of
+              Nothing -> error "Local activity result missing status"
               Just (ActivityResult.ActivityResolution'Completed success) -> do
-                decodedPayload <- liftIO $ payloadProcessorDecode inst.payloadProcessor $ convertFromProtoPayload $ success ^. ActivityResult.result
-                case decodedPayload of
-                  Left err -> pure $ Throw $ toException $ ValueError err
-                  Right payload -> do
-                    result <- liftIO $ decode codec payload
-                    case result of
-                      Left err -> pure $ Throw $ toException $ ValueError err
-                      Right val -> pure $ Done val
+                res' <- ilift $ liftIO $ payloadProcessorDecode inst.payloadProcessor $ convertFromProtoPayload (success ^. ActivityResult.result)
+                case res' of
+                  Left err -> Temporal.Workflow.Internal.Monad.throw $ ValueError err
+                  Right val -> pure val
               Just (ActivityResult.ActivityResolution'Failed failure_) ->
                 let failure = failure_ ^. ActivityResult.failure
-                in pure $
-                    Throw $
-                      toException $
-                        ActivityFailure
-                          { message = failure ^. Failure.message
-                          , activityType = ActivityType n
-                          , activityId = ActivityId actId
-                          , retryState = retryStateFromProto $ failure ^. Failure.activityFailureInfo . Failure.retryState
-                          , identity = failure ^. Failure.activityFailureInfo . Failure.identity
-                          , cause =
-                              let cause_ = failure ^. Failure.cause
-                              in ApplicationFailure
-                                  { type' = cause_ ^. Failure.applicationFailureInfo . Failure.type'
-                                  , message = cause_ ^. Failure.message
-                                  , nonRetryable = cause_ ^. Failure.applicationFailureInfo . Failure.nonRetryable
-                                  , details = cause_ ^. Failure.applicationFailureInfo . Failure.details . Payloads.payloads . to (fmap convertFromProtoPayload)
-                                  , stack = cause_ ^. Failure.stackTrace
-                                  , nextRetryDelay = Nothing
-                                  }
-                          , scheduledEventId = failure ^. Failure.activityFailureInfo . Failure.scheduledEventId
-                          , startedEventId = failure ^. Failure.activityFailureInfo . Failure.startedEventId
-                          , original = failure ^. Failure.activityFailureInfo
-                          , stack = Text.pack $ Temporal.Exception.prettyCallStack callStack
-                          }
-              Just (ActivityResult.ActivityResolution'Cancelled details) -> pure $ Throw $ toException $ ActivityCancelled (details ^. ActivityResult.failure)
-              Just (ActivityResult.ActivityResolution'Backoff _doBackoff) -> error "not implemented"
+                    cause_ = failure ^. Failure.cause
+                in Temporal.Workflow.Internal.Monad.throw $
+                    ActivityFailure
+                      { message = failure ^. Failure.message
+                      , activityType = ActivityType localInput.localActivityType
+                      , activityId = ActivityId actId
+                      , retryState = retryStateFromProto $ failure ^. Failure.activityFailureInfo . Failure.retryState
+                      , identity = failure ^. Failure.activityFailureInfo . Failure.identity
+                      , cause =
+                          ApplicationFailure
+                            { type' = cause_ ^. Failure.applicationFailureInfo . Failure.type'
+                            , message = cause_ ^. Failure.message
+                            , nonRetryable = cause_ ^. Failure.applicationFailureInfo . Failure.nonRetryable
+                            , details = cause_ ^. Failure.applicationFailureInfo . Failure.details . Payloads.payloads . to (fmap convertFromProtoPayload)
+                            , stack = cause_ ^. Failure.stackTrace
+                            , nextRetryDelay = fmap durationFromProto (cause_ ^. Failure.applicationFailureInfo . Failure.maybe'nextRetryDelay)
+                            }
+                      , scheduledEventId = failure ^. Failure.activityFailureInfo . Failure.scheduledEventId
+                      , startedEventId = failure ^. Failure.activityFailureInfo . Failure.startedEventId
+                      , original = failure ^. Failure.activityFailureInfo
+                      , stack = Text.pack $ Temporal.Exception.prettyCallStack callStack
+                      }
+              Just (ActivityResult.ActivityResolution'Cancelled details) ->
+                Temporal.Workflow.Internal.Monad.throw $ ActivityCancelled (details ^. ActivityResult.failure)
+              Just (ActivityResult.ActivityResolution'Backoff doBackoff) -> do
+                cancelled <- ilift $ liftIO $ readIORef cancelledRef
+                if cancelled
+                  then Temporal.Workflow.Internal.Monad.throw $ ActivityCancelled defMessage
+                  else do
+                    let dur = durationFromProto (doBackoff ^. ActivityResult.backoffDuration)
+                        newOrigTime = doBackoff ^. ActivityResult.originalScheduleTime
+                        newAttempt = doBackoff ^. ActivityResult.attempt
+                    sleep dur
+                    retryTask <- scheduleLocalActivityAttempt name opts typedPayloads newAttempt newOrigTime cancelledRef
+                    Temporal.Workflow.Unsafe.Handle.wait retryTask
         , cancelAction = do
+            ilift $ liftIO $ writeIORef cancelledRef True
             let cancelCmd =
                   defMessage
                     & Command.requestCancelLocalActivity
@@ -944,6 +924,27 @@ startLocalActivity (activityRef -> KnownActivity codec n) opts = withWorkflowArg
                          )
             ilift $ addCommand cancelCmd
         }
+
+
+startLocalActivity
+  :: forall act
+   . (RequireCallStack, ActivityRef act)
+  => act
+  -> StartLocalActivityOptions
+  -> (ActivityArgs act :->: Workflow (Task (ActivityResult act)))
+startLocalActivity (activityRef -> k@(KnownActivity codec _name)) opts =
+  withWorkflowArgs @(ActivityArgs act) @(Task (ActivityResult act)) codec (startLocalActivityFromPayloads k opts)
+
+
+executeLocalActivity
+  :: forall act
+   . (RequireCallStack, ActivityRef act)
+  => act
+  -> StartLocalActivityOptions
+  -> (ActivityArgs act :->: Workflow (ActivityResult act))
+executeLocalActivity (activityRef -> k@(KnownActivity codec _name)) opts = withWorkflowArgs @(ActivityArgs act) @(ActivityResult act) codec $ \typedPayloads -> do
+  actHandle <- startLocalActivityFromPayloads k opts typedPayloads
+  Temporal.Workflow.Unsafe.Handle.wait actHandle
 
 
 {- $metadata

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -965,8 +965,17 @@ data ActivityInput = ActivityInput
   }
 
 
+data LocalActivityInput = LocalActivityInput
+  { localActivityType :: Text
+  , localArgs :: Vector Payload
+  , localOptions :: StartLocalActivityOptions
+  , localSeq :: Sequence
+  }
+
+
 data WorkflowOutboundInterceptor = WorkflowOutboundInterceptor
   { scheduleActivity :: ActivityInput -> (ActivityInput -> IO (Task Payload)) -> IO (Task Payload)
+  , scheduleLocalActivity :: LocalActivityInput -> (LocalActivityInput -> IO (Task Payload)) -> IO (Task Payload)
   , startChildWorkflowExecution :: Text -> StartChildWorkflowOptions -> (Text -> StartChildWorkflowOptions -> IO (ChildWorkflowHandle Payload)) -> IO (ChildWorkflowHandle Payload)
   , continueAsNew :: forall a. Text -> ContinueAsNewOptions -> (Text -> ContinueAsNewOptions -> IO a) -> IO a
   }
@@ -976,6 +985,7 @@ instance Semigroup WorkflowOutboundInterceptor where
   l <> r =
     WorkflowOutboundInterceptor
       { scheduleActivity = \input cont -> scheduleActivity l input $ \input' -> scheduleActivity r input' cont
+      , scheduleLocalActivity = \input cont -> Temporal.Workflow.Internal.Monad.scheduleLocalActivity l input $ \input' -> Temporal.Workflow.Internal.Monad.scheduleLocalActivity r input' cont
       , startChildWorkflowExecution = \t input cont -> startChildWorkflowExecution l t input $ \t' input' -> startChildWorkflowExecution r t' input' cont
       , continueAsNew = \n input cont -> continueAsNew l n input $ \n' input' -> continueAsNew r n' input' cont
       }
@@ -985,6 +995,7 @@ instance Monoid WorkflowOutboundInterceptor where
   mempty =
     WorkflowOutboundInterceptor
       { scheduleActivity = \input cont -> cont input
+      , scheduleLocalActivity = \input cont -> cont input
       , startChildWorkflowExecution = \t input cont -> cont t input
       , continueAsNew = \n input cont -> cont n input
       }

--- a/sdk/src/Temporal/Workflow/Types.hs
+++ b/sdk/src/Temporal/Workflow/Types.hs
@@ -287,6 +287,69 @@ defaultChildWorkflowOptions =
     }
 
 
+data StartLocalActivityOptions = StartLocalActivityOptions
+  { activityId :: Maybe ActivityId
+  , scheduleToCloseTimeout :: Maybe Duration
+  -- ^ Indicates how long the caller is willing to wait for local activity completion. Limits how
+  -- long retries will be attempted. When not specified defaults to the workflow execution
+  -- timeout (which may be unset).
+  , scheduleToStartTimeout :: Maybe Duration
+  -- ^ Limits time the local activity can idle internally before being executed. That can happen if
+  -- the worker is currently at max concurrent local activity executions. This timeout is always
+  -- non retryable as all a retry would achieve is to put it back into the same queue. Defaults
+  -- to `schedule_to_close_timeout` if not specified and that is set. Must be <=
+  -- `schedule_to_close_timeout` when set, otherwise, it will be clamped down.
+  , startToCloseTimeout :: Maybe Duration
+  -- ^ Maximum time the local activity is allowed to execute after the task is dispatched. This
+  -- timeout is always retryable. Either or both of `schedule_to_close_timeout` and this must be
+  -- specified. If set, this must be <= `schedule_to_close_timeout`, otherwise, it will be
+  -- clamped down.
+  , retryPolicy :: Maybe RetryPolicy
+  -- ^ Specify a retry policy for the local activity. By default local activities will be retried
+  -- indefinitely.
+  , localRetryThreshold :: Maybe Duration
+  -- ^ If the activity is retrying and backoff would exceed this value, lang will be told to
+  -- schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
+  -- core. Defaults to 1 minute.
+  , cancellationType :: ActivityCancellationType
+  -- ^ Defines how the workflow will wait (or not) for cancellation of the activity to be
+  -- confirmed. Lang should default this to `WAIT_CANCELLATION_COMPLETED`, even though proto
+  -- will default to `TRY_CANCEL` automatically.
+  , headers :: Map Text Payload
+  }
+  deriving stock (Show, Lift)
+
+
+{- |
+Default options for starting a local activity.
+
+@
+'StartLocalActivityOptions'
+  { activityId = 'Nothing'
+  , scheduleToCloseTimeout = 'Nothing'
+  , scheduleToStartTimeout = 'Nothing'
+  , startToCloseTimeout = 'Nothing'
+  , retryPolicy = 'Nothing'
+  , localRetryThreshold = 'Nothing'
+  , cancellationType = 'ActivityCancellationWaitCancellationCompleted'
+  , headers = 'mempty'
+  }
+@
+-}
+defaultStartLocalActivityOptions :: StartLocalActivityOptions
+defaultStartLocalActivityOptions =
+  StartLocalActivityOptions
+    { activityId = Nothing
+    , scheduleToCloseTimeout = Nothing
+    , scheduleToStartTimeout = Nothing
+    , startToCloseTimeout = Nothing
+    , retryPolicy = Nothing
+    , localRetryThreshold = Nothing
+    , cancellationType = ActivityCancellationWaitCancellationCompleted
+    , headers = mempty
+    }
+
+
 data ContinueAsNewOptions = ContinueAsNewOptions
   { taskQueue :: Maybe TaskQueue
   , runTimeout :: Maybe Duration

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -833,6 +833,483 @@ needsClient = do
           useClient (C.execute ActivityTimeoutInWorkflow (WorkflowId wfId) opts)
             `shouldReturn` False
 
+    describe "Local Activities" $ do
+      specify "should run a basic local activity" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Activity () Int)
+            localAct = provideCallStack $ provideActivity defaultCodec "basicLocalAct" $ pure 42
+
+            workflow :: MyWorkflow Int
+            workflow = do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5})
+
+            wf = W.provideWorkflow defaultCodec "basicLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient (C.execute wf.reference "basicLocalActivity" opts)
+            `shouldReturn` 42
+
+      specify "local activity with arguments" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Int -> Text -> Activity () Text)
+            localAct = provideCallStack $ provideActivity defaultCodec "localActWithArgs" $ \n msg ->
+              pure $ msg <> Text.pack (show n)
+
+            workflow :: MyWorkflow Text
+            workflow = do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5})
+                (3 :: Int)
+                ("hello" :: Text)
+
+            wf = W.provideWorkflow defaultCodec "localActivityWithArgsWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient (C.execute wf.reference "localActivityWithArgs" opts)
+            `shouldReturn` "hello3"
+
+      specify "local activity failure propagates to workflow" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Activity () ())
+            localAct = provideCallStack $ provideActivity defaultCodec "failingLocalAct" $ do
+              error "local activity failure"
+
+            workflow :: MyWorkflow ()
+            workflow = do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions
+                  { W.startToCloseTimeout = Just $ seconds 5
+                  , W.retryPolicy = Just $ W.defaultRetryPolicy { W.maximumAttempts = 1 }
+                  })
+
+            wf = W.provideWorkflow defaultCodec "failingLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 10
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          res <- Control.Exception.try @SomeException $ useClient (C.execute wf.reference "failingLocalActivity" opts)
+          res `shouldSatisfy` isLeft
+
+      specify "local activity with startLocalActivity and wait" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Activity () Text)
+            localAct = provideCallStack $ provideActivity defaultCodec "asyncLocalAct" $ pure "async-result"
+
+            workflow :: MyWorkflow Text
+            workflow = do
+              task <- W.startLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5})
+              W.wait task
+
+            wf = W.provideWorkflow defaultCodec "asyncLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient (C.execute wf.reference "asyncLocalActivity" opts)
+            `shouldReturn` "async-result"
+
+      specify "local activity retries on transient failure" $ \TestEnv {..} -> do
+        attemptRef <- newIORef (0 :: Int)
+        let localAct :: ProvidedActivity () (Activity () Int)
+            localAct = provideCallStack $ provideActivity defaultCodec "retryLocalAct" $ do
+              attempt <- liftIO $ atomicModifyIORef' attemptRef (\n -> (n + 1, n + 1))
+              if attempt < 3
+                then error "transient failure"
+                else pure attempt
+
+            workflow :: MyWorkflow Int
+            workflow = do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions
+                  { W.startToCloseTimeout = Just $ seconds 10
+                  , W.retryPolicy = Just $ W.defaultRetryPolicy
+                      { W.maximumAttempts = 5
+                      , W.initialInterval = milliseconds 100
+                      }
+                  })
+
+            wf = W.provideWorkflow defaultCodec "retryLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 30
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          useClient (C.execute wf.reference "retryLocalActivity" opts)
+            `shouldReturn` 3
+
+      specify "parallel local activities" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Text -> Activity () Text)
+            localAct = provideCallStack $ provideActivity defaultCodec "echoLocalAct" pure
+
+            workflow :: MyWorkflow [Text]
+            workflow = do
+              let laOpts = W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5}
+              t1 <- W.startLocalActivity localAct.reference laOpts ("one" :: Text)
+              t2 <- W.startLocalActivity localAct.reference laOpts ("two" :: Text)
+              t3 <- W.startLocalActivity localAct.reference laOpts ("three" :: Text)
+              r1 <- W.wait t1
+              r2 <- W.wait t2
+              r3 <- W.wait t3
+              pure [r1, r2, r3]
+
+            wf = W.provideWorkflow defaultCodec "parallelLocalActivitiesWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient (C.execute wf.reference "parallelLocalActivities" opts)
+            `shouldReturn` ["one", "two", "three"]
+
+      specify "serial local activities in same task" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Text -> Activity () Text)
+            localAct = provideCallStack $ provideActivity defaultCodec "serialEchoLocalAct" pure
+
+            workflow :: MyWorkflow [Text]
+            workflow = do
+              let laOpts = W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5}
+              r1 <- W.executeLocalActivity localAct.reference laOpts ("first" :: Text)
+              r2 <- W.executeLocalActivity localAct.reference laOpts ("second" :: Text)
+              r3 <- W.executeLocalActivity localAct.reference laOpts ("third" :: Text)
+              pure [r1, r2, r3]
+
+            wf = W.provideWorkflow defaultCodec "serialLocalActivitiesWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient (C.execute wf.reference "serialLocalActivities" opts)
+            `shouldReturn` ["first", "second", "third"]
+
+      specify "local activity cancellation" $ \TestEnv {..} -> do
+        blockForever <- newEmptyMVar
+        let localAct :: ProvidedActivity () (Activity () Int)
+            localAct = provideCallStack $ provideActivity defaultCodec "longRunningLocalAct" $ do
+              liftIO $ takeMVar blockForever
+              pure 0
+
+            workflow :: MyWorkflow Int
+            workflow = do
+              h <- W.startLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 10})
+              W.cancel (h :: W.Task Int)
+              W.wait h `Catch.catch` \(_ :: ActivityCancelled) -> pure 99
+
+            wf = W.provideWorkflow defaultCodec "cancelLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 15
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          useClient (C.execute wf.reference "cancelLocalActivity" opts)
+            `shouldReturn` 99
+
+      specify "local activity non-retryable error does not retry" $ \TestEnv {..} -> do
+        attemptRef <- newIORef (0 :: Int)
+        let localAct :: ProvidedActivity () (Activity () ())
+            localAct = provideCallStack $ provideActivity defaultCodec "nonRetryLocalAct" $
+              checkpoint annotateNonRetryableError $ do
+                _ <- liftIO $ atomicModifyIORef' attemptRef (\n -> (n + 1, n + 1))
+                error "non-retryable error"
+
+            workflow :: MyWorkflow ()
+            workflow = do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions
+                  { W.startToCloseTimeout = Just $ seconds 5
+                  , W.retryPolicy = Just $ W.defaultRetryPolicy { W.maximumAttempts = 5 }
+                  })
+
+            wf = W.provideWorkflow defaultCodec "nonRetryLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 10
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          res <- Control.Exception.try @SomeException $ useClient (C.execute wf.reference "nonRetryLocalActivity" opts)
+          res `shouldSatisfy` isLeft
+        finalAttempts <- readIORef attemptRef
+        finalAttempts `shouldBe` 1
+
+      specify "isLocal flag is set correctly" $ \TestEnv {..} -> do
+        let checkIsLocalAct :: ProvidedActivity () (Activity () Bool)
+            checkIsLocalAct = provideCallStack $ provideActivity defaultCodec "checkIsLocalAct" $ do
+              info <- askActivityInfo
+              pure info.isLocal
+
+            workflow :: MyWorkflow (Bool, Bool)
+            workflow = do
+              localResult <- W.executeLocalActivity
+                checkIsLocalAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5})
+              remoteResult <- W.executeActivity
+                checkIsLocalAct.reference
+                (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+              pure (localResult, remoteResult)
+
+            wf = W.provideWorkflow defaultCodec "isLocalFlagWf" workflow
+            conf = configure () (wf, activityDefinition checkIsLocalAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          useClient (C.execute wf.reference "isLocalFlag" opts)
+            `shouldReturn` (True, False)
+
+      specify "local activity timer backoff" $ \TestEnv {..} -> do
+        attemptRef <- newIORef (0 :: Int)
+        let localAct :: ProvidedActivity () (Activity () Int)
+            localAct = provideCallStack $ provideActivity defaultCodec "backoffLocalAct" $ do
+              attempt <- liftIO $ atomicModifyIORef' attemptRef (\n -> (n + 1, n + 1))
+              if attempt < 2
+                then error "retry me"
+                else pure attempt
+
+            workflow :: MyWorkflow Int
+            workflow = do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions
+                  { W.startToCloseTimeout = Just $ seconds 30
+                  , W.localRetryThreshold = Just $ milliseconds 1
+                  , W.retryPolicy = Just $ W.defaultRetryPolicy
+                      { W.maximumAttempts = 3
+                      , W.initialInterval = seconds 2
+                      }
+                  })
+
+            wf = W.provideWorkflow defaultCodec "backoffLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 60
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          useClient (C.execute wf.reference "backoffLocalActivity" opts)
+            `shouldReturn` 2
+
+      specify "local activity timeout configuration" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Activity () (Maybe Duration, Maybe Duration))
+            localAct = provideCallStack $ provideActivity defaultCodec "timeoutInfoLocalAct" $ do
+              info <- askActivityInfo
+              pure (info.startToCloseTimeout, info.scheduleToCloseTimeout)
+
+            workflowStcOnly :: MyWorkflow (Maybe Duration, Maybe Duration)
+            workflowStcOnly =
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5})
+
+            workflowS2cOnly :: MyWorkflow (Maybe Duration, Maybe Duration)
+            workflowS2cOnly =
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.scheduleToCloseTimeout = Just $ seconds 7})
+
+            workflowBoth :: MyWorkflow (Maybe Duration, Maybe Duration)
+            workflowBoth =
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions
+                  { W.startToCloseTimeout = Just $ seconds 3
+                  , W.scheduleToCloseTimeout = Just $ seconds 7
+                  })
+
+            wfStc = W.provideWorkflow defaultCodec "timeoutStcOnlyWf" workflowStcOnly
+            wfS2c = W.provideWorkflow defaultCodec "timeoutS2cOnlyWf" workflowS2cOnly
+            wfBoth = W.provideWorkflow defaultCodec "timeoutBothWf" workflowBoth
+            conf = configure () (wfStc, wfS2c, wfBoth, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  }
+          stcResult <- useClient (C.execute wfStc.reference "timeoutStcOnly" opts)
+          fst stcResult `shouldBe` Just (seconds 5)
+
+          s2cResult <- useClient (C.execute wfS2c.reference "timeoutS2cOnly" opts)
+          snd s2cResult `shouldBe` Just (seconds 7)
+
+          bothResult <- useClient (C.execute wfBoth.reference "timeoutBoth" opts)
+          fst bothResult `shouldBe` Just (seconds 3)
+          snd bothResult `shouldBe` Just (seconds 7)
+
+      specify "cancel local activity during DoBackoff timer" $ \TestEnv {..} -> do
+        attemptRef <- newIORef (0 :: Int)
+        let localAct :: ProvidedActivity () (Activity () ())
+            localAct = provideCallStack $ provideActivity defaultCodec "failForDoBackoffCancelAct" $ do
+              n <- liftIO $ atomicModifyIORef' attemptRef (\n -> (n + 1, n))
+              when (n < 5) $ error "retry me"
+
+            workflow :: MyWorkflow Int
+            workflow = do
+              h <- W.startLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions
+                  { W.startToCloseTimeout = Just $ seconds 30
+                  , W.retryPolicy = Just $ W.defaultRetryPolicy
+                      { W.maximumAttempts = 10
+                      , W.initialInterval = seconds 30
+                      }
+                  -- Tiny threshold forces DoBackoff after every failure, creating
+                  -- server-side timers that can be cancelled.
+                  , W.localRetryThreshold = Just $ milliseconds 1
+                  })
+              -- Wait long enough for the first attempt to fail and the DoBackoff
+              -- timer to be scheduled, then cancel.
+              W.sleep $ seconds 2
+              W.cancel (h :: W.Task ())
+              (W.wait h >> pure 0) `Catch.catch` \(_ :: ActivityCancelled) -> pure 77
+
+            wf = W.provideWorkflow defaultCodec "cancelDoBackoffLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 30
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          useClient (C.execute wf.reference "cancelDoBackoffLocalActivity" opts)
+            `shouldReturn` 77
+
+      specify "worker shutdown completes local activity gracefully" $ \TestEnv {..} -> do
+        activityStarted <- newEmptyMVar
+        activityCanFinish <- newEmptyMVar
+        let localAct :: ProvidedActivity () (Activity () Text)
+            localAct = provideCallStack $ provideActivity defaultCodec "shutdownLocalAct" $ do
+              liftIO $ putMVar activityStarted ()
+              liftIO $ takeMVar activityCanFinish
+              pure "completed-during-shutdown"
+
+            workflow :: MyWorkflow Text
+            workflow =
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 30})
+
+            wf = W.provideWorkflow defaultCodec "workerShutdownLocalActivityWf" workflow
+            conf = configure () (wf, activityDefinition localAct) $ do
+              baseConf
+        -- Start workflow in one worker, then shut down while activity is running.
+        -- The workflow should still complete because the activity finishes before
+        -- the shutdown grace period expires.
+        resultVar <- newEmptyMVar
+        withWorker conf $ do
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 30
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                  }
+          _ <- forkIO $ do
+            res <- useClient (C.execute wf.reference "workerShutdownLA" opts)
+            putMVar resultVar res
+          -- Wait until the activity has started executing
+          takeMVar activityStarted
+          -- Allow the activity to finish
+          putMVar activityCanFinish ()
+          -- Wait for the workflow result before the bracket-based shutdown
+          res <- takeMVar resultVar
+          res `shouldBe` "completed-during-shutdown"
+
+      specify "local activity replay works" $ \TestEnv {..} -> do
+        let localAct :: ProvidedActivity () (Text -> Activity () Text)
+            localAct = provideCallStack $ provideActivity defaultCodec "replayEchoLocalAct" pure
+
+            originalWorkflow :: W.ProvidedWorkflow (W.Workflow Text)
+            originalWorkflow = W.provideWorkflow defaultCodec "replay-local-activity-wf" $ provideCallStack $ do
+              W.executeLocalActivity
+                localAct.reference
+                (W.defaultStartLocalActivityOptions {W.startToCloseTimeout = Just $ seconds 5})
+                ("replayed" :: Text)
+
+            originalConf = provideCallStack $ configure () (testConf <> toDefinitions (activityDefinition localAct) <> toDefinitions originalWorkflow) baseConf
+
+        history <- withWorker originalConf $ do
+          uuid <- uuidText
+          let opts =
+                (C.startWorkflowOptions taskQueue)
+                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                  , C.timeouts = C.TimeoutOptions {C.runTimeout = Just $ seconds 10, C.executionTimeout = Nothing, C.taskTimeout = Nothing}
+                  }
+          useClient $ do
+            wfHandle <- C.start originalWorkflow (WorkflowId uuid) opts
+            C.waitWorkflowResult wfHandle
+            C.fetchHistory wfHandle
+
+        let replayConf = originalConf {payloadProcessor = sillyEncryptionPayloadProcessor}
+        replayResult <- runReplayHistory globalRuntime replayConf history
+        replayResult `shouldSatisfy` isRight
+
     describe "Args and return values" $ do
       specify "args should be passed to the workflow in the correct order" $ \TestEnv {..} -> do
         let testFn :: Int -> Text -> Bool -> MyWorkflow (Int, Text, Bool)


### PR DESCRIPTION
## Summary

- Implement local activity scheduling, execution, and retry handling (DoBackoff with server-side timers for deterministic replay)
- Add shared `IORef Bool` cancellation flag across retry attempts so cancelling a `Task` during a DoBackoff timer correctly raises `ActivityCancelled`
- Wire up `LocalActivityInput` / `scheduleLocalActivity` through the interceptor and OpenTelemetry layers
- Move `StartLocalActivityOptions` to `Temporal.Workflow.Types` to break a circular dependency

Public API: `startLocalActivity`, `executeLocalActivity`

## Test plan

15 integration tests added covering:
- [x] Basic execution, multi-arg, failure propagation
- [x] Async start+wait
- [x] Retry on transient failure
- [x] Parallel and serial execution
- [x] Cancellation (immediate + during DoBackoff timer)
- [x] Non-retryable error (single attempt)
- [x] `isLocal` flag verification
- [x] DoBackoff timer path
- [x] Timeout configuration propagation
- [x] Worker shutdown graceful completion
- [x] Replay (with PayloadProcessor parity requirement)

Full suite: 169 pass, 0 failures.

Resolves STAB-152
