### PR TITLE
Be less down about `maximumAttempts`

### DIFF
--- a/sdk/src/Temporal/Common.hs
+++ b/sdk/src/Temporal/Common.hs
@@ -204,8 +204,13 @@ data RetryPolicy = RetryPolicy
   -- * Setting the value to 1 means a single execution attempt and no retries.
   -- * Setting the value to a negative integer results in an error when the execution is invoked.
   --
-  -- Use case: Use this attribute to ensure that retries do not continue indefinitely. However, in the majority of cases, we recommend relying on the Workflow Execution Timeout,
-  -- in the case of Workflows, or Schedule-To-Close Timeout, in the case of Activities, to limit the total duration of retries instead of using this attribute.
+  -- Use case: Use this attribute to ensure that retries do not
+  -- continue indefinitely. However, if your use case is such that
+  -- late is wrong and it's better to just abort if things take too
+  -- long, consider the Workflow Execution Timeout (in the case of
+  -- Workflows) or Schedule-To-Close Timeout (in the case of
+  -- Activities) to limit the total duration of retries instead of
+  -- using this attribute.
   , nonRetryableErrorTypes :: Vector Text
   -- ^ Description: Specifies errors that shouldn't be retried.
   --


### PR DESCRIPTION
@iand675 mentioned to me in work correspondence that using `maximumAttempts` is perfectly reasonable in cases where you don't know what kind of latency you might encounter in your task queue, and that timeouts are really only appropriate in cases where once late, it's better not to act at all. Let's try to rewrite this doc comment to align with that quasi-recommendation.