### PR TITLE
add a watchdog timer to the activity shutdown path

### DIFF
--- a/core/src/Temporal/Core/Worker.hs
+++ b/core/src/Temporal/Core/Worker.hs
@@ -480,6 +480,7 @@ data WorkerConfig = WorkerConfig
   , maxActivitiesPerSecond :: Maybe Double
   , maxTaskQueueActivitiesPerSecond :: Maybe Double
   , gracefulShutdownPeriodMillis :: Word64
+  , fatalShutdownPeriodMillis :: Maybe Word64
   , nondeterminismAsWorkflowFail :: Bool
   , nondeterminismAsWorkflowFailForTypes :: [Text]
   , tuner :: Maybe TunerConfig
@@ -512,6 +513,7 @@ defaultWorkerConfig =
     , maxActivitiesPerSecond = Nothing
     , maxTaskQueueActivitiesPerSecond = Nothing
     , gracefulShutdownPeriodMillis = 0
+    , fatalShutdownPeriodMillis = Nothing
     , nondeterminismAsWorkflowFail = False
     , nondeterminismAsWorkflowFailForTypes = []
     , tuner = Nothing

--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -12,9 +12,11 @@ import Control.Monad.Reader
 import Data.Bifunctor
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
+import Data.Maybe (catMaybes)
 import Data.ProtoLens
 import Data.Text (Text)
 import qualified Data.Text as T
+import GHC.Conc.Sync (threadLabel)
 import Lens.Family2
 import qualified ListT
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as P
@@ -54,12 +56,25 @@ data ActivityWorker env = ActivityWorker
 
 notifyShutdown :: MonadUnliftIO m => ActivityWorker env -> m ()
 notifyShutdown worker = do
-  let shutdownGracePeriod = fromIntegral (Core.gracefulShutdownPeriodMillis $ Core.getWorkerConfig worker.workerCore)
-  -- TODO logging here
-  when (shutdownGracePeriod > 0) $ do
+  let cfg = Core.getWorkerConfig worker.workerCore
+      shutdownGracePeriod = fromIntegral (Core.gracefulShutdownPeriodMillis cfg)
+      fatalShutdownPeriod = Core.fatalShutdownPeriodMillis cfg
+  when (shutdownGracePeriod > 0) $
     threadDelay (shutdownGracePeriod * 1000)
   running <- liftIO $ ListT.toList $ StmMap.listTNonAtomic $ worker.runningActivities
-  forConcurrently_ running $ \thread -> cancelWith (snd thread) WorkerShutdown
+  results <- forConcurrently running $ \(_, thread) -> do
+    -- If a fatal shutdown period was given, set up a watchdog to kill the
+    -- cancellation thread if it hasn't returned within that time limit.
+    let watchdog = case fatalShutdownPeriod of
+          Nothing -> fmap Just
+          Just t -> UnliftIO.timeout (fromIntegral t * 1000)
+    result <- watchdog (cancelWith thread WorkerShutdown)
+    case result of
+      Just () -> pure Nothing
+      Nothing -> liftIO $ threadLabel (asyncThreadId thread)
+  let unterminated = catMaybes results
+  unless (null unterminated) $
+    throwIO $ ActivityShutdownTimeout unterminated
 
 
 newtype ActivityWorkerM env m a = ActivityWorkerM {unActivityWorkerM :: ReaderT (ActivityWorker env) m a}

