### PR TITLE
otel: update to hs-opentelemetry-1.0 libraries

### DIFF
--- a/nix/overlays/haskell/deps.nix
+++ b/nix/overlays/haskell/deps.nix
@@ -1,11 +1,39 @@
-{ haskell, ... }:
+{ haskell, fetchFromGitHub, ... }:
 hfinal: hprev:
 let
-  inherit (haskell.lib.compose) markUnbroken packageSourceOverrides;
+  inherit (haskell.lib.compose) dontCheck markUnbroken packageSourceOverrides;
+
+  hs-opentelemetry-src = fetchFromGitHub {
+    owner = "iand675";
+    repo = "hs-opentelemetry";
+    rev = "f9d78fbe89da9e5c149c60a2ba7d75acb471942e";
+    hash = "sha256-oBrmeqoltrIfPUhsgtgoahgHi85iBa3H5p6PkiHeKTU=";
+  };
+  otelPackage =
+    name: subdir:
+    dontCheck (hfinal.callCabal2nix name "${hs-opentelemetry-src}/${subdir}" { });
 in
 {
   if-instance = markUnbroken hprev.if-instance;
-  hs-opentelemetry-propagator-datadog = markUnbroken hprev.hs-opentelemetry-propagator-datadog;
+
+  thread-utils-context = hfinal.callHackageDirect {
+    pkg = "thread-utils-context";
+    ver = "0.4.1.0";
+    sha256 = "sha256-etbB97HVjo0TL8s09wsgxFoKa8DnNbam0ToPl61jsiw=";
+  } { };
+
+  hs-opentelemetry-api-types = otelPackage "hs-opentelemetry-api-types" "api-types";
+  hs-opentelemetry-semantic-conventions = otelPackage "hs-opentelemetry-semantic-conventions" "semantic-conventions";
+  hs-opentelemetry-otlp = otelPackage "hs-opentelemetry-otlp" "otlp";
+  hs-opentelemetry-api = otelPackage "hs-opentelemetry-api" "api";
+  hs-opentelemetry-propagator-w3c = otelPackage "hs-opentelemetry-propagator-w3c" "propagators/w3c";
+  hs-opentelemetry-propagator-b3 = otelPackage "hs-opentelemetry-propagator-b3" "propagators/b3";
+  hs-opentelemetry-propagator-datadog = otelPackage "hs-opentelemetry-propagator-datadog" "propagators/datadog";
+  hs-opentelemetry-propagator-jaeger = otelPackage "hs-opentelemetry-propagator-jaeger" "propagators/jaeger";
+  hs-opentelemetry-propagator-xray = otelPackage "hs-opentelemetry-propagator-xray" "propagators/xray";
+  hs-opentelemetry-exporter-handle = otelPackage "hs-opentelemetry-exporter-handle" "exporters/handle";
+  hs-opentelemetry-exporter-otlp = otelPackage "hs-opentelemetry-exporter-otlp" "exporters/otlp";
+  hs-opentelemetry-sdk = otelPackage "hs-opentelemetry-sdk" "sdk";
 }
 // (packageSourceOverrides {
   # any package version pins reflected in 'all-cabal-hashes' should go here.

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -145,7 +145,7 @@ tests:
       - proto-lens
       - containers
       - require-callstack
-      - hs-opentelemetry-sdk
+      - hs-opentelemetry-sdk < 1.1
       - resourcet
     main: Main.hs
     source-dirs: test

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -48,6 +49,15 @@ import Temporal.Workflow.Unsafe
 import Prelude hiding (span)
 
 
+-- The 'Propagator' record field @propagatorNames@ was renamed to
+-- @propagatorFields@ in hs-opentelemetry-api 1.0.
+#if MIN_VERSION_hs_opentelemetry_api(1,0,0)
+#define PROPAGATOR_FIELDS propagatorFields
+#else
+#define PROPAGATOR_FIELDS propagatorNames
+#endif
+
+
 -- | "_tracer-data"
 defaultHeaderKey :: Text
 defaultHeaderKey = "_tracer-data"
@@ -70,7 +80,7 @@ defaultOpenTelemetryInterceptorOptions =
 headersPropagator :: Propagator Context (Map Text Payload) (Map Text Payload)
 headersPropagator =
   Propagator
-    { propagatorNames = ["tracecontext"]
+    { PROPAGATOR_FIELDS = ["tracecontext"]
     , extractor = \hs c -> do
         let traceParentHeader = payloadData <$> Map.lookup "traceparent" hs
             traceStateHeader = payloadData <$> Map.lookup "tracestate" hs
@@ -91,7 +101,7 @@ headersPropagator =
 headersBaggagePropagator :: Propagator Context (Map Text Payload) (Map Text Payload)
 headersBaggagePropagator =
   Propagator
-    { propagatorNames = ["baggage"]
+    { PROPAGATOR_FIELDS = ["baggage"]
     , extractor = \headers ctxt ->
         let payload = payloadData <$> Map.lookup "baggage" headers
         in pure $! case payload >>= decodeBaggage of
@@ -147,7 +157,7 @@ makeOpenTelemetryInterceptor = do
         makeTracer
           tracerProvider
           "temporal-sdk"
-          (TracerOptions Nothing)
+          tracerOptions
   pure $
     Interceptors
       { workflowInboundInterceptors =

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -209,7 +209,7 @@ test-suite temporal-sdk-tests
     , hedgehog
     , hs-opentelemetry-api
     , hs-opentelemetry-propagator-w3c
-    , hs-opentelemetry-sdk
+    , hs-opentelemetry-sdk <1.1
     , hspec
     , hspec-api
     , hspec-hedgehog


### PR DESCRIPTION
## description

this updates the Nix infra to target the updated opentelemetry libraries, as well as updating `hs-temporal-sdk` to be compatible with the (minor) API changes via some CPP glue to retain backwards compatibility.