### PR TITLE
sdk: stop processing headers

### DIFF
--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -98,7 +98,7 @@ execute worker = runActivityWorker worker go
 activityInfoFromProto :: MonadIO m => TaskToken -> TaskQueue -> AT.Start -> ActivityWorkerM actEnv m ActivityInfo
 activityInfoFromProto tt tq msg = do
   w <- ask
-  hdrs <- processorDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.headerFields))
+  hdrs <- processorTryDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.headerFields))
   heartbeats <- processorDecodePayloads w.payloadProcessor (fmap convertFromProtoPayload (msg ^. AT.vec'heartbeatDetails))
   heartbeatsRef <- newIORef heartbeats
   pure $

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -384,7 +384,6 @@ signal
   -> (SignalArgs sig :->: m ())
 signal (WorkflowHandle _ _t c wf r _) (signalRef -> (KnownSignal sName sCodec)) opts = withArgs @(SignalArgs sig) @(m ()) sCodec $ \inputs -> liftIO $ do
   inputs' <- processorEncodePayloads c.clientConfig.payloadProcessor =<< liftIO (sequence inputs)
-  hdrs <- processorEncodePayloads c.clientConfig.payloadProcessor opts.headers
   result <-
     signalWorkflowExecution c.clientCore $
       defMessage
@@ -401,7 +400,7 @@ signal (WorkflowHandle _ _t c wf r _) (signalRef -> (KnownSignal sName sCodec)) 
         -- Deprecated, no need to set
         -- & WF.control .~ _
         -- TODO put other useful headers in here
-        & WF.header .~ headerToProto (fmap convertToProtoPayload hdrs)
+        & WF.header .~ headerToProto (fmap convertToProtoPayload opts.headers)
   -- FIXME: Can we just ignore this now that it's no longer present?
   -- & WF.skipGenerateWorkflowTask .~ opts.skipGenerateWorkflowTask
   case result of
@@ -460,7 +459,6 @@ query h (queryRef -> KnownQuery qn codec) opts = withArgs @(QueryArgs query) @(m
           }
   eRes <- h.workflowHandleClient.clientConfig.interceptors.queryWorkflow baseInput $ \input -> do
     queryArgs <- processorEncodePayloads processor input.queryWorkflowArgs
-    headerPayloads <- processorEncodePayloads processor input.queryWorkflowHeaders
     let msg :: QueryWorkflowRequest
         msg =
           defMessage
@@ -475,7 +473,7 @@ query h (queryRef -> KnownQuery qn codec) opts = withArgs @(QueryArgs query) @(m
                     & Query.queryType .~ input.queryWorkflowType
                     & Query.queryArgs
                       .~ (defMessage & Common.vec'payloads .~ fmap convertToProtoPayload queryArgs)
-                    & Query.header .~ headerToProto (fmap convertToProtoPayload headerPayloads)
+                    & Query.header .~ headerToProto (fmap convertToProtoPayload input.queryWorkflowHeaders)
                  )
             & WF.queryRejectCondition .~ case opts.queryRejectCondition of
               QueryRejectConditionRejectNone -> Query.QUERY_REJECT_CONDITION_NONE
@@ -579,7 +577,6 @@ startFromPayloads k@(KnownWorkflow codec _) wfId opts payloads = do
     reqId <- UUID.nextRandom
     searchAttrs <- searchAttributesToProto opts'.searchAttributes
     payloads'' <- processorEncodePayloads c.clientConfig.payloadProcessor payloads'
-    hdrs <- processorEncodePayloads c.clientConfig.payloadProcessor opts'.headers
     memo' <- processorEncodePayloads c.clientConfig.payloadProcessor opts'.memo
     let tq = rawTaskQueue opts'.taskQueue
         req =
@@ -611,7 +608,7 @@ startFromPayloads k@(KnownWorkflow codec _) wfId opts payloads = do
             & WF.memo .~ convertToProtoMemo memo'
             & WF.searchAttributes .~ (defMessage & Common.indexedFields .~ searchAttrs)
             --     TODO Not sure how to use these yet
-            & WF.header .~ headerToProto (fmap convertToProtoPayload hdrs)
+            & WF.header .~ headerToProto (fmap convertToProtoPayload opts'.headers)
             & WF.requestEagerExecution .~ opts'.requestEagerExecution
             {-
               These values will be available as ContinuedFailure and LastCompletionResult in the
@@ -693,7 +690,6 @@ signalWithStartFromPayloads (KnownSignal sigName _) w@(KnownWorkflow codec _) wf
     searchAttrs <- searchAttributesToProto opts'.signalWithStartOptions.searchAttributes
     sigPayloads'' <- processorEncodePayloads processor opts'.signalWithStartSignalArgs
     wfPayloads'' <- processorEncodePayloads processor opts'.signalWithStartArgs
-    hdrs <- processorEncodePayloads processor opts'.signalWithStartOptions.headers
     memo' <- processorEncodePayloads processor opts'.signalWithStartOptions.memo
     let tq = rawTaskQueue opts'.signalWithStartOptions.taskQueue
         msg =
@@ -729,7 +725,7 @@ signalWithStartFromPayloads (KnownSignal sigName _) w@(KnownWorkflow codec _) wf
             & RR.maybe'retryPolicy .~ (retryPolicyToProto <$> opts'.signalWithStartOptions.retryPolicy)
             & RR.cronSchedule .~ fromMaybe "" opts'.signalWithStartOptions.cronSchedule
             & RR.memo .~ convertToProtoMemo memo'
-            & RR.header .~ headerToProto (fmap convertToProtoPayload hdrs)
+            & RR.header .~ headerToProto (fmap convertToProtoPayload opts'.signalWithStartOptions.headers)
     -- & RR.workflowStartDelay .~ _
     -- & RR.skipGenerateWorkflowTask .~ _
     res <-
@@ -1078,7 +1074,6 @@ startUpdateFromPayloads h@(WorkflowHandle _ _ c _ _ _) (KnownUpdate updateCodec 
           }
   updateHandle <- liftIO $ h.workflowHandleClient.clientConfig.interceptors.updateWorkflow baseInput $ \input -> do
     updateArgs <- processorEncodePayloads processor input.updateWorkflowArgs
-    headerPayloads <- processorEncodePayloads processor input.updateWorkflowHeaders
     let msg :: UpdateWorkflowExecutionRequest
         msg =
           defMessage
@@ -1102,7 +1097,7 @@ startUpdateFromPayloads h@(WorkflowHandle _ _ c _ _ _) (KnownUpdate updateCodec 
                          )
                     & Update.input
                       .~ ( defMessage
-                            & Update.header .~ headerToProto (fmap convertToProtoPayload headerPayloads)
+                            & Update.header .~ headerToProto (fmap convertToProtoPayload input.updateWorkflowHeaders)
                             & Update.name .~ input.updateWorkflowType
                             & Update.args .~ (defMessage & Common.vec'payloads .~ fmap convertToProtoPayload updateArgs)
                          )

--- a/sdk/src/Temporal/Payload.hs
+++ b/sdk/src/Temporal/Payload.hs
@@ -58,6 +58,7 @@ module Temporal.Payload (
   UnencodedPayload,
   processorEncodePayloads,
   processorDecodePayloads,
+  processorTryDecodePayloads,
   AllArgs,
   GatherArgs,
   GatherArgsOf,
@@ -456,6 +457,22 @@ processorEncodePayloads processor = liftIO . mapM (payloadProcessorEncode proces
 processorDecodePayloads :: (MonadIO m, Traversable f) => PayloadProcessor -> f Payload -> m (f Payload)
 processorDecodePayloads processor = liftIO . mapM (payloadProcessorDecode processor >=> either (throwIO . ValueError) pure)
 {-# INLINE processorDecodePayloads #-}
+
+
+{- | Best-effort header decoding for backwards compatibility.
+
+@DEPRECATED@ - This is a temporary fix for an oversight in the SDK where
+headers were not consistently handled without payload processing codecs. Once
+we've run this for awhile, we can remove this function and have callsites
+convert headers directly rom protobuf payloads as-intended.
+-}
+processorTryDecodePayloads :: (MonadIO m, Traversable f) => PayloadProcessor -> f Payload -> m (f Payload)
+processorTryDecodePayloads processor = liftIO . traverse tryDecode
+  where
+    tryDecode p = do
+      result <- payloadProcessorDecode processor p
+      pure $ either (\_ -> p) id result
+{-# INLINE processorTryDecodePayloads #-}
 
 
 gatherArgs :: forall args codec. (VarArgs args, AllArgs (Codec codec) args) => codec -> args :->: V.Vector UnencodedPayload

--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -415,7 +415,6 @@ startActivityFromPayloads (KnownActivity codec name) opts typedPayloads = ilift 
       seqMaps {activities = HashMap.insert s resultSlot (activities seqMaps)}
 
     i <- readIORef inst.workflowInstanceInfo
-    hdrs <- processorEncodePayloads inst.payloadProcessor activityInput.options.headers
     args <- processorEncodePayloads inst.payloadProcessor activityInput.args
     let actId = maybe (Text.pack $ show actSeq) rawActivityId (activityInput.options.activityId)
         scheduleActivity =
@@ -424,7 +423,7 @@ startActivityFromPayloads (KnownActivity codec name) opts typedPayloads = ilift 
             & Command.activityId .~ actId
             & Command.activityType .~ activityInput.activityType
             & Command.taskQueue .~ rawTaskQueue (fromMaybe i.taskQueue activityInput.options.taskQueue)
-            & Command.headers .~ fmap convertToProtoPayload hdrs
+            & Command.headers .~ fmap convertToProtoPayload activityInput.options.headers
             & Command.vec'arguments .~ fmap convertToProtoPayload args
             & Command.maybe'retryPolicy .~ fmap retryPolicyToProto activityInput.options.retryPolicy
             & Command.cancellationType .~ activityCancellationTypeToProto activityInput.options.cancellationType
@@ -696,7 +695,6 @@ startChildWorkflowFromPayloads (workflowRef -> k@(KnownWorkflow codec _)) opts p
       wfHandle <- liftIO $ inst.outboundInterceptor.startChildWorkflowExecution (knownWorkflowName k) opts $ \wfName opts' -> runInIO $ do
         args <- processorEncodePayloads inst.payloadProcessor typedPayloads
         let convertedPayloads = fmap convertToProtoPayload args
-        hdrs <- processorEncodePayloads inst.payloadProcessor opts'.headers
         memo <- processorEncodePayloads inst.payloadProcessor opts'.initialMemo
 
         s@(Sequence wfSeq) <- nextChildWorkflowSequence
@@ -720,7 +718,7 @@ startChildWorkflowFromPayloads (workflowRef -> k@(KnownWorkflow codec _)) opts p
                 & Command.workflowIdReusePolicy .~ workflowIdReusePolicyToProto opts'.workflowIdReusePolicy
                 & Command.maybe'retryPolicy .~ fmap retryPolicyToProto opts'.retryPolicy
                 & Command.cronSchedule .~ fromMaybe "" opts'.cronSchedule
-                & Command.headers .~ fmap convertToProtoPayload hdrs
+                & Command.headers .~ fmap convertToProtoPayload opts'.headers
                 & Command.memo .~ fmap convertToProtoPayload memo
                 & Command.searchAttributes .~ searchAttrs
                 & Command.cancellationType .~ childWorkflowCancellationTypeToProto opts'.cancellationType

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -203,7 +203,7 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
               searchAttrs <- liftIO $ do
                 decodedAttrs <- initializeWorkflow ^. Activation.searchAttributes . Message.indexedFields . to searchAttributesFromProto
                 either (throwIO . ValueError) pure decodedAttrs
-              hdrs <- processorDecodePayloads worker.processor (initializeWorkflow ^. Activation.headers . to (fmap convertFromProtoPayload))
+              hdrs <- processorTryDecodePayloads worker.processor (initializeWorkflow ^. Activation.headers . to (fmap convertFromProtoPayload))
               memo <- processorDecodePayloads worker.processor (initializeWorkflow ^. Activation.memo . Message.fields . to (fmap convertFromProtoPayload))
               pure (searchAttrs, hdrs, memo)
             case ePayloads of

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -387,11 +387,12 @@ setUpWorkflowExecution initializeWorkflow = do
   writeIORef inst.workflowTime (initializeWorkflow ^. Activation.startTime . to timespecFromTimestamp)
   info <- readIORef inst.workflowInstanceInfo
 
+  hdrs <- processorTryDecodePayloads inst.payloadProcessor (fmap convertFromProtoPayload (initializeWorkflow ^. Activation.headers))
   pure $
     ExecuteWorkflowInput
       { executeWorkflowInputType = WorkflowType (initializeWorkflow ^. Activation.workflowType)
       , executeWorkflowInputArgs = fmap convertFromProtoPayload (initializeWorkflow ^. Command.vec'arguments)
-      , executeWorkflowInputHeaders = fmap convertFromProtoPayload (initializeWorkflow ^. Activation.headers)
+      , executeWorkflowInputHeaders = hdrs
       , executeWorkflowInputInfo = info
       }
 
@@ -442,12 +443,13 @@ applyQueryWorkflow queryWorkflow = do
   Logging.logDebug $ Text.pack ("Applying query: " <> show (queryWorkflow ^. Activation.queryType))
   let processor = inst.payloadProcessor
   args <- processorDecodePayloads processor (fmap convertFromProtoPayload (queryWorkflow ^. Command.vec'arguments))
+  hdrs <- processorTryDecodePayloads processor (fmap convertFromProtoPayload (queryWorkflow ^. Activation.headers))
   let baseInput =
         HandleQueryInput
           { handleQueryId = QueryId (queryWorkflow ^. Activation.queryId)
           , handleQueryInputType = queryWorkflow ^. Activation.queryType
           , handleQueryInputArgs = args
-          , handleQueryInputHeaders = fmap convertFromProtoPayload (queryWorkflow ^. Activation.headers)
+          , handleQueryInputHeaders = hdrs
           , handleQueryWorkflowInfo = instInfo
           }
       lookupHandler input =
@@ -541,9 +543,9 @@ applyDoUpdateWorkflow doUpdate = provideCallStack do
         pure (pure False, error "This should never happen")
       Just WorkflowUpdateImplementation {..} -> do
         updateArgs <- UnliftIO.try $ processorDecodePayloads inst.payloadProcessor (fmap convertFromProtoPayload (doUpdate ^. Activation.vec'input))
+        updateHeaders <- processorTryDecodePayloads inst.payloadProcessor (fmap convertFromProtoPayload (doUpdate ^. Activation.headers))
         let runValidator = doUpdate ^. Activation.runValidator
             updateId = UpdateId $ doUpdate ^. Activation.id
-            updateHeaders = fmap convertFromProtoPayload (doUpdate ^. Activation.headers)
         case updateArgs of
           Left err ->
             pure
@@ -916,7 +918,6 @@ convertExitVariantToCommand variant = do
                 else continueAsNewOptions.searchAttributes
             )
       args <- processorEncodePayloads processor continueAsNewArguments
-      hdrs <- processorEncodePayloads processor continueAsNewOptions.headers
       memo <- processorEncodePayloads processor continueAsNewOptions.memo
       pure $
         defMessage
@@ -927,7 +928,7 @@ convertExitVariantToCommand variant = do
                   & Command.vec'arguments .~ fmap convertToProtoPayload args
                   & Command.maybe'retryPolicy .~ (retryPolicyToProto <$> continueAsNewOptions.retryPolicy)
                   & Command.searchAttributes .~ searchAttrs
-                  & Command.headers .~ fmap convertToProtoPayload hdrs
+                  & Command.headers .~ fmap convertToProtoPayload continueAsNewOptions.headers
                   & Command.memo .~ fmap convertToProtoPayload memo
                   & Command.maybe'workflowTaskTimeout .~ (durationToProto <$> continueAsNewOptions.taskTimeout)
                   & Command.maybe'workflowRunTimeout .~ (durationToProto <$> continueAsNewOptions.runTimeout)


### PR DESCRIPTION
Other Temporal SDKs do not apply payload processors to their headers, and doing so makes it more difficult for interceptors (which don't have access to these processors) to use headers (which is their whole reason for existing) unless care is taken to run the processors on them before handing off to the interceptor.

Now we stop doing that.

We'll attempt to decode headers with the payload processor (falling back to plain protobuf conversion) to allow for graceful adoption, and after that we can remove the helper function added in this commit.