### PR TITLE
add task_queue to StartWorkflow otel metadata

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -348,7 +348,8 @@ makeOpenTelemetryInterceptor = do
                         { kind = Client
                         , attributes =
                             HashMap.fromList
-                              [ ("temporal.workflow_id", toAttribute $ rawWorkflowId wfId)
+                              [ ("temporal.task_queue", toAttribute $ rawTaskQueue taskQueue)
+                              , ("temporal.workflow_id", toAttribute $ rawWorkflowId wfId)
                               , ("temporal.workflow_type", toAttribute $ rawWorkflowType ty)
                               ]
                         }


### PR DESCRIPTION
## description

just what it says: we should add `task_queue` as an otel attribute for client calls that start a workflow