### PR TITLE
feat(sdk): implement async activity completion

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -90,7 +90,6 @@ library:
   - Temporal.Activity.Definition
   - Temporal.Activity.Worker
   - Temporal.Client.Types
-  - Temporal.Client.AsyncActivity
   - Temporal.Client.Workflow
   - Temporal.Common
   - Temporal.Common.Async

--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -11,6 +11,7 @@ import Control.Monad.Logger
 import Control.Monad.Reader
 import Data.Bifunctor
 import Data.HashMap.Strict (HashMap)
+import Data.Maybe (isJust)
 import qualified Data.HashMap.Strict as HashMap
 import Data.ProtoLens
 import Data.Text (Text)
@@ -222,25 +223,28 @@ applyActivityTaskStart _tsk tt msg = do
             pure $
               defMessage
                 & C.taskToken .~ rawTaskToken tt
-                & C.result .~ case fromException err of
-                  Just (_cancelled :: ActivityCancelReason) ->
-                    defMessage
-                      & AR.cancelled
-                        .~ ( defMessage
-                              & AR.failure
-                                .~ ( defMessage
-                                      & F.message .~ "Activity cancelled"
-                                      & F.canceledFailureInfo
-                                        .~ ( defMessage
-                                              -- FIXME: provide some details if we have them
-                                              & F.details .~ defMessage
-                                           )
-                                   )
-                           )
-                  Nothing ->
-                    defMessage
-                      & AR.failed
-                        .~ (defMessage & AR.failure .~ enrichedApplicationFailure)
+                & C.result .~
+                  if isJust (fromException @CompleteAsync err)
+                    then defMessage & AR.willCompleteAsync .~ defMessage
+                    else case fromException err of
+                      Just (_cancelled :: ActivityCancelReason) ->
+                        defMessage
+                          & AR.cancelled
+                            .~ ( defMessage
+                                  & AR.failure
+                                    .~ ( defMessage
+                                          & F.message .~ "Activity cancelled"
+                                          & F.canceledFailureInfo
+                                            .~ ( defMessage
+                                                  -- FIXME: provide some details if we have them
+                                                  & F.details .~ defMessage
+                                               )
+                                       )
+                               )
+                      Nothing ->
+                        defMessage
+                          & AR.failed
+                            .~ (defMessage & AR.failure .~ enrichedApplicationFailure)
           Right ok -> do
             Logging.logDebug "Got activity result"
             ok' <- liftIO $ payloadProcessorEncode w.payloadProcessor ok

--- a/sdk/src/Temporal/Client/AsyncActivity.hs
+++ b/sdk/src/Temporal/Client/AsyncActivity.hs
@@ -1,29 +1,222 @@
-module Temporal.Client.AsyncActivity where
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE TypeApplications #-}
 
-import Control.Exception
+{- | Async activity completion client.
+
+When an activity calls 'Temporal.Activity.Worker.completeAsync', the worker
+signals that the activity will be completed out-of-band. This module provides
+the client-side API to complete, fail, heartbeat, or cancel such activities.
+
+Activities can be addressed either by 'TaskToken' (obtained from
+'Temporal.Activity.Types.taskToken' on 'ActivityInfo') or by ID
+(namespace + workflow ID + run ID + activity ID).
+-}
+module Temporal.Client.AsyncActivity (
+  -- * Client
+  AsyncCompletionClient (..),
+  asyncCompletionClient,
+  asyncCompletionClientWithProcessor,
+
+  -- * Token-based operations
+  complete,
+  Temporal.Client.AsyncActivity.fail,
+  heartbeat,
+  reportCancellation,
+
+  -- * ID-based operations
+  completeById,
+  failById,
+  heartbeatById,
+  reportCancellationById,
+) where
+
+import Control.Exception (throwIO)
+import Data.ProtoLens (defMessage)
+import Data.ProtoLens.Field (field)
+import qualified Data.Vector as V
+import Data.Function ((&))
+import Lens.Family2 ((.~))
+import Data.Text (Text)
 import Temporal.Common
