### PR TITLE
remove extraneous 'eprintln!' calls

### DIFF
--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -322,7 +322,6 @@ where
     match res {
         Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
         Err(err) => {
-            eprintln!("Error: {:?}", err);
             Err(CRPCError::c_repr_of(RPCError {
                 code: err.code() as u32,
                 message: err.message().to_owned(),

--- a/core/rust/src/worker.rs
+++ b/core/rust/src/worker.rs
@@ -604,7 +604,6 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
                     unsafe { *result_slot = Box::into_raw(Box::new(worker_ref)) };
                 }
                 Err(worker_error) => {
-                    eprintln!("Error: {:?}", worker_error);
                     unsafe {
                         *error_slot = CWorkerError::c_repr_of(worker_error)
                             .unwrap()
@@ -614,7 +613,6 @@ pub unsafe extern "C" fn hs_temporal_new_worker(
             }
         }
         Err(worker_error) => {
-            eprintln!("Error: {:?}", worker_error);
             unsafe {
                 *error_slot = CWorkerError::c_repr_of(worker_error)
                     .unwrap()


### PR DESCRIPTION
## description

these calls can be useful for debugging in development, but in all cases they were redundant with respect to the structured error information passed across the FFI boundary