### PR TITLE
chore: update 'sdk-rust'

### DIFF
--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -134,6 +134,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,9 +273,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -258,11 +283,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -272,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -303,37 +327,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -2344,6 +2337,7 @@ dependencies = [
 name = "temporal_bridge"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "ffi-convert",
  "libc",
@@ -2366,14 +2360,14 @@ dependencies = [
 [[package]]
 name = "temporalio-client"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#9a87ebf7260c3594675ffed83a3728d2cd96e912"
+source = "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#43d582b57fbc63d858a35f11ebfee193bda00834"
 dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
  "base64",
+ "bon",
  "bytes",
- "derive_builder",
  "derive_more",
  "dyn-clone",
  "futures-retry",
@@ -2398,12 +2392,12 @@ dependencies = [
 [[package]]
 name = "temporalio-common"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#9a87ebf7260c3594675ffed83a3728d2cd96e912"
+source = "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#43d582b57fbc63d858a35f11ebfee193bda00834"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
- "derive_builder",
+ "bon",
  "derive_more",
  "opentelemetry",
  "prost",
@@ -2425,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "temporalio-macros"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#9a87ebf7260c3594675ffed83a3728d2cd96e912"
+source = "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#43d582b57fbc63d858a35f11ebfee193bda00834"
 dependencies = [
  "derive_more",
  "proc-macro2",
@@ -2436,15 +2430,15 @@ dependencies = [
 [[package]]
 name = "temporalio-sdk-core"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#9a87ebf7260c3594675ffed83a3728d2cd96e912"
+source = "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#43d582b57fbc63d858a35f11ebfee193bda00834"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bon",
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
  "dashmap",
- "derive_builder",
  "derive_more",
  "enum-iterator",
  "enum_dispatch",

--- a/core/rust/Cargo.nix
+++ b/core/rust/Cargo.nix
@@ -463,6 +463,73 @@ rec {
         };
         resolvedDefaultFeatures = [ "std" ];
       };
+      "bon" = rec {
+        crateName = "bon";
+        version = "3.9.1";
+        edition = "2021";
+        sha256 = "1zmj96nj080arzvy35h3wxza2sygp7gi1hsk6djywxh6an9bwzgl";
+        dependencies = [
+          {
+            name = "bon-macros";
+            packageId = "bon-macros";
+          }
+          {
+            name = "rustversion";
+            packageId = "rustversion";
+          }
+        ];
+        features = {
+          "alloc" = [ "bon-macros/alloc" ];
+          "default" = [ "std" ];
+          "experimental-generics-setters" = [ "bon-macros/experimental-generics-setters" ];
+          "experimental-overwritable" = [ "bon-macros/experimental-overwritable" ];
+          "implied-bounds" = [ "bon-macros/implied-bounds" ];
+          "std" = [ "bon-macros/std" "alloc" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "default" "implied-bounds" "std" ];
+      };
+      "bon-macros" = rec {
+        crateName = "bon-macros";
+        version = "3.9.1";
+        edition = "2021";
+        sha256 = "0z66ygzjyr4ivp3mzn2y98yhs5yh2qnri7f2f99jvd7fd88x76si";
+        procMacro = true;
+        libName = "bon_macros";
+        dependencies = [
+          {
+            name = "darling";
+            packageId = "darling";
+          }
+          {
+            name = "ident_case";
+            packageId = "ident_case";
+          }
+          {
+            name = "prettyplease";
+            packageId = "prettyplease";
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "rustversion";
+            packageId = "rustversion";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+            features = [ "full" "visit-mut" "visit" ];
+          }
+        ];
+        features = {
+        };
+        resolvedDefaultFeatures = [ "alloc" "default" "implied-bounds" "std" ];
+      };
       "bumpalo" = rec {
         crateName = "bumpalo";
         version = "3.20.2";
@@ -749,9 +816,9 @@ rec {
       };
       "darling" = rec {
         crateName = "darling";
-        version = "0.20.11";
+        version = "0.23.0";
         edition = "2021";
-        sha256 = "1vmlphlrlw4f50z16p4bc9p5qwdni1ba95qmxfrrmzs6dh8lczzw";
+        sha256 = "179fj6p6ajw4dnkrik51wjhifxwy02x5zhligyymcb905zd17bi5";
         authors = [
           "Ted Driggs <ted.driggs@outlook.com>"
         ];
@@ -768,23 +835,20 @@ rec {
         features = {
           "default" = [ "suggestions" ];
           "diagnostics" = [ "darling_core/diagnostics" ];
+          "serde" = [ "darling_core/serde" ];
           "suggestions" = [ "darling_core/suggestions" ];
         };
         resolvedDefaultFeatures = [ "default" "suggestions" ];
       };
       "darling_core" = rec {
         crateName = "darling_core";
-        version = "0.20.11";
+        version = "0.23.0";
         edition = "2021";
-        sha256 = "0bj1af6xl4ablnqbgn827m43b8fiicgv180749f5cphqdmcvj00d";
+        sha256 = "1c033vrks38vpw8kwgd5w088dsr511kfz55n9db56prkgh7sarcq";
         authors = [
           "Ted Driggs <ted.driggs@outlook.com>"
         ];
         dependencies = [
-          {
-            name = "fnv";
-            packageId = "fnv";
-          }
           {
             name = "ident_case";
             packageId = "ident_case";
@@ -809,6 +873,7 @@ rec {
           }
         ];
         features = {
+          "serde" = [ "dep:serde" ];
           "strsim" = [ "dep:strsim" ];
           "suggestions" = [ "strsim" ];
         };
@@ -816,9 +881,9 @@ rec {
       };
       "darling_macro" = rec {
         crateName = "darling_macro";
-        version = "0.20.11";
+        version = "0.23.0";
         edition = "2021";
-        sha256 = "1bbfbc2px6sj1pqqq97bgqn6c8xdnb2fmz66f7f40nrqrcybjd7w";
+        sha256 = "13fvzji9xyp304mgq720z5l0xgm54qj68jibwscagkynggn88fdc";
         procMacro = true;
         authors = [
           "Ted Driggs <ted.driggs@outlook.com>"
@@ -912,95 +977,6 @@ rec {
           }
         ];
 
-      };
-      "derive_builder" = rec {
-        crateName = "derive_builder";
-        version = "0.20.2";
-        edition = "2018";
-        sha256 = "0is9z7v3kznziqsxa5jqji3ja6ay9wzravppzhcaczwbx84znzah";
-        authors = [
-          "Colin Kiegel <kiegel@gmx.de>"
-          "Pascal Hertleif <killercup@gmail.com>"
-          "Jan-Erik Rediger <janerik@fnordig.de>"
-          "Ted Driggs <ted.driggs@outlook.com>"
-        ];
-        dependencies = [
-          {
-            name = "derive_builder_macro";
-            packageId = "derive_builder_macro";
-          }
-        ];
-        features = {
-          "alloc" = [ "derive_builder_macro/alloc" ];
-          "clippy" = [ "derive_builder_macro/clippy" ];
-          "default" = [ "std" ];
-          "std" = [ "derive_builder_macro/lib_has_std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
-      "derive_builder_core" = rec {
-        crateName = "derive_builder_core";
-        version = "0.20.2";
-        edition = "2018";
-        sha256 = "1s640r6q46c2iiz25sgvxw3lk6b6v5y8hwylng7kas2d09xwynrd";
-        authors = [
-          "Colin Kiegel <kiegel@gmx.de>"
-          "Pascal Hertleif <killercup@gmail.com>"
-          "Jan-Erik Rediger <janerik@fnordig.de>"
-          "Ted Driggs <ted.driggs@outlook.com>"
-        ];
-        dependencies = [
-          {
-            name = "darling";
-            packageId = "darling";
-          }
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2";
-          }
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "syn";
-            packageId = "syn 2.0.117";
-            features = [ "full" "extra-traits" ];
-          }
-        ];
-        features = {
-        };
-        resolvedDefaultFeatures = [ "lib_has_std" ];
-      };
-      "derive_builder_macro" = rec {
-        crateName = "derive_builder_macro";
-        version = "0.20.2";
-        edition = "2018";
-        sha256 = "0g1zznpqrmvjlp2w7p0jzsjvpmw5rvdag0rfyypjhnadpzib0qxb";
-        procMacro = true;
-        authors = [
-          "Colin Kiegel <kiegel@gmx.de>"
-          "Pascal Hertleif <killercup@gmail.com>"
-          "Jan-Erik Rediger <janerik@fnordig.de>"
-          "Ted Driggs <ted.driggs@outlook.com>"
-        ];
-        dependencies = [
-          {
-            name = "derive_builder_core";
-            packageId = "derive_builder_core";
-          }
-          {
-            name = "syn";
-            packageId = "syn 2.0.117";
-            features = [ "full" "extra-traits" ];
-          }
-        ];
-        features = {
-          "alloc" = [ "derive_builder_core/alloc" ];
-          "clippy" = [ "derive_builder_core/clippy" ];
-          "lib_has_std" = [ "derive_builder_core/lib_has_std" ];
-        };
-        resolvedDefaultFeatures = [ "lib_has_std" ];
       };
       "derive_more" = rec {
         crateName = "derive_more";
@@ -7647,6 +7623,10 @@ rec {
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };type = [ "cdylib" "staticlib" ];
         dependencies = [
           {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
             name = "async-trait";
             packageId = "async-trait";
           }
@@ -7728,8 +7708,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-rust";
-          rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912";
-          sha256 = "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2";
+          rev = "43d582b57fbc63d858a35f11ebfee193bda00834";
+          sha256 = "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj";
         };
         libName = "temporalio_client";
         authors = [
@@ -7753,12 +7733,12 @@ rec {
             packageId = "base64";
           }
           {
-            name = "bytes";
-            packageId = "bytes";
+            name = "bon";
+            packageId = "bon";
           }
           {
-            name = "derive_builder";
-            packageId = "derive_builder";
+            name = "bytes";
+            packageId = "bytes";
           }
           {
             name = "derive_more";
@@ -7853,8 +7833,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-rust";
-          rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912";
-          sha256 = "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2";
+          rev = "43d582b57fbc63d858a35f11ebfee193bda00834";
+          sha256 = "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj";
         };
         libName = "temporalio_common";
         authors = [
@@ -7874,8 +7854,9 @@ rec {
             packageId = "base64";
           }
           {
-            name = "derive_builder";
-            packageId = "derive_builder";
+            name = "bon";
+            packageId = "bon";
+            features = [ "implied-bounds" ];
           }
           {
             name = "derive_more";
@@ -7967,8 +7948,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-rust";
-          rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912";
-          sha256 = "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2";
+          rev = "43d582b57fbc63d858a35f11ebfee193bda00834";
+          sha256 = "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj";
         };
         procMacro = true;
         libName = "temporalio_macros";
@@ -8005,8 +7986,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/temporalio/sdk-rust";
-          rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912";
-          sha256 = "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2";
+          rev = "43d582b57fbc63d858a35f11ebfee193bda00834";
+          sha256 = "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj";
         };
         libName = "temporalio_sdk_core";
         authors = [
@@ -8020,6 +8001,11 @@ rec {
           {
             name = "async-trait";
             packageId = "async-trait";
+          }
+          {
+            name = "bon";
+            packageId = "bon";
+            features = [ "implied-bounds" ];
           }
           {
             name = "crossbeam-channel";
@@ -8036,10 +8022,6 @@ rec {
           {
             name = "dashmap";
             packageId = "dashmap";
-          }
-          {
-            name = "derive_builder";
-            packageId = "derive_builder";
           }
           {
             name = "derive_more";
@@ -8269,6 +8251,7 @@ rec {
           }
         ];
         features = {
+          "antithesis_assertions" = [ "dep:antithesis_sdk" ];
           "console-subscriber" = [ "dep:console-subscriber" ];
           "debug-plugin" = [ "dep:reqwest" ];
           "default" = [ "otel" "prom" ];

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2024"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-temporalio-client = { git = "https://github.com/temporalio/sdk-rust", rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912" }
-temporalio-sdk-core = { git = "https://github.com/temporalio/sdk-rust", rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912", features = ["ephemeral-server"] }
-temporalio-common = { git = "https://github.com/temporalio/sdk-rust", rev = "9a87ebf7260c3594675ffed83a3728d2cd96e912", features = ["serde_serialize"] }
+temporalio-client = { git = "https://github.com/temporalio/sdk-rust", rev = "43d582b57fbc63d858a35f11ebfee193bda00834" }
+temporalio-sdk-core = { git = "https://github.com/temporalio/sdk-rust", rev = "43d582b57fbc63d858a35f11ebfee193bda00834", features = ["ephemeral-server"] }
+temporalio-common = { git = "https://github.com/temporalio/sdk-rust", rev = "43d582b57fbc63d858a35f11ebfee193bda00834", features = ["serde_serialize"] }
 tokio = "~1.52"
 tokio-stream = "~0.1"
 tonic = "~0.14"
@@ -26,6 +26,7 @@ prost = "~0.14"
 prost-types = { version = "~0.7", package = "prost-wkt-types" }
 libc = "~0.2"
 async-trait = "0.1"
+anyhow = "~1.0"
 
 [profile.release]
 opt-level = 3

--- a/core/rust/crate-hashes.json
+++ b/core/rust/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#temporalio-client@0.1.0": "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2",
-  "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#temporalio-common@0.1.0": "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2",
-  "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#temporalio-macros@0.1.0": "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2",
-  "git+https://github.com/temporalio/sdk-rust?rev=9a87ebf7260c3594675ffed83a3728d2cd96e912#temporalio-sdk-core@0.1.0": "0zvl7d6v1k0fkhcn90rp911wfxy7051ppgzjpnf9dvrq79w63ys2"
+  "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#temporalio-client@0.1.0": "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj",
+  "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#temporalio-common@0.1.0": "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj",
+  "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#temporalio-macros@0.1.0": "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj",
+  "git+https://github.com/temporalio/sdk-rust?rev=43d582b57fbc63d858a35f11ebfee193bda00834#temporalio-sdk-core@0.1.0": "022x9qh7q7vsc74psslr26485mn66q9c72qz8wlz5njfsn7x7bpj"
 }

--- a/core/rust/src/client.rs
+++ b/core/rust/src/client.rs
@@ -6,8 +6,7 @@ use std::ffi::CStr;
 use std::str::{FromStr, from_utf8_unchecked};
 use std::time::Duration;
 use temporalio_client::{
-    ClientOptions, ClientOptionsBuilder, ClientOptionsBuilderError, ConfiguredClient, RetryClient,
-    RetryConfig, TemporalServiceClient, TlsConfig,
+    ClientOptions, ConfiguredClient, RetryClient, RetryOptions, TemporalServiceClient, TlsOptions,
 };
 use tonic::metadata::{MetadataKey, errors::InvalidMetadataValue};
 use url::Url;
@@ -20,10 +19,10 @@ pub struct ClientConfig {
     client_name: String,
     client_version: String,
     metadata: HashMap<String, String>,
+    api_key: Option<String>,
     identity: String,
     tls_config: Option<ClientTlsConfig>,
     retry_config: Option<ClientRetryConfig>,
-    api_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -44,51 +43,62 @@ struct ClientRetryConfig {
     pub max_retries: usize,
 }
 
-fn client_config_to_options(
-    client_config: ClientConfig,
-) -> Result<ClientOptions, ClientOptionsBuilderError> {
-    let mut defaults = ClientOptionsBuilder::default();
-    let mut options_builder = defaults
-        .target_url(Url::parse(&client_config.target_url).unwrap())
-        .client_name(client_config.client_name)
-        .client_version(client_config.client_version)
-        .identity(client_config.identity);
+impl TryFrom<ClientConfig> for ClientOptions {
+    type Error = anyhow::Error;
 
-    if let Some(tls_config) = client_config.tls_config {
-        let tls_config = TlsConfig {
-            server_root_ca_cert: tls_config.server_root_ca_cert,
-            domain: tls_config.domain,
-            client_tls_config: match (tls_config.client_cert, tls_config.client_private_key) {
+    fn try_from(cfg: ClientConfig) -> anyhow::Result<Self> {
+        let tls_cfg = cfg.tls_config.map(|c| c.try_into()).transpose()?;
+        let retry_cfg = cfg
+            .retry_config
+            .map_or(RetryOptions::default(), |c| c.into());
+        Ok(ClientOptions::builder()
+            .target_url(Url::parse(&cfg.target_url)?)
+            .client_name(cfg.client_name)
+            .client_version(cfg.client_version)
+            .identity(cfg.identity)
+            .retry_options(retry_cfg)
+            .maybe_api_key(cfg.api_key)
+            .maybe_tls_options(tls_cfg)
+            .build())
+    }
+}
+
+impl TryFrom<ClientTlsConfig> for TlsOptions {
+    type Error = anyhow::Error;
+
+    fn try_from(cfg: ClientTlsConfig) -> anyhow::Result<Self> {
+        Ok(TlsOptions {
+            server_root_ca_cert: cfg.server_root_ca_cert,
+            domain: cfg.domain,
+            client_tls_options: match (cfg.client_cert, cfg.client_private_key) {
+                (None, None) => None,
                 (Some(client_cert), Some(client_private_key)) => {
-                    Some(temporalio_client::ClientTlsConfig {
+                    Some(temporalio_client::ClientTlsOptions {
                         client_cert,
                         client_private_key,
                     })
                 }
-                _ => None,
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "Must have both client cert and private key or neither"
+                    ));
+                }
             },
-        };
-        options_builder = options_builder.tls_cfg(tls_config);
+        })
     }
+}
 
-    if let Some(retry_config) = client_config.retry_config {
-        options_builder = options_builder.retry_config(RetryConfig {
-            initial_interval: Duration::from_millis(retry_config.initial_interval_millis),
-            randomization_factor: retry_config.randomization_factor,
-            multiplier: retry_config.multiplier,
-            max_interval: Duration::from_millis(retry_config.max_interval_millis),
-            max_elapsed_time: retry_config
-                .max_elapsed_time_millis
-                .map(Duration::from_millis),
-            max_retries: retry_config.max_retries,
-        });
+impl From<ClientRetryConfig> for RetryOptions {
+    fn from(cfg: ClientRetryConfig) -> Self {
+        RetryOptions {
+            initial_interval: Duration::from_millis(cfg.initial_interval_millis),
+            randomization_factor: cfg.randomization_factor,
+            multiplier: cfg.multiplier,
+            max_interval: Duration::from_millis(cfg.max_interval_millis),
+            max_elapsed_time: cfg.max_elapsed_time_millis.map(Duration::from_millis),
+            max_retries: cfg.max_retries,
+        }
     }
-
-    if client_config.api_key.is_some() {
-        options_builder = options_builder.api_key(client_config.api_key)
-    }
-
-    options_builder.build()
 }
 
 #[repr(C)]
@@ -196,7 +206,7 @@ pub fn connect_client(
     config: ClientConfig,
     hs_callback: HsCallback<ClientRef, CArray<u8>>,
 ) {
-    let opts: ClientOptions = client_config_to_options(config).unwrap();
+    let opts: ClientOptions = config.try_into().unwrap();
     let runtime = runtime_ref.runtime.clone();
     runtime_ref
         .runtime
@@ -321,13 +331,11 @@ where
 {
     match res {
         Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
-        Err(err) => {
-            Err(CRPCError::c_repr_of(RPCError {
-                code: err.code() as u32,
-                message: err.message().to_owned(),
-                details: err.details().into(),
-            })
-            .unwrap())
-        }
+        Err(err) => Err(CRPCError::c_repr_of(RPCError {
+            code: err.code() as u32,
+            message: err.message().to_owned(),
+            details: err.details().into(),
+        })
+        .unwrap()),
     }
 }

--- a/core/rust/src/runtime.rs
+++ b/core/rust/src/runtime.rs
@@ -8,13 +8,12 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use temporalio_common::telemetry::metrics::{CoreMeter, NoOpCoreMeter};
 use temporalio_common::telemetry::{
-    CoreTelemetry, Logger, OtelCollectorOptionsBuilder, PrometheusExporterOptionsBuilder,
-    TelemetryOptions, TelemetryOptionsBuilder,
+    CoreTelemetry, Logger, OtelCollectorOptions, PrometheusExporterOptions, TelemetryOptions,
 };
 use temporalio_sdk_core::telemetry::{
     build_otlp_metric_exporter, construct_filter_string, start_prometheus_metric_exporter,
 };
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptionsBuilder, TokioRuntimeBuilder};
+use temporalio_sdk_core::{CoreRuntime, RuntimeOptions, TokioRuntimeBuilder};
 use tracing::Level;
 
 pub struct RuntimeRef {
@@ -32,7 +31,7 @@ fn init_runtime(
     late_telemetry_options: HsTelemetryOptions,
     try_put_mvar: extern "C" fn(capability: Capability, mvar: *mut MVar) -> (),
 ) -> Box<RuntimeRef> {
-    let runtime_options = RuntimeOptionsBuilder::default()
+    let runtime_options = RuntimeOptions::builder()
         .telemetry_options(telemetry_config)
         .build()
         .unwrap();
@@ -48,13 +47,12 @@ fn init_runtime(
             global_tags,
         } => Arc::new(
             build_otlp_metric_exporter(
-                OtelCollectorOptionsBuilder::default()
+                OtelCollectorOptions::builder()
                     .url(url.parse().expect("Invalid URL"))
                     .metric_periodicity(metric_periodicity.unwrap_or_else(|| Duration::new(1, 0)))
                     .headers(headers)
                     .global_tags(global_tags)
-                    .build()
-                    .expect("Invalid OTEl configuration"),
+                    .build(),
             )
             .expect("Otel Metric exporter"),
         ) as Arc<dyn CoreMeter>,
@@ -65,13 +63,12 @@ fn init_runtime(
             unit_suffix,
         } => {
             let srv = start_prometheus_metric_exporter(
-                PrometheusExporterOptionsBuilder::default()
+                PrometheusExporterOptions::builder()
                     .socket_addr(socket_addr)
                     .unit_suffix(unit_suffix)
                     .global_tags(global_tags)
                     .counters_total_suffix(counters_total_suffix)
-                    .build()
-                    .expect("Invalid Prometheus configuration"),
+                    .build(),
             )
             .expect("Failed to start prometheus exporter");
             srv.meter as Arc<dyn CoreMeter>
@@ -125,14 +122,13 @@ pub unsafe extern "C" fn hs_temporal_init_runtime(
     let telemetry_opts: HsTelemetryOptions =
         serde_json::from_slice(telemetry_opts.as_slice()).expect("Failed to parse");
 
-    let early_options = TelemetryOptionsBuilder::default()
+    let early_options = TelemetryOptions::builder()
         .logging(Logger::Forward {
             filter: construct_filter_string(Level::INFO, Level::ERROR),
         })
         .attach_service_name(true)
         // .metrics(core_meter)
-        .build()
-        .expect("Invalid TelemetryOptions");
+        .build();
     let rt = init_runtime(early_options, telemetry_opts, try_put_mvar);
     Box::into_raw(rt)
 }

--- a/core/rust/src/worker.rs
+++ b/core/rust/src/worker.rs
@@ -8,18 +8,18 @@ use std::sync::Arc;
 use std::time::Duration;
 use temporalio_common::Worker;
 use temporalio_common::errors::{PollError, WorkflowErrorType};
+use temporalio_common::protos::coresdk::nexus::NexusTaskCompletion;
 use temporalio_common::protos::coresdk::workflow_completion::WorkflowActivationCompletion;
 use temporalio_common::protos::coresdk::{ActivityHeartbeat, ActivityTaskCompletion};
-use temporalio_common::protos::coresdk::nexus::NexusTaskCompletion;
 use temporalio_common::protos::temporal::api::history::v1::History;
 use temporalio_common::worker::{
-    PollerBehavior, SlotKind, SlotInfoTrait, SlotMarkUsedContext, SlotReleaseContext,
+    PollerBehavior, SlotInfoTrait, SlotKind, SlotMarkUsedContext, SlotReleaseContext,
     SlotReservationContext, SlotSupplier, SlotSupplierPermit, WorkerVersioningStrategy,
 };
 use temporalio_sdk_core::replay::{HistoryForReplay, ReplayWorkerInput};
 use temporalio_sdk_core::{
-    ResourceBasedSlotsOptionsBuilder, ResourceSlotOptions,
-    SlotSupplierOptions, TunerHolderOptionsBuilder,
+    FixedSizeSlotSupplier, ResourceBasedSlotsOptions, ResourceSlotOptions, SlotSupplierOptions,
+    TunerBuilder, TunerHolder, TunerHolderOptions,
 };
 use tokio::sync::mpsc::{Sender, channel};
 use tokio_stream::wrappers::ReceiverStream;
@@ -59,90 +59,93 @@ pub struct TunerConfig {
     pub workflow_slot_supplier: Option<SlotSupplierConfig>,
     pub activity_slot_supplier: Option<SlotSupplierConfig>,
     pub local_activity_slot_supplier: Option<SlotSupplierConfig>,
+    pub nexus_slot_supplier: Option<SlotSupplierConfig>,
     pub resource_based_tuner_options: Option<ResourceBasedTunerConfig>,
 }
 
-impl TunerConfig {
-    fn build_tuner_holder(self) -> Result<Box<dyn temporalio_common::worker::WorkerTuner + Send + Sync>, WorkerError> {
-        let resource_opts = self.resource_based_tuner_options.as_ref().map(|rbt| {
-            ResourceBasedSlotsOptionsBuilder::default()
+impl<SK: SlotKind + Send + Sync + 'static> From<&SlotSupplierConfig>
+    for temporalio_sdk_core::SlotSupplierOptions<SK>
+{
+    fn from(cfg: &SlotSupplierConfig) -> SlotSupplierOptions<SK> {
+        match cfg {
+            SlotSupplierConfig::FixedSize { slots } => {
+                SlotSupplierOptions::FixedSize { slots: *slots }
+            }
+            SlotSupplierConfig::ResourceBased {
+                minimum_slots,
+                maximum_slots,
+                ramp_throttle_ms,
+            } => SlotSupplierOptions::ResourceBased(ResourceSlotOptions::new(
+                minimum_slots.unwrap_or(1),
+                maximum_slots.unwrap_or(10_000),
+                Duration::from_millis(ramp_throttle_ms.unwrap_or(50)),
+            )),
+            SlotSupplierConfig::Custom { handle } => {
+                let inner_ptr = *handle as *const HaskellSlotSupplierInner;
+                let inner = unsafe { &*inner_ptr };
+                let supplier: HaskellSlotSupplier<SK> = HaskellSlotSupplier {
+                    inner: Arc::new(HaskellSlotSupplierInner {
+                        reserve_fn: inner.reserve_fn,
+                        try_reserve_fn: inner.try_reserve_fn,
+                        mark_used_fn: inner.mark_used_fn,
+                        release_fn: inner.release_fn,
+                    }),
+                    _phantom: PhantomData,
+                };
+                SlotSupplierOptions::Custom(Arc::new(supplier))
+            }
+        }
+    }
+}
+
+impl TryFrom<&TunerConfig> for TunerHolder {
+    type Error = WorkerError;
+    fn try_from(cfg: &TunerConfig) -> Result<Self, WorkerError> {
+        let maybe_resource_opts = cfg.resource_based_tuner_options.as_ref().map(|rbt| {
+            ResourceBasedSlotsOptions::builder()
                 .target_mem_usage(rbt.target_memory_usage)
-                .target_cpu_usage(rbt.target_cpu_usage)
+                .target_cpu_usage(rbt.target_memory_usage)
                 .build()
-                .expect("resource based slot options should not fail with just targets set")
         });
 
-        let any_resource_based = matches!(self.workflow_slot_supplier, Some(SlotSupplierConfig::ResourceBased { .. }))
-            || matches!(self.activity_slot_supplier, Some(SlotSupplierConfig::ResourceBased { .. }))
-            || matches!(self.local_activity_slot_supplier, Some(SlotSupplierConfig::ResourceBased { .. }));
+        let any_resource_based = matches!(
+            cfg.workflow_slot_supplier,
+            Some(SlotSupplierConfig::ResourceBased { .. })
+        ) || matches!(
+            cfg.activity_slot_supplier,
+            Some(SlotSupplierConfig::ResourceBased { .. })
+        ) || matches!(
+            cfg.local_activity_slot_supplier,
+            Some(SlotSupplierConfig::ResourceBased { .. })
+        ) || matches!(
+            cfg.nexus_slot_supplier,
+            Some(SlotSupplierConfig::ResourceBased { .. })
+        );
 
-        if any_resource_based && resource_opts.is_none() {
+        if any_resource_based && maybe_resource_opts.is_none() {
             return Err(WorkerError {
                 code: WorkerErrorCode::InvalidWorkerConfig,
                 message: "resource_based_tuner_options must be set when any slot supplier is resource_based".to_string(),
             });
         }
 
-        let mut builder = TunerHolderOptionsBuilder::default();
+        let maybe_workflow_slot_opts = cfg.workflow_slot_supplier.as_ref().map(Into::into);
+        let maybe_activity_slot_opts = cfg.activity_slot_supplier.as_ref().map(Into::into);
+        let maybe_local_activity_slot_opts =
+            cfg.local_activity_slot_supplier.as_ref().map(Into::into);
+        let maybe_nexus_slot_opts = cfg.nexus_slot_supplier.as_ref().map(Into::into);
 
-        if let Some(ref opts) = resource_opts {
-            builder.resource_based_options(opts.clone());
-        }
-
-        if let Some(ref ss) = self.workflow_slot_supplier {
-            builder.workflow_slot_options(to_slot_supplier_options(ss)?);
-        }
-        if let Some(ref ss) = self.activity_slot_supplier {
-            builder.activity_slot_options(to_slot_supplier_options(ss)?);
-        }
-        if let Some(ref ss) = self.local_activity_slot_supplier {
-            builder.local_activity_slot_options(to_slot_supplier_options(ss)?);
-        }
-
-        let tuner = builder.build_tuner_holder().map_err(|err| WorkerError {
-            code: WorkerErrorCode::InvalidWorkerConfig,
-            message: format!("Failed building tuner: {}", err),
-        })?;
-
-        Ok(Box::new(tuner))
-    }
-}
-
-fn to_slot_supplier_options<SK: SlotKind + Send + Sync + 'static>(
-    config: &SlotSupplierConfig,
-) -> Result<SlotSupplierOptions<SK>, WorkerError>
-where
-    SK::Info: SlotInfoTrait,
-{
-    match config {
-        SlotSupplierConfig::FixedSize { slots } => {
-            Ok(SlotSupplierOptions::FixedSize { slots: *slots })
-        }
-        SlotSupplierConfig::ResourceBased {
-            minimum_slots,
-            maximum_slots,
-            ramp_throttle_ms,
-        } => Ok(SlotSupplierOptions::ResourceBased(
-            ResourceSlotOptions::new(
-                minimum_slots.unwrap_or(1),
-                maximum_slots.unwrap_or(10_000),
-                Duration::from_millis(ramp_throttle_ms.unwrap_or(50)),
-            ),
-        )),
-        SlotSupplierConfig::Custom { handle } => {
-            let inner_ptr = *handle as *const HaskellSlotSupplierInner;
-            let inner = unsafe { &*inner_ptr };
-            let supplier: HaskellSlotSupplier<SK> = HaskellSlotSupplier {
-                inner: Arc::new(HaskellSlotSupplierInner {
-                    reserve_fn: inner.reserve_fn,
-                    try_reserve_fn: inner.try_reserve_fn,
-                    mark_used_fn: inner.mark_used_fn,
-                    release_fn: inner.release_fn,
-                }),
-                _phantom: PhantomData,
-            };
-            Ok(SlotSupplierOptions::Custom(Arc::new(supplier)))
-        }
+        TunerHolderOptions::builder()
+            .maybe_workflow_slot_options(maybe_workflow_slot_opts)
+            .maybe_activity_slot_options(maybe_activity_slot_opts)
+            .maybe_local_activity_slot_options(maybe_local_activity_slot_opts)
+            .maybe_nexus_slot_options(maybe_nexus_slot_opts)
+            .maybe_resource_based_options(maybe_resource_opts)
+            .build_tuner_holder()
+            .map_err(|err| WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: format!("Failed building tuner: {}", err),
+            })
     }
 }
 
@@ -160,7 +163,11 @@ where
 /// `try_reserve_slot`: synchronous. Returns 1 if a slot was granted, 0 otherwise.
 ///
 /// `mark_slot_used` / `release_slot`: fire-and-forget notifications with JSON-encoded info.
-type ReserveSlotFn = unsafe extern "C" fn(ctx_ptr: *const u8, ctx_len: usize, completion: *mut SlotReserveCompletion);
+type ReserveSlotFn = unsafe extern "C" fn(
+    ctx_ptr: *const u8,
+    ctx_len: usize,
+    completion: *mut SlotReserveCompletion,
+);
 type TryReserveSlotFn = unsafe extern "C" fn(ctx_ptr: *const u8, ctx_len: usize) -> i32;
 type MarkSlotUsedFn = unsafe extern "C" fn(info_ptr: *const u8, info_len: usize);
 type ReleaseSlotFn = unsafe extern "C" fn(info_ptr: *const u8, info_len: usize);
@@ -210,7 +217,10 @@ impl SerializedSlotReservationContext {
 #[serde(tag = "type")]
 enum SerializedSlotInfo {
     #[serde(rename = "workflow")]
-    Workflow { workflow_type: String, is_sticky: bool },
+    Workflow {
+        workflow_type: String,
+        is_sticky: bool,
+    },
     #[serde(rename = "activity")]
     Activity { activity_type: String },
     #[serde(rename = "local_activity")]
@@ -289,7 +299,9 @@ where
     }
 
     fn release_slot(&self, ctx: &dyn SlotReleaseContext<SlotKind = SK>) {
-        let info = ctx.info().map(|i| SerializedSlotInfo::from_info(i.downcast()));
+        let info = ctx
+            .info()
+            .map(|i| SerializedSlotInfo::from_info(i.downcast()));
         let json = serde_json::to_vec(&SerializedReleaseContext { slot_info: info })
             .expect("serialization should not fail");
         unsafe { (self.inner.release_fn)(json.as_ptr(), json.len()) };
@@ -337,9 +349,7 @@ pub unsafe extern "C" fn hs_temporal_drop_custom_slot_supplier(
 ///
 /// Haskell FFI bridge invariants.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hs_temporal_slot_reserve_complete(
-    completion: *mut SlotReserveCompletion,
-) {
+pub unsafe extern "C" fn hs_temporal_slot_reserve_complete(completion: *mut SlotReserveCompletion) {
     let mut completion = unsafe { Box::from_raw(completion) };
     if let Some(sender) = completion.sender.take() {
         let _ = sender.send(());
@@ -373,19 +383,45 @@ pub struct WorkerConfig {
     max_concurrent_nexus_task_polls: Option<usize>,
 }
 
+impl TryFrom<&WorkerConfig> for TunerHolder {
+    type Error = WorkerError;
+    fn try_from(conf: &WorkerConfig) -> Result<TunerHolder, WorkerError> {
+        match conf.tuner {
+            Some(ref tuner_config) => tuner_config.try_into(),
+            None => {
+                let mut builder = TunerBuilder::default();
+                builder.workflow_slot_supplier(Arc::new(FixedSizeSlotSupplier::new(
+                    conf.max_outstanding_workflow_tasks,
+                )));
+                builder.activity_slot_supplier(Arc::new(FixedSizeSlotSupplier::new(
+                    conf.max_outstanding_activities,
+                )));
+                builder.local_activity_slot_supplier(Arc::new(FixedSizeSlotSupplier::new(
+                    conf.max_outstanding_local_activities,
+                )));
+                if let Some(m) = conf.max_outstanding_nexus_tasks {
+                    builder.nexus_slot_supplier(Arc::new(FixedSizeSlotSupplier::new(m)));
+                };
+                Ok(builder.build())
+            }
+        }
+    }
+}
+
 impl TryFrom<WorkerConfig> for temporalio_sdk_core::WorkerConfig {
     type Error = WorkerError;
 
     fn try_from(conf: WorkerConfig) -> Result<Self, WorkerError> {
-        let mut builder = temporalio_sdk_core::WorkerConfigBuilder::default();
-        builder
+        let converted_tuner: TunerHolder = (&conf).try_into()?;
+        temporalio_sdk_core::WorkerConfig::builder()
             .namespace(conf.namespace)
             .task_queue(conf.task_queue)
             .versioning_strategy(WorkerVersioningStrategy::None {
                 build_id: conf.build_id,
             })
-            .client_identity_override(conf.identity_override)
+            .maybe_client_identity_override(conf.identity_override)
             .max_cached_workflows(conf.max_cached_workflows)
+            .tuner(Arc::new(converted_tuner))
             .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(
                 conf.max_concurrent_workflow_task_polls,
             ))
@@ -393,7 +429,6 @@ impl TryFrom<WorkerConfig> for temporalio_sdk_core::WorkerConfig {
             .activity_task_poller_behavior(PollerBehavior::SimpleMaximum(
                 conf.max_concurrent_activity_task_polls,
             ))
-            .no_remote_activities(conf.no_remote_activities)
             .sticky_queue_schedule_to_start_timeout(Duration::from_millis(
                 conf.sticky_queue_schedule_to_start_timeout_millis,
             ))
@@ -403,8 +438,8 @@ impl TryFrom<WorkerConfig> for temporalio_sdk_core::WorkerConfig {
             .default_heartbeat_throttle_interval(Duration::from_millis(
                 conf.default_heartbeat_throttle_interval_millis,
             ))
-            .max_worker_activities_per_second(conf.max_activities_per_second)
-            .max_task_queue_activities_per_second(conf.max_task_queue_activities_per_second)
+            .maybe_max_worker_activities_per_second(conf.max_activities_per_second)
+            .maybe_max_task_queue_activities_per_second(conf.max_task_queue_activities_per_second)
             .graceful_shutdown_period(Duration::from_millis(conf.graceful_shutdown_period_millis))
             .workflow_failure_errors(if conf.nondeterminism_as_workflow_fail {
                 HashSet::from([WorkflowErrorType::Nondeterminism])
@@ -424,35 +459,29 @@ impl TryFrom<WorkerConfig> for temporalio_sdk_core::WorkerConfig {
             )
             .nexus_task_poller_behavior(PollerBehavior::SimpleMaximum(
                 conf.max_concurrent_nexus_task_polls.unwrap_or(5),
-            ));
-
-        if let Some(max) = conf.max_outstanding_nexus_tasks {
-            builder.max_outstanding_nexus_tasks(max);
-        }
-
-        match conf.tuner {
-            Some(tuner_config) => {
-                let tuner = tuner_config.build_tuner_holder()?;
-                builder.tuner(Arc::from(tuner));
-            }
-            None => {
-                builder
-                    .max_outstanding_workflow_tasks(conf.max_outstanding_workflow_tasks)
-                    .max_outstanding_activities(conf.max_outstanding_activities)
-                    .max_outstanding_local_activities(conf.max_outstanding_local_activities);
-            }
-        }
-
-        builder.build().map_err(|err| WorkerError {
-            code: WorkerErrorCode::InvalidWorkerConfig,
-            message: format!("{}", err),
-        })
+            ))
+            // FIXME: Implement 'WorkerTaskTypes' as an FFI type
+            .task_types(temporalio_common::worker::WorkerTaskTypes {
+                enable_workflows: true,
+                enable_local_activities: true,
+                enable_remote_activities: !conf.no_remote_activities,
+                enable_nexus: true,
+            })
+            .build()
+            .map_err(|err| WorkerError {
+                code: WorkerErrorCode::InvalidWorkerConfig,
+                message: err.to_string(),
+            })
     }
 }
 
 macro_rules! enter_sync {
     ($runtime:expr) => {
-        let _trace_guard = $runtime.core.telemetry().trace_subscriber().map(|s| tracing::subscriber::set_default(s));
+        let _trace_guard = $runtime
+            .core
+            .telemetry()
+            .trace_subscriber()
+            .map(|s| tracing::subscriber::set_default(s));
         let _guard = $runtime.core.tokio_handle().enter();
     };
 }
@@ -631,12 +660,11 @@ fn new_replay_worker(
     let (history_pusher, stream) = HistoryPusher::new(runtime_ref.runtime.clone());
     let worker = WorkerRef {
         worker: Some(Arc::new(
-            temporalio_sdk_core::init_replay_worker(ReplayWorkerInput::new(config, stream)).map_err(
-                |err| WorkerError {
+            temporalio_sdk_core::init_replay_worker(ReplayWorkerInput::new(config, stream))
+                .map_err(|err| WorkerError {
                     code: WorkerErrorCode::InitReplayWorkerFailed,
                     message: format!("Failed creating replay worker: {}", err),
-                },
-            )?,
+                })?,
         )),
         runtime: runtime_ref.runtime.clone(),
     };
@@ -796,8 +824,10 @@ impl WorkerRef {
                     message: format!("Poll failure: {}", err),
                 }),
             };
-            Ok(CArray::c_repr_of(bytes.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?)
-                .unwrap())
+            Ok(
+                CArray::c_repr_of(bytes.map_err(|err| CWorkerError::c_repr_of(err).unwrap())?)
+                    .unwrap(),
+            )
         })
     }
 
@@ -1307,9 +1337,10 @@ pub unsafe extern "C" fn hs_temporal_history_proto_to_json(
                     .into_raw_pointer_mut();
             },
             Err(err) => unsafe {
-                *error_slot = CArray::c_repr_of(format!("JSON serialization failed: {}", err).into_bytes())
-                    .unwrap()
-                    .into_raw_pointer_mut();
+                *error_slot =
+                    CArray::c_repr_of(format!("JSON serialization failed: {}", err).into_bytes())
+                        .unwrap()
+                        .into_raw_pointer_mut();
             },
         },
         Err(err) => unsafe {

--- a/core/src/Temporal/Core/Worker.hs
+++ b/core/src/Temporal/Core/Worker.hs
@@ -438,6 +438,7 @@ data TunerConfig = TunerConfig
   { workflowSlotSupplier :: Maybe SlotSupplierConfig
   , activitySlotSupplier :: Maybe SlotSupplierConfig
   , localActivitySlotSupplier :: Maybe SlotSupplierConfig
+  , nexusSlotSupplier :: Maybe SlotSupplierConfig
   , resourceBasedTunerOptions :: Maybe ResourceBasedTunerConfig
   }
 
@@ -448,6 +449,7 @@ instance ToJSON TunerConfig where
       [ "workflow_slot_supplier" .= workflowSlotSupplier t
       , "activity_slot_supplier" .= activitySlotSupplier t
       , "local_activity_slot_supplier" .= localActivitySlotSupplier t
+      , "nexus_slot_supplier" .= nexusSlotSupplier t
       , "resource_based_tuner_options" .= resourceBasedTunerOptions t
       ]
 
@@ -458,6 +460,7 @@ instance FromJSON TunerConfig where
       <$> o .:? "workflow_slot_supplier"
       <*> o .:? "activity_slot_supplier"
       <*> o .:? "local_activity_slot_supplier"
+      <*> o .:? "nexus_slot_supplier"
       <*> o .:? "resource_based_tuner_options"
 
 

--- a/sdk/src/Temporal/Worker.hs
+++ b/sdk/src/Temporal/Worker.hs
@@ -76,6 +76,8 @@ module Temporal.Worker (
   setMaxOutstandingWorkflowTasks,
   setMaxOutstandingActivities,
   setMaxOutstandingLocalActivities,
+  setMaxOutstandingNexusTasks,
+  unsetMaxOutstandingNexusTasks,
   setMaxConcurrentWorkflowTaskPolls,
   setNonstickyToStickyPollRatio,
   setMaxConcurrentActivityTaskPolls,
@@ -369,6 +371,18 @@ setMaxOutstandingLocalActivities n = modifyCore $ \conf ->
     }
 
 
+setMaxOutstandingNexusTasks :: Word64 -> ConfigM actEnv ()
+setMaxOutstandingNexusTasks n = modifyCore $ \conf ->
+  conf
+    { Core.maxOutstandingNexusTasks = Just n
+    }
+
+unsetMaxOutstandingNexusTasks :: ConfigM actEnv ()
+unsetMaxOutstandingNexusTasks = modifyCore $ \conf ->
+  conf
+    { Core.maxOutstandingNexusTasks = Nothing
+    }
+
 setMaxConcurrentWorkflowTaskPolls :: Word64 -> ConfigM actEnv ()
 setMaxConcurrentWorkflowTaskPolls n = modifyCore $ \conf ->
   conf
@@ -473,9 +487,11 @@ setGracefulShutdownPeriodMillis n = modifyCore $ \conf ->
 {- | Set a tuner for the worker, controlling how task slots are allocated.
 
 When a tuner is set, the @maxOutstandingWorkflowTasks@, @maxOutstandingActivities@,
-and @maxOutstandingLocalActivities@ fields are ignored in favor of the tuner's
-slot suppliers. This enables dynamic scaling strategies like resource-based
-autoscaling with PID controllers targeting CPU and memory thresholds.
+@maxOutstandingLocalActivities@, and @maxOutstandingNexusTasks@ fields are
+ignored in favor of the tuner's slot suppliers.
+
+This enables dynamic scaling strategies like resource-based autoscaling with PID
+controllers targeting CPU and memory thresholds.
 
 Use 'Core.FixedSizeSlotSupplier' for a static number of slots, or
 'Core.ResourceBasedSlotSupplier' to scale slots based on system resource usage.

--- a/sdk/test/WorkerTunerSpec.hs
+++ b/sdk/test/WorkerTunerSpec.hs
@@ -171,6 +171,7 @@ spec = do
                 { workflowSlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 100) (Just 0)
                 , activitySlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 10) (Just 20)
                 , localActivitySlotSupplier = Just $ ResourceBasedSlotSupplier (Just 1) (Just 50) Nothing
+                , nexusSlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 10) (Just 100)
                 , resourceBasedTunerOptions =
                     Just
                       ResourceBasedTunerConfig
@@ -187,6 +188,7 @@ spec = do
                 { workflowSlotSupplier = Just $ FixedSizeSlotSupplier 10
                 , activitySlotSupplier = Just $ FixedSizeSlotSupplier 10
                 , localActivitySlotSupplier = Just $ FixedSizeSlotSupplier 10
+                , nexusSlotSupplier = Just $ FixedSizeSlotSupplier 5
                 , resourceBasedTunerOptions = Nothing
                 }
         result <- runWorkflowWithTuner pn tunerCfg
@@ -198,6 +200,7 @@ spec = do
                 { workflowSlotSupplier = Just $ FixedSizeSlotSupplier 10
                 , activitySlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 10) (Just 20)
                 , localActivitySlotSupplier = Just $ FixedSizeSlotSupplier 10
+                , nexusSlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 10) (Just 100)
                 , resourceBasedTunerOptions =
                     Just
                       ResourceBasedTunerConfig
@@ -214,6 +217,7 @@ spec = do
                 { workflowSlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 100) Nothing
                 , activitySlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 100) (Just 20)
                 , localActivitySlotSupplier = Just $ ResourceBasedSlotSupplier (Just 1) (Just 50) Nothing
+                , nexusSlotSupplier = Just $ ResourceBasedSlotSupplier (Just 2) (Just 10) (Just 100)
                 , resourceBasedTunerOptions =
                     Just
                       ResourceBasedTunerConfig
@@ -230,6 +234,7 @@ spec = do
                 { workflowSlotSupplier = Just $ ResourceBasedSlotSupplier Nothing Nothing Nothing
                 , activitySlotSupplier = Just $ ResourceBasedSlotSupplier (Just 1) Nothing Nothing
                 , localActivitySlotSupplier = Nothing
+                , nexusSlotSupplier = Just $ ResourceBasedSlotSupplier Nothing Nothing Nothing
                 , resourceBasedTunerOptions =
                     Just
                       ResourceBasedTunerConfig
@@ -256,6 +261,7 @@ spec = do
                   { workflowSlotSupplier = Just $ CustomSlotSupplierConfig h
                   , activitySlotSupplier = Just $ FixedSizeSlotSupplier 10
                   , localActivitySlotSupplier = Just $ FixedSizeSlotSupplier 10
+                  , nexusSlotSupplier = Just $ FixedSizeSlotSupplier 10
                   , resourceBasedTunerOptions = Nothing
                   }
           result <- runWorkflowWithTuner pn tunerCfg
@@ -278,6 +284,7 @@ spec = do
                   { workflowSlotSupplier = Just $ CustomSlotSupplierConfig h
                   , activitySlotSupplier = Just $ CustomSlotSupplierConfig h
                   , localActivitySlotSupplier = Just $ CustomSlotSupplierConfig h
+                  , nexusSlotSupplier = Just $ CustomSlotSupplierConfig h
                   , resourceBasedTunerOptions = Nothing
                   }
           result <- runActivityWorkflowWithTuner pn tunerCfg
@@ -314,6 +321,7 @@ spec = do
                   { workflowSlotSupplier = Just $ CustomSlotSupplierConfig h
                   , activitySlotSupplier = Just $ FixedSizeSlotSupplier 10
                   , localActivitySlotSupplier = Just $ FixedSizeSlotSupplier 10
+                  , nexusSlotSupplier = Just $ FixedSizeSlotSupplier 10
                   , resourceBasedTunerOptions = Nothing
                   }
           result <- runWorkflowWithTuner pn tunerCfg


### PR DESCRIPTION
## description

* temporalio/sdk-rust@9a87ebf7 -> temporalio/sdk-rust@43d582b
* updates to `client.rs`, `runtime.rs`, & `worker.rs` in response to upstream changes

### notes

big change is that upstream switched to using [`bon`](https://bon-rs.com/) for deriving builders, which means a few things:
1. some of the builders that were fallible before are no longer
2. we can't partially construct a builder and pass it around as data b/c `bon` uses trait bounds to perform completeness checks

(1) is nice, (2) is annoying but ultimately not _really_ a problem to work around