-import Temporal.Core.Client
+import Temporal.Core.Client (Client)
+import qualified Temporal.Core.Client.WorkflowService as RPC
+import Temporal.Exception (ApplicationFailure, applicationFailureToFailureProto, coreRpcErrorToRpcError)
 import Temporal.Payload
 
 
----------------------------------------------------------------------------------
--- AsyncCompletionClient
+{- | Client for completing activities that signalled async completion.
 
--- | A client for asynchronous completion and heartbeating of Activities.
-data AsyncCompletionClient = AsyncCompletionClient Client
-
-
-complete :: AsyncCompletionClient -> TaskToken -> m ()
-complete = undefined
-
-
-fail :: AsyncCompletionClient -> TaskToken -> SomeException -> m ()
-fail = undefined
+Construct with 'asyncCompletionClient'.
+-}
+data AsyncCompletionClient = AsyncCompletionClient
+  { client :: !Client
+  , namespace :: !Namespace
+  , identity :: !Text
+  , payloadProcessor :: !PayloadProcessor
+  }
 
 
-heartbeat :: AsyncCompletionClient -> TaskToken -> [Payload] -> m ()
-heartbeat = undefined
+-- | Build an 'AsyncCompletionClient' from a raw gRPC 'Client', namespace, and caller identity.
+-- Uses the identity 'PayloadProcessor' (no encoding).
+asyncCompletionClient :: Client -> Namespace -> Text -> AsyncCompletionClient
+asyncCompletionClient c ns ident =
+  AsyncCompletionClient c ns ident (PayloadProcessor pure (pure . Right))
 
 
-reportCancellation :: AsyncCompletionClient -> TaskToken -> [Payload] -> m ()
-reportCancellation = undefined
+-- | Build an 'AsyncCompletionClient' with a custom 'PayloadProcessor'.
+asyncCompletionClientWithProcessor :: Client -> Namespace -> Text -> PayloadProcessor -> AsyncCompletionClient
+asyncCompletionClientWithProcessor = AsyncCompletionClient
+
+
+-- Token-based operations -------------------------------------------------------
+
+-- | Complete an async activity by task token with a result payload.
+complete :: AsyncCompletionClient -> TaskToken -> Payload -> IO ()
+complete c tok result = do
+  encoded <- payloadProcessorEncode c.payloadProcessor result
+  let req =
+        defMessage
+          & field @"taskToken" .~ rawTaskToken tok
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"result"
+            .~ ( defMessage
+                  & field @"vec'payloads" .~ V.singleton (convertToProtoPayload encoded)
+               )
+  res <- RPC.respondActivityTaskCompleted c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- | Fail an async activity by task token with an 'ApplicationFailure'.
+fail :: AsyncCompletionClient -> TaskToken -> ApplicationFailure -> IO ()
+fail c tok appFailure = do
+  let req =
+        defMessage
+          & field @"taskToken" .~ rawTaskToken tok
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"failure" .~ applicationFailureToFailureProto appFailure
+  res <- RPC.respondActivityTaskFailed c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- | Record a heartbeat for an async activity by task token.
+heartbeat :: AsyncCompletionClient -> TaskToken -> [Payload] -> IO ()
+heartbeat c tok details = do
+  let req =
+        defMessage
+          & field @"taskToken" .~ rawTaskToken tok
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"details"
+            .~ ( defMessage
+                  & field @"vec'payloads" .~ V.fromList (fmap convertToProtoPayload details)
+               )
+  res <- RPC.recordActivityTaskHeartbeat c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- | Report cancellation of an async activity by task token.
+reportCancellation :: AsyncCompletionClient -> TaskToken -> [Payload] -> IO ()
+reportCancellation c tok details = do
+  let req =
+        defMessage
+          & field @"taskToken" .~ rawTaskToken tok
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"details"
+            .~ ( defMessage
+                  & field @"vec'payloads" .~ V.fromList (fmap convertToProtoPayload details)
+               )
+  res <- RPC.respondActivityTaskCanceled c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- ID-based operations ----------------------------------------------------------
+
+-- | Complete an async activity by workflow\/activity ID.
+completeById :: AsyncCompletionClient -> WorkflowId -> RunId -> ActivityId -> Payload -> IO ()
+completeById c wfId runId actId result = do
+  encoded <- payloadProcessorEncode c.payloadProcessor result
+  let req =
+        defMessage
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"workflowId" .~ rawWorkflowId wfId
+          & field @"runId" .~ rawRunId runId
+          & field @"activityId" .~ rawActivityId actId
+          & field @"result"
+            .~ ( defMessage
+                  & field @"vec'payloads" .~ V.singleton (convertToProtoPayload encoded)
+               )
+  res <- RPC.respondActivityTaskCompletedById c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- | Fail an async activity by workflow\/activity ID.
+failById :: AsyncCompletionClient -> WorkflowId -> RunId -> ActivityId -> ApplicationFailure -> IO ()
+failById c wfId runId actId appFailure = do
+  let req =
+        defMessage
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"workflowId" .~ rawWorkflowId wfId
+          & field @"runId" .~ rawRunId runId
+          & field @"activityId" .~ rawActivityId actId
+          & field @"failure" .~ applicationFailureToFailureProto appFailure
+  res <- RPC.respondActivityTaskFailedById c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- | Record a heartbeat for an async activity by workflow\/activity ID.
+heartbeatById :: AsyncCompletionClient -> WorkflowId -> RunId -> ActivityId -> [Payload] -> IO ()
+heartbeatById c wfId runId actId details = do
+  let req =
+        defMessage
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"workflowId" .~ rawWorkflowId wfId
+          & field @"runId" .~ rawRunId runId
+          & field @"activityId" .~ rawActivityId actId
+          & field @"details"
+            .~ ( defMessage
+                  & field @"vec'payloads" .~ V.fromList (fmap convertToProtoPayload details)
+               )
+  res <- RPC.recordActivityTaskHeartbeatById c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()
+
+
+-- | Report cancellation of an async activity by workflow\/activity ID.
+reportCancellationById :: AsyncCompletionClient -> WorkflowId -> RunId -> ActivityId -> [Payload] -> IO ()
+reportCancellationById c wfId runId actId details = do
+  let req =
+        defMessage
+          & field @"namespace" .~ rawNamespace c.namespace
+          & field @"identity" .~ c.identity
+          & field @"workflowId" .~ rawWorkflowId wfId
+          & field @"runId" .~ rawRunId runId
+          & field @"activityId" .~ rawActivityId actId
+          & field @"details"
+            .~ ( defMessage
+                  & field @"vec'payloads" .~ V.fromList (fmap convertToProtoPayload details)
+               )
+  res <- RPC.respondActivityTaskCanceledById c.client req
+  case res of
+    Left err -> throwIO $ coreRpcErrorToRpcError err
+    Right _ -> pure ()

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -22,6 +22,7 @@ library
       Temporal.Bundle
       Temporal.Bundle.TH
       Temporal.Client