--- a/sdk/src/Temporal/Exception.hs
+++ b/sdk/src/Temporal/Exception.hs
@@ -37,6 +37,9 @@ module Temporal.Exception (
   CompleteAsync (..),
   ActivityCancelReason (..),
 
+  -- * Worker exceptions
+  ActivityShutdownTimeout (..),
+
   -- * Annotations for errors
   NonRetryableError (..),
   annotateNonRetryableError,
@@ -498,6 +501,24 @@ data ActivityCancelReason
 instance Exception ActivityCancelReason where
   toException = asyncExceptionToException
   fromException = asyncExceptionFromException
+
+
+{- | Thrown from the worker shutdown path when one or more activity threads fail to
+terminate within the configured fatal shutdown period after being sent 'WorkerShutdown'.
+The payload lists the labels of the threads that were still alive when the worker
+abandoned the wait.
+
+A common cause is user activity code swallowing async exceptions (e.g. a bare
+@catch \@SomeException@ without rethrowing) or blocking in a non-interruptible
+way (@uninterruptibleMask@, non-interruptible FFI calls).
+-}
+newtype ActivityShutdownTimeout = ActivityShutdownTimeout
+  { unterminatedThreadLabels :: [String]
+  }
+  deriving stock (Show)
+
+
+instance Exception ActivityShutdownTimeout
 
 
 applicationFailureToException :: (Exception e, ToApplicationFailure e) => e -> SomeException

--- a/sdk/src/Temporal/Worker.hs
+++ b/sdk/src/Temporal/Worker.hs
@@ -86,6 +86,7 @@ module Temporal.Worker (
   setMaxActivitiesPerSecond,
   setMaxTaskQueueActivitiesPerSecond,
   setGracefulShutdownPeriodMillis,
+  setFatalShutdownPeriodMillis,
   addInterceptors,
   setPayloadProcessor,
   addNexusServiceHandler,
@@ -467,6 +468,24 @@ setGracefulShutdownPeriodMillis :: Word64 -> ConfigM actEnv ()
 setGracefulShutdownPeriodMillis n = modifyCore $ \conf ->
   conf
     { Core.gracefulShutdownPeriodMillis = n
+    }
+
+
+{- | Optional deadline after which an activity thread that failed to respect
+'WorkerShutdown' is abandoned by the shutdown coordinator.
+
+When this deadline expires for one or more threads, 'shutdown' will raise
+'ActivityShutdownTimeout' containing the labels of the threads that were
+still alive. The process itself can then exit, and the GHC runtime will
+tear the leaked threads down with it.
+
+Defaults to 'Nothing', which blocks indefinitely waiting for activities to
+shut down.
+-}
+setFatalShutdownPeriodMillis :: Maybe Word64 -> ConfigM actEnv ()
+setFatalShutdownPeriodMillis n = modifyCore $ \conf ->
+  conf
+    { Core.fatalShutdownPeriodMillis = n
     }
 
 
@@ -921,8 +940,10 @@ waitWorkerSTM Temporal.Worker.Worker {workerType, workerWorkflowLoop, workerActi
     Core.SReplay -> waitSTM workerWorkflowLoop
 
 
-{- | Shut down a worker. This will initiate a graceful shutdown of the worker, waiting for all
-in-flight tasks to complete before finalizing the shutdown.
+{- | Shut down a worker.
+
+This will initiate a graceful shutdown of the worker, waiting for all in-flight
+tasks to complete before finalizing the shutdown.
 -}
 shutdown :: (MonadUnliftIO m) => Temporal.Worker.Worker actEnv -> m ()
 shutdown worker@Temporal.Worker.Worker {workerCore, workerTracer, workerType, workerActivityWorker} = OT.inSpan workerTracer "shutdown" defaultSpanArguments $ UnliftIO.mask $ \restore -> do

--- a/sdk/test/ActivitySpec.hs
+++ b/sdk/test/ActivitySpec.hs
@@ -1,6 +1,8 @@
 module ActivitySpec where
 
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import qualified Control.Exception as E
 import Control.Exception (SomeException)
 import Control.Exception.Annotated (checkpoint)
 import Control.Monad.IO.Class (liftIO)
@@ -22,7 +24,7 @@ import qualified Temporal.Client as C
 import Temporal.Duration
 import Temporal.Exception hiding (activityId)
 import Temporal.Payload
-import Temporal.Worker (configure, setLogger, setNamespace, setTaskQueue)
+import Temporal.Worker (configure, setFatalShutdownPeriodMillis, setLogger, setNamespace, setTaskQueue)
 import Temporal.Workflow (StartActivityOptions(activityId, retryPolicy, cancellationType, heartbeatTimeout))
 import qualified Temporal.Workflow as W
 import Test.Hspec
@@ -30,7 +32,9 @@ import TestHelpers
 
 
 spec :: Spec
-spec = withTestServer_ tests
+spec = do
+  withTestServer_ tests
+  withTestServer_ shutdownTests
 
 
 tests :: SpecWith TestEnv
@@ -729,3 +733,39 @@ tests = describe "Activities" $ do
         let opts = defaultStartOptsWithTimeout taskQueue (seconds 15)
         useClient (C.execute wf.reference "waitCancelAct" opts)
           `shouldReturn` "cancelled"
+
+shutdownTests :: SpecWith TestEnv
+shutdownTests = do
+  describe "Worker shutdown" $ do
+    specify "shutdown raises ActivityShutdownTimeout when an activity swallows async exceptions" $ \TestEnv {..} -> do
+      started <- newEmptyMVar
+      blocked <- newEmptyMVar
+      let act :: Activity () ()
+          act = liftIO $ do
+            putMVar started ()
+            -- Swallow *every* async exception — the worker sends at least two
+            -- during shutdown (one via applyActivityTaskCancel from Rust Core,
+            -- one via notifyShutdown). Poll `blocked` so the test can release
+            -- this thread cleanly once it has verified the timeout.
+            let loop = do
+                  done <- E.try @SomeException (takeMVar blocked)
+                  case done of
+                    Right () -> pure ()
+                    _ -> loop
+            loop
+          actDef = provideActivity defaultCodec "unkillableAct" act
+          workflow :: MyWorkflow ()
+          workflow = W.executeActivity actDef.reference
+            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 30)
+          wf = W.provideWorkflow defaultCodec "unkillableActWf" workflow
+          conf = configure () (wf, actDef) $ do
+            baseConf
+            setFatalShutdownPeriodMillis (Just 200)
+
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 60)
+          run = withWorker conf $ do
+            _ <- useClient (C.start wf.reference "unkillableActWf" opts)
+            takeMVar started
+      run `shouldThrow` \case
+        ActivityShutdownTimeout labels -> not (null labels)
+      putMVar blocked ()


### PR DESCRIPTION
## description

activities can provide pathological behavior, including loops that swallow the async exceptions we depend on for task cancellation.

we should provide a watchdog that can ensure the Temporal runtime loop will terminate, even if that termination is unclean, in accordance with a user's requested fatal timeout period.