### PR TITLE
misc: clean up dead code in `createTimer` & add a local `yield` function

### DIFF
--- a/sdk/src/Temporal/Client/Schedule.hs
+++ b/sdk/src/Temporal/Client/Schedule.hs
@@ -212,7 +212,7 @@ import Temporal.Exception
 import Temporal.Payload
 import Temporal.SearchAttributes
 import Temporal.SearchAttributes.Internal
-import Temporal.Workflow
+import Temporal.Workflow hiding (yield)
 import UnliftIO
 
 

--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -175,6 +175,7 @@ module Temporal.Workflow (
   independently,
   biselect,
   biselectOpt,
+  yield,
 
   -- * Interacting with running Workflows
 
@@ -1435,7 +1436,8 @@ Note that the timer is started when the command is received by the Temporal Plat
 not when the timer is created. The command is sent as soon as the workflow is blocked
 by any operation, such as 'sleep', 'awaitCondition', 'awaitActivity', 'awaitWorkflow', etc.
 
-If the duration is less than or equal to zero, the timer will not be created.
+If the duration is less than or equal to zero, no timer is created and this
+returns 'Nothing'.
 -}
 createTimer :: Duration -> Workflow (Maybe Timer)
 createTimer ts = provideCallStack $ ilift $ do
@@ -1444,13 +1446,12 @@ createTimer ts = provideCallStack $ ilift $ do
   if ts <= mempty
     then pure Nothing
     else do
-      let ts' = if ts <= mempty then nanoseconds 1 else ts
-          cmd =
+      let cmd =
             defMessage
               & Command.startTimer
                 .~ ( defMessage
                       & Command.seq .~ seqId
-                      & Command.startToFireTimeout .~ durationToProto ts'
+                      & Command.startToFireTimeout .~ durationToProto ts
                    )
       Logging.logDebug "Add command: sleep"
       res <- newTrackedIVar
@@ -1472,7 +1473,8 @@ by any operation, such as 'sleep', 'awaitCondition', 'awaitActivity', 'awaitWork
 This function suspends the workflow itself, allowing other workflows to execute. It does not
 block the workflow thread in a busy-wait.
 
-If the duration is less than or equal to zero, the function will return immediately.
+__NOTE__: If the duration is less than or equal to zero, no timer is created and the
+function returns immediately; see 'createTimer' for details.
 -}
 sleep :: RequireCallStack => Duration -> Workflow ()
 sleep ts = do
@@ -1483,9 +1485,8 @@ sleep ts = do
 
 {- | Suspends the workflow execution until the specified system time.
 
-If the target time is in the past, the function will return immediately.
-
-See 'sleep' for details about timer behavior and workflow suspension.
+__NOTE__: If the target time is in the past, no timer is created and the
+function returns immediately; see 'createTimer' for details.
 -}
 sleepUntilSystemTime :: RequireCallStack => SystemTime -> Workflow ()
 sleepUntilSystemTime t = do
@@ -1497,7 +1498,7 @@ sleepUntilSystemTime t = do
 
 {- | Suspends the workflow execution until the specified UTC time.
 
-If the target time is in the past, the function will return immediately.
+If the target time is in the past, the function returns immediately.
 
 See 'sleep' for details about timer behavior and workflow suspension.
 -}

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -358,6 +358,35 @@ addJob env !wf !resultIVar IVar {ivarRef = ref} =
     full -> (full, modifyIORef' env.runQueueRef (JobCons env wf resultIVar))
 
 
+{- | Yield control back to the workflow scheduler, re-queueing the current
+continuation behind everything that is currently runnable.
+
+This is a purely local yield: it appends the continuation to the instance run
+queue and returns control to the scheduler, emits __no__ command, writes
+__no__ history, and never reaches the flush-and-suspend boundary, does not
+round-trip to the server and is invisible to replay.
+-}
+yield :: Workflow ()
+yield = Workflow $ \env -> do
+  -- NOTE: We return `Blocked gate` on a fresh, empty `IVar` so the scheduler
+  -- parks the current continuation in gate's waiting list, and we append a
+  -- trivial "filler" job, targeting gate, to the back of the run queue.
+  --
+  -- Once the scheduler drains everything ahead of it, the filler runs, fills
+  -- gate, and the parked continuation is re-queued and resumed.
+  -- 
+  -- Keeping a job on the run queue for the duration of the yield is what prevents
+  -- the scheduler from flushing commands and suspending.
+  -- 
+  -- The gate is intentionally untracked so this momentary block does not show
+  -- up in __stack_trace queries.
+  gate <- newIVar
+  let filler = Workflow $ \_ -> pure (Done ())
+  liftIO $ modifyIORef' env.runQueueRef $ \j ->
+    appendJobList j (JobCons env filler gate JobNil)
+  pure (Blocked gate (Return gate))
+
+
 -- -----------------------------------------------------------------------------
 -- Cont
 

--- a/sdk/test/WorkflowSpec.hs
+++ b/sdk/test/WorkflowSpec.hs
@@ -325,6 +325,28 @@ tests = do
         let opts = defaultStartOpts taskQueue
         useClient (C.execute wf.reference "multiStateVar" opts) `shouldReturn` (42, "hello")
 
+  describe "Local yield" $ do
+    specify "yield hands control to a concurrent branch before resuming" $ \TestEnv {..} -> do
+      -- Branch A records 1, yields, then records 3; Branch B records 2.
+      --
+      -- With yield, A blocks after 1, letting B record 2 before A resumes:
+      -- -> [1, 2, 3].
+      --
+      -- Without yield, A runs straight through (1, 3) then B (2):
+      -- -> [1, 3, 2].
+      let workflow :: MyWorkflow [Int]
+          workflow = do
+            st <- W.newStateVar ([] :: [Int])
+            let a = W.modifyStateVar st (1 :) *> W.yield *> W.modifyStateVar st (3 :)
+                b = W.modifyStateVar st (2 :)
+            W.concurrently_ a b
+            reverse <$> W.readStateVar st
+          wf = W.provideWorkflow defaultCodec "localYield" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOpts taskQueue
+        useClient (C.execute wf.reference "localYield" opts) `shouldReturn` [1, 2, 3]
+
   describe "WorkflowIdConflictPolicy" $ do
     specify "Fail policy prevents duplicate workflows" $ \TestEnv {..} -> do
       let wf :: W.ProvidedWorkflow (W.Workflow ())


### PR DESCRIPTION
## description

there was a small bit of dead code in the `Workflow.createTimer`, and in the process of debugging something else i realized it would be very cute to implement `Workflow.yield`