+      Temporal.Client.AsyncActivity
       Temporal.Client.Namespace
       Temporal.Client.Schedule
       Temporal.Client.TestService
@@ -48,7 +49,6 @@ library
       Temporal.Activity.Definition
       Temporal.Activity.Worker
       Temporal.Client.Types
-      Temporal.Client.AsyncActivity
       Temporal.Client.Workflow
       Temporal.Common
       Temporal.Common.Async

--- a/sdk/test/AsyncCompletionSpec.hs
+++ b/sdk/test/AsyncCompletionSpec.hs
@@ -1,0 +1,250 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module AsyncCompletionSpec where
+
+import Control.Concurrent.MVar
+import Control.Exception (SomeException)
+import Control.Monad.IO.Class (liftIO)
+import qualified Control.Monad.Catch as Catch
+import Data.Text (Text)
+import Temporal.Activity
+import qualified Temporal.Client as C
+import qualified Temporal.Client.AsyncActivity as Async
+import Temporal.Duration
+import Temporal.Exception
+import Temporal.Payload
+import Temporal.Worker (configure)
+import qualified Temporal.Workflow as W
+import Test.Hspec
+import TestHelpers
+
+
+spec :: Spec
+spec = withTestServer_ tests
+
+
+asyncAct :: MVar TaskToken -> Activity () Text
+asyncAct tokenVar = do
+  info <- askActivityInfo
+  liftIO $ putMVar tokenVar info.taskToken
+  completeAsync
+  pure "never returned"
+
+
+asyncActInfo :: MVar ActivityInfo -> Activity () Text
+asyncActInfo infoVar = do
+  info <- askActivityInfo
+  liftIO $ putMVar infoVar info
+  completeAsync
+  pure "never returned"
+
+
+actOpts :: W.StartActivityOptions
+actOpts = W.defaultStartActivityOptions $ W.StartToClose $ seconds 30
+
+
+actOptsNoRetry :: W.StartActivityOptions
+actOptsNoRetry =
+  actOpts {W.retryPolicy = Just W.defaultRetryPolicy {W.maximumAttempts = 1}}
+
+
+actOptsHeartbeat :: W.StartActivityOptions
+actOptsHeartbeat =
+  actOpts {W.heartbeatTimeout = Just (seconds 5)}
+
+
+tests :: SpecWith TestEnv
+tests = describe "Async Activity Completion" $ do
+  describe "Complete by token" $ do
+    specify "Activity can complete asynchronously" $ \TestEnv {..} -> do
+      tokenVar <- newEmptyMVar
+      let actDef = provideActivity defaultCodec "asyncCompleteAct" (asyncAct tokenVar)
+          workflow :: MyWorkflow Text
+          workflow = do
+            h <- W.startActivity actDef.reference actOpts
+            W.wait (h :: W.Task Text)
+          wf = W.provideWorkflow defaultCodec "asyncCompleteWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        wfHandle <- useClient $ C.start wf.reference "asyncComplete" opts
+        tok <- takeMVar tokenVar
+        let asyncClient = Async.asyncCompletionClientWithProcessor coreClient (W.Namespace "default") "test-identity" sillyEncryptionPayloadProcessor
+            resultPayload = encodeJSON ("async-result" :: Text)
+        Async.complete asyncClient tok resultPayload
+        result <- useClient $ C.waitWorkflowResult wfHandle
+        result `shouldBe` "async-result"
+
+    specify "Activity can complete asynchronously by ID" $ \TestEnv {..} -> do
+      infoVar <- newEmptyMVar
+      let actDef = provideActivity defaultCodec "asyncCompleteByIdAct" (asyncActInfo infoVar)
+          workflow :: MyWorkflow Text
+          workflow = do
+            h <- W.startActivity actDef.reference actOpts
+            W.wait (h :: W.Task Text)
+          wf = W.provideWorkflow defaultCodec "asyncCompleteByIdWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        wfHandle <- useClient $ C.start wf.reference "asyncCompleteById" opts
+        info <- takeMVar infoVar
+        let asyncClient = Async.asyncCompletionClientWithProcessor coreClient (W.Namespace "default") "test-identity" sillyEncryptionPayloadProcessor
+            resultPayload = encodeJSON ("async-by-id-result" :: Text)
+        Async.completeById asyncClient info.workflowId info.runId info.activityId resultPayload
+        result <- useClient $ C.waitWorkflowResult wfHandle
+        result `shouldBe` "async-by-id-result"
+
+  describe "Fail by token" $ do
+    specify "Activity can fail asynchronously" $ \TestEnv {..} -> do
+      tokenVar <- newEmptyMVar
+      let actDef = provideActivity defaultCodec "asyncFailAct" (asyncAct tokenVar)
+          workflow :: MyWorkflow Text
+          workflow = do
+            h <- W.startActivity actDef.reference actOptsNoRetry
+            W.wait (h :: W.Task Text)
+          wf = W.provideWorkflow defaultCodec "asyncFailWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        wfHandle <- useClient $ C.start wf.reference "asyncFail" opts
+        tok <- takeMVar tokenVar
+        let asyncClient = Async.asyncCompletionClient coreClient (W.Namespace "default") "test-identity"
+            appFailure =
+              ApplicationFailure
+                { type' = "AsyncTestFailure"
+                , message = "deliberately failed async"
+                , nonRetryable = True
+                , details = []
+                , stack = ""
+                , nextRetryDelay = Nothing
+                }
+        Async.fail asyncClient tok appFailure
+        res <- Catch.try @IO @WorkflowExecutionClosed $ useClient (C.waitWorkflowResult @Text wfHandle)
+        res `shouldSatisfy` isLeft
+
+    specify "Activity can fail asynchronously by ID" $ \TestEnv {..} -> do
+      infoVar <- newEmptyMVar
+      let actDef = provideActivity defaultCodec "asyncFailByIdAct" (asyncActInfo infoVar)
+          workflow :: MyWorkflow Text
+          workflow = do
+            h <- W.startActivity actDef.reference actOptsNoRetry
+            W.wait (h :: W.Task Text)
+          wf = W.provideWorkflow defaultCodec "asyncFailByIdWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        wfHandle <- useClient $ C.start wf.reference "asyncFailById" opts
+        info <- takeMVar infoVar
+        let asyncClient = Async.asyncCompletionClient coreClient (W.Namespace "default") "test-identity"
+            appFailure =
+              ApplicationFailure
+                { type' = "AsyncTestFailure"
+                , message = "deliberately failed async by ID"
+                , nonRetryable = True
+                , details = []
+                , stack = ""
+                , nextRetryDelay = Nothing
+                }
+        Async.failById asyncClient info.workflowId info.runId info.activityId appFailure
+        res <- Catch.try @IO @WorkflowExecutionClosed $ useClient (C.waitWorkflowResult @Text wfHandle)
+        res `shouldSatisfy` isLeft
+
+  describe "Heartbeat and cancel" $ do
+    specify "Activity can heartbeat with AsyncCompletionClient" $ \TestEnv {..} -> do
+      tokenVar <- newEmptyMVar
+      let actDef = provideActivity defaultCodec "asyncHeartbeatAct" (asyncAct tokenVar)
+          workflow :: MyWorkflow Text
+          workflow = do
+            h <- W.startActivity actDef.reference actOptsHeartbeat
+            W.wait (h :: W.Task Text)
+          wf = W.provideWorkflow defaultCodec "asyncHeartbeatWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        wfHandle <- useClient $ C.start wf.reference "asyncHeartbeat" opts
+        tok <- takeMVar tokenVar
+        let asyncClient = Async.asyncCompletionClientWithProcessor coreClient (W.Namespace "default") "test-identity" sillyEncryptionPayloadProcessor
+        Async.heartbeat asyncClient tok []
+        Async.complete asyncClient tok (encodeJSON ("heartbeat-ok" :: Text))
+        result <- useClient $ C.waitWorkflowResult wfHandle
+        result `shouldBe` "heartbeat-ok"
+
+    specify "Activity can heartbeat by ID with AsyncCompletionClient" $ \TestEnv {..} -> do
+      infoVar <- newEmptyMVar
+      let actDef = provideActivity defaultCodec "asyncHeartbeatByIdAct" (asyncActInfo infoVar)
+          workflow :: MyWorkflow Text
+          workflow = do
+            h <- W.startActivity actDef.reference actOptsHeartbeat
+            W.wait (h :: W.Task Text)
+          wf = W.provideWorkflow defaultCodec "asyncHeartbeatByIdWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        wfHandle <- useClient $ C.start wf.reference "asyncHeartbeatById" opts
+        info <- takeMVar infoVar
+        let asyncClient = Async.asyncCompletionClientWithProcessor coreClient (W.Namespace "default") "test-identity" sillyEncryptionPayloadProcessor
+        Async.heartbeatById asyncClient info.workflowId info.runId info.activityId []
+        Async.completeById asyncClient info.workflowId info.runId info.activityId (encodeJSON ("heartbeat-by-id-ok" :: Text))
+        result <- useClient $ C.waitWorkflowResult wfHandle
+        result `shouldBe` "heartbeat-by-id-ok"
+
+  describe "Non-existing activity errors" $ do
+    let mkAsyncClient env = Async.asyncCompletionClient env.coreClient (W.Namespace "default") "test"
+        bogusTok = TaskToken "bogus-token-does-not-exist"
+        bogusWfId = W.WorkflowId "nonexistent-wf"
+        bogusRunId = W.RunId "nonexistent-run"
+        bogusActId = W.ActivityId "nonexistent-act"
+
+    specify "Non existing activity async completion throws" $ \env -> do
+      let ac = mkAsyncClient env
+          p = encodeJSON ("x" :: Text)
+      res <- Catch.try @IO @SomeException (Async.complete ac bogusTok p)
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async completion by ID throws" $ \env -> do
+      let ac = mkAsyncClient env
+          p = encodeJSON ("x" :: Text)
+      res <- Catch.try @IO @SomeException (Async.completeById ac bogusWfId bogusRunId bogusActId p)
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async failure throws" $ \env -> do
+      let ac = mkAsyncClient env
+          appF = ApplicationFailure "T" "msg" True [] "" Nothing
+      res <- Catch.try @IO @SomeException (Async.fail ac bogusTok appF)
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async failure by ID throws" $ \env -> do
+      let ac = mkAsyncClient env
+          appF = ApplicationFailure "T" "msg" True [] "" Nothing
+      res <- Catch.try @IO @SomeException (Async.failById ac bogusWfId bogusRunId bogusActId appF)
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async cancellation throws" $ \env -> do
+      let ac = mkAsyncClient env
+      res <- Catch.try @IO @SomeException (Async.reportCancellation ac bogusTok [])
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async cancellation by ID throws" $ \env -> do
+      let ac = mkAsyncClient env
+      res <- Catch.try @IO @SomeException (Async.reportCancellationById ac bogusWfId bogusRunId bogusActId [])
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async heartbeat throws" $ \env -> do
+      let ac = mkAsyncClient env
+      res <- Catch.try @IO @SomeException (Async.heartbeat ac bogusTok [])
+      res `shouldSatisfy` isLeft
+
+    specify "Non existing activity async heartbeat by ID throws" $ \env -> do
+      let ac = mkAsyncClient env
+      res <- Catch.try @IO @SomeException (Async.heartbeatById ac bogusWfId bogusRunId bogusActId [])
+      res `shouldSatisfy` isLeft
+
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False

--- a/sdk/test/PendingFeaturesSpec.hs
+++ b/sdk/test/PendingFeaturesSpec.hs
@@ -17,20 +17,6 @@ spec = do
     it "lazy client initialization" $ const pending
     it "cloud client authentication" $ const pending
 
-  describe "Async Activity Completion (Py/TS)" $ do
-    it "complete async activity by token" $ const pending
-    it "fail async activity by token" $ const pending
-    it "heartbeat async activity by token" $ const pending
-    it "cancel async activity by token" $ const pending
-    it "complete async activity by ID" $ const pending
-    it "fail async activity by ID" $ const pending
-    it "non-existing activity errors (complete)" $ const pending
-    it "non-existing activity errors (fail)" $ const pending
-    it "non-existing activity errors (heartbeat)" $ const pending
-    it "non-existing activity errors (cancel)" $ const pending
-    it "async completion with activity env access" $ const pending
-    it "async completion cancellation flow" $ const pending
-    it "async completion failure flow" $ const pending
 
   describe "Worker Tuner (Py/TS)" $ do
     it "configure slot supplier" $ const pending


### PR DESCRIPTION
## Summary

- Rewrite `Temporal.Client.AsyncActivity` from stubs to full implementation: token-based (`complete`, `fail`, `heartbeat`, `reportCancellation`) and ID-based (`completeById`, `failById`, `heartbeatById`, `reportCancellationById`) operations
- Fix `Activity.Worker` to recognize `CompleteAsync` exceptions and send `willCompleteAsync` result instead of treating them as failures
- Add `asyncCompletionClientWithProcessor` for matching worker's `PayloadProcessor`
- 14 tests in `AsyncCompletionSpec`: complete/fail by token and ID, heartbeat flows, and non-existing activity error handling