### PR TITLE
Add MonadMask to Workflow; run finalizers on cancelled race losers

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -122,27 +122,34 @@ is inserted into the fiber-local OpenTelemetry context for the duration of
 the handler, so spans created inside it (e.g. @StartActivity@) nest under
 it — even across suspension points, since the scheduler snapshots and
 restores the context per fiber.
+
+The span's lifecycle is a 'generalBracket' over the handler: the span is
+created and attached in the acquire step, and ended in the release step for
+both the returning and the throwing exit (recording the exception on the
+latter). Because 'Workflow''s handler frames ride the fiber's captured
+continuation, this bracket stays armed across every suspension inside the
+handler — the span opened before an @await@ is still the one closed after
+the workflow resumes on a later activation.
 -}
 inWorkflowHandlerSpan :: Tracer -> Text -> SpanArguments -> Map Text Payload -> Workflow a -> Workflow a
-inWorkflowHandlerSpan tracer spanName spanArgs headers action = do
-  (span, prevCtxt) <- performUnsafeNonDeterministicIO $ do
-    hdrCtxt <- extract headersPropagator headers Ctxt.empty
-    prevCtxt <- getContext
-    let parentCtxt = maybe prevCtxt (const hdrCtxt) (Ctxt.lookupSpan hdrCtxt)
-    span <- createSpan tracer parentCtxt spanName spanArgs
-    _ <- attachContext (Ctxt.insertSpan span parentCtxt)
-    pure (span, prevCtxt)
-  result <- Control.Monad.Catch.try action
-  performUnsafeNonDeterministicIO $ do
-    case result of
-      Left err -> do
-        setStatus span (Error $ T.pack $ show err)
-        recordException span mempty Nothing err
-      Right _ -> pure ()
-    endSpan span Nothing
-    _ <- attachContext prevCtxt
-    pure ()
-  either (throwM @_ @SomeException) pure result
+inWorkflowHandlerSpan tracer spanName spanArgs headers action =
+  fst <$> generalBracket acquire release (const action)
+  where
+    acquire = performUnsafeNonDeterministicIO $ do
+      hdrCtxt <- extract headersPropagator headers Ctxt.empty
+      prevCtxt <- getContext
+      let parentCtxt = maybe prevCtxt (const hdrCtxt) (Ctxt.lookupSpan hdrCtxt)
+      span <- createSpan tracer parentCtxt spanName spanArgs
+      _ <- attachContext (Ctxt.insertSpan span parentCtxt)
+      pure (span, prevCtxt)
+    release (span, prevCtxt) ec = performUnsafeNonDeterministicIO $ do
+      case ec of
+        ExitCaseException err -> do
+          setStatus span (Error $ T.pack $ show err)
+          recordException span mempty Nothing err
+        _ -> pure ()
+      endSpan span Nothing
+      void $ attachContext prevCtxt
 
 
 --    * Workflow is scheduled by a client

--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -1714,18 +1714,41 @@ biselectOpt
   -> Workflow t
 biselectOpt discrimA discrimB left right wfL wfR = Workflow $ \env -> do
   let
+    -- Cancel a side whose result we no longer need, gated on the
+    -- race-loser-cancellation SDK flag (see 'sdkFlagRaceLoserCancellation').
+    -- A history recorded before the flag existed takes the disabled branch:
+    -- the loser is dropped silently and @step@ is not even forced, exactly as
+    -- the SDK behaved before. When enabled we force @step@ (starting a
+    -- not-yet-started loser, as 'Control.Concurrent.Async.race' forks both
+    -- sides) and, if it is blocked, deliver a synthetic
+    -- 'WorkflowFiberCancelled' so its finalizers run (see 'cancelSubFiber').
+    cancelSide :: forall x. InstanceM (SubStatus x) -> InstanceM ()
+    cancelSide step = do
+      enabled <- tryUseSdkFlag sdkFlagRaceLoserCancellation
+      when enabled $ do
+        s <- step
+        case s of
+          SubBlocked ivar k -> cancelSubFiber env ivar k
+          _ -> pure ()
+    -- Like 'cancelSide', but for a loser we already hold as a blocked
+    -- continuation (so there is nothing to force). Same flag gate.
+    cancelBlocked :: forall x w. IVar w -> (ResultVal w -> IO (Status x)) -> InstanceM ()
+    cancelBlocked ivar k = do
+      enabled <- tryUseSdkFlag sdkFlagRaceLoserCancellation
+      when enabled $ cancelSubFiber env ivar k
     -- Each round: step the left side first (resuming it only if the IVar it
     -- was blocked on has been filled), then, unless the left side
     -- short-circuited, step the right side. When both sides remain blocked,
     -- park unit jobs on both blocked IVars that fill a fresh
     -- synchronisation IVar 'i', and block the parent on 'i' so that it
-    -- wakes up whenever either side's IVar is filled.
+    -- wakes up whenever either side's IVar is filled. Whenever one side wins
+    -- or throws, the still-running other side is cancelled.
     go :: InstanceM (SubStatus l) -> InstanceM (SubStatus r) -> InstanceM t
     go stepA stepB = do
       sa <- stepA
       case sa of
         SubDone ea -> case discrimA ea of
-          Left a -> pure (left a)
+          Left a -> cancelSide stepB *> pure (left a)
           Right b -> do
             sb <- stepB
             case sb of
@@ -1738,18 +1761,18 @@ biselectOpt discrimA discrimB left right wfL wfR = Workflow $ \env -> do
                 case discrimB eb of
                   Left a -> pure (left a)
                   Right c -> pure (right (b, c))
-        SubThrown e -> throwWorkflow e
+        SubThrown e -> cancelSide stepB *> throwWorkflow e
         SubBlocked ia ka -> do
           sb <- stepB
           case sb of
             SubDone eb -> case discrimB eb of
-              Left a -> pure (left a)
+              Left a -> cancelBlocked ia ka *> pure (left a)
               Right c -> do
                 ea <- driveSubFiber env ia ka
                 case discrimA ea of
                   Left a -> pure (left a)
                   Right b -> pure (right (b, c))
-            SubThrown e -> throwWorkflow e
+            SubThrown e -> cancelBlocked ia ka *> throwWorkflow e
             SubBlocked ib kb -> do
               i <- newIVar
               parkTask (fiberContEnv env) (fiberLocals env) (FreshTask (return ())) i ia

--- a/sdk/src/Temporal/Workflow/Eval.hs
+++ b/sdk/src/Temporal/Workflow/Eval.hs
@@ -297,9 +297,11 @@ injectWorkflowSignalOrUpdate signal = do
 
 {- | Run one fiber step under the fiber's own OpenTelemetry context.
 
-Fibers interleave on a single thread (and may resume on a different thread
-after an activation), so the thread-local OTel context cannot be trusted
-across steps. Instead each fiber owns a context slot: it is attached before
+Fibers for one workflow instance all interleave cooperatively on that
+instance's single dedicated GHC thread, so a fiber never migrates threads;
+but because sibling fibers share that thread, the thread-local OTel context
+left behind by one fiber cannot be trusted by the next. Instead each fiber
+owns a context slot: it is attached before
 the step, snapshotted back after the step (whether the fiber completed or
 suspended), and the ambient context is restored for the scheduler. A fiber
 that has not run yet inherits the ambient context of its first step, which

--- a/sdk/src/Temporal/Workflow/Internal/Instance.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Instance.hs
@@ -20,6 +20,7 @@ module Temporal.Workflow.Internal.Instance (
 
 import Control.Monad.Reader
 import Data.Atomics (atomicModifyIORefCAS)
+import qualified Data.HashSet as HashSet
 import Data.ProtoLens
 import qualified Data.Text as T
 import GHC.Stack
@@ -41,12 +42,16 @@ flushCommands :: HasCallStack => InstanceM ()
 flushCommands = do
   inst <- ask
   info <- readIORef inst.workflowInstanceInfo
+  knownFlags <- readIORef inst.workflowKnownFlags
   cmds <- atomically $ do
     currentCmds <- readTVar inst.workflowCommands
     writeTVar inst.workflowCommands $ Reversed []
     pure currentCmds
   let completionSuccessful :: Core.Success
-      completionSuccessful = defMessage & Completion.commands .~ fromReversed cmds
+      completionSuccessful =
+        defMessage
+          & Completion.commands .~ fromReversed cmds
+          & Completion.usedInternalFlags .~ HashSet.toList knownFlags
       completionMessage :: Core.WorkflowActivationCompletion
       completionMessage =
         defMessage

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -13,6 +13,8 @@ import Control.Monad.Reader
 import Data.Atomics (atomicModifyIORefCAS)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
+import Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
 import Data.Kind
 import Data.Map.Strict (Map)
 import Data.Monoid (Endo (..))
@@ -194,6 +196,24 @@ deliverResultVal (ThrowWorkflow e) = throwWorkflow e
 deliverResultVal (ThrowInternal e) = liftIO $ throwIO e
 
 
+{- | A synthetic cancellation delivered to a fiber continuation that the
+scheduler is about to drop (the losing side of a 'race'\/'biselectOpt').
+
+It mirrors the async exception that 'Control.Concurrent.Async.cancel' throws
+into a thread: it unwinds the loser through its 'bracket'\/'finally'
+finalizers instead of abandoning them. Unlike a real async exception, it is
+/not/ swallowed by 'Temporal.Workflow.Internal.Monad.catch', 'try', or
+'Control.Applicative.<|>' (those rethrow it), so a catch-all handler in the
+loser cannot accidentally resurrect a cancelled fiber; only the bracket
+family ('generalBracket') observes it, runs its release, and re-raises.
+-}
+data WorkflowFiberCancelled = WorkflowFiberCancelled
+  deriving stock (Show)
+
+
+instance Exception WorkflowFiberCancelled
+
+
 instance Functor Workflow where
   fmap f (Workflow m) = Workflow (fmap f . m)
 
@@ -325,9 +345,15 @@ catch (Workflow m) h = Workflow $ \env ->
   m env `UnliftIO.catch` \(se :: SomeException) ->
     case fromException se of
       Just (WorkflowThrown inner)
+        -- A fiber cancellation ('WorkflowFiberCancelled') must never be
+        -- swallowed by an ordinary handler, or a catch-all in a cancelled
+        -- 'race' loser would resurrect it. Rethrow; only the bracket family
+        -- ('generalBracket') observes it, to run finalizers.
+        | Just WorkflowFiberCancelled <- fromException inner -> throwIO se
         | Just e <- fromException inner -> unWorkflow (h e) env
         | otherwise -> throwIO se
       Nothing
+        | Just WorkflowFiberCancelled <- fromException se -> throwIO se
         | Just e <- fromException se -> unWorkflow (h e) env
         | otherwise -> throwIO se
 
@@ -354,6 +380,82 @@ instance Catch.MonadThrow Workflow where throwM = Temporal.Workflow.Internal.Mon
 
 
 instance Catch.MonadCatch Workflow where catch = Temporal.Workflow.Internal.Monad.catch
+
+
+-- | Build an 'Catch.ExitCaseException' from a caught exception, unwrapping
+-- the internal 'WorkflowThrown' envelope so the release action observes the
+-- exception the workflow actually raised.
+exitCaseException :: SomeException -> Catch.ExitCase a
+exitCaseException se = Catch.ExitCaseException $ case fromException se of
+  Just (WorkflowThrown inner) -> inner
+  _ -> se
+
+
+{- | An intentionally UNLAWFUL 'Catch.MonadMask' instance for 'Workflow'.
+
+A lawful 'MonadMask' is impossible here: async-exception masking state lives
+in the thread-state object, not on the Haskell stack, so the
+delimited-continuation primops ('control0#') that suspend and resume a fiber
+neither capture nor restore it. A 'mask' therefore cannot span a suspension,
+and we do not pretend otherwise.
+
+The instance is nonetheless safe /in this monad/, because the sole thing a
+lawful 'MonadMask' buys you is async-exception-safe handling of a leakable
+resource — and 'Workflow' cannot allocate one. It has 'TypeError' instances
+for 'MonadIO' and 'MonadUnliftIO' (below), so no arbitrary IO, and hence no
+file handle, socket, or lock, can be acquired inside a workflow. The bracket
+family is provided purely for /control-flow/ instrumentation (interceptor
+spans, error reporting), where the semantics below are exactly what is
+wanted. If you find yourself wanting these methods to guard a real resource,
+you have gone wrong: acquire it in an activity instead.
+
+Caveats, made explicit:
+
+  * 'mask' and 'uninterruptibleMask' do NOT block async exceptions. The
+    @restore@ argument is 'id'. Do not rely on them for atomicity. (A given
+    workflow instance runs entirely on one dedicated GHC thread and its
+    fibers are scheduled cooperatively, so there is no concurrent thread
+    racing to deliver an async exception mid-region anyway.)
+
+  * 'generalBracket' runs @release@ for 'Catch.ExitCaseSuccess' and
+    'Catch.ExitCaseException', so @bracket@\/@finally@\/@onException@ close a
+    span on both the returning and the throwing path, even across a
+    suspension, since the handler frame rides the fiber's captured
+    continuation. It catches at the IO level (not via the user-facing
+    'catch'), so it observes and re-raises a 'WorkflowFiberCancelled' too:
+    the SDK's own combinators never leave a continuation in the
+    'Catch.ExitCaseAbort' state. When 'race'\/'biselectOpt' drops its losing
+    side, 'cancelSubFiber' resumes that continuation with a
+    'WorkflowFiberCancelled' (gated on 'sdkFlagRaceLoserCancellation' so it
+    stays off when replaying histories recorded before the change), so the
+    loser's finalizers run through the
+    'Catch.ExitCaseException' path rather than being abandoned. A genuine
+    'Catch.ExitCaseAbort' (a continuation neither resumed nor cancelled)
+    would skip @release@, but nothing in the SDK produces one, and there is
+    no resource to leak regardless.
+-}
+instance Catch.MonadMask Workflow where
+  mask restoreToRunner = restoreToRunner id
+  uninterruptibleMask restoreToRunner = restoreToRunner id
+  generalBracket acquire release use = Workflow $ \env -> do
+    resource <- unWorkflow acquire env
+    -- Catch at the IO level rather than via the user-facing 'catch', so that
+    -- @release@ runs for EVERY exit, including a 'WorkflowFiberCancelled'
+    -- (which 'catch' deliberately refuses to swallow). The catch frame rides
+    -- the fiber's captured continuation, so it stays armed across any
+    -- suspension inside @use@. The original exception is re-raised verbatim
+    -- (no 'WorkflowThrown' re-wrapping), preserving its identity for the
+    -- fiber runner and any outer handler.
+    result <-
+      (Right <$> unWorkflow (use resource) env)
+        `UnliftIO.catch` \(se :: SomeException) -> pure (Left se)
+    case result of
+      Left se -> do
+        _ <- unWorkflow (release resource (exitCaseException se)) env
+        throwIO se
+      Right b -> do
+        c <- unWorkflow (release resource (Catch.ExitCaseSuccess b)) env
+        pure (b, c)
 
 
 newtype WorkflowGenM = WorkflowGenM {unWorkflowGenM :: IORef StdGen}
@@ -610,6 +712,90 @@ driveSubFiber env = go
         SubDone a -> pure a
         SubThrown e -> throwWorkflow e
         SubBlocked ivar' k' -> go ivar' k'
+
+
+{- | Cancel a fiber continuation that the scheduler is about to drop (the
+losing side of a 'race'\/'biselectOpt'). Instead of silently discarding it,
+resume it once with a synthetic 'WorkflowFiberCancelled' so its
+'bracket'\/'finally' finalizers run, mirroring how
+'Control.Concurrent.Async.cancel' delivers an async exception to a thread.
+
+The loser's result (or the re-raised cancellation) is discarded. If a
+finalizer itself suspends, it is driven to completion, so 'race' does not
+return until the loser has finished unwinding (matching
+'Control.Concurrent.Async.race', which waits on the cancelled loser). Each
+continuation is still resumed at most once. A workflow-level exception
+escaping the loser is swallowed (it belongs to a computation whose result is
+being thrown away); an internal machinery exception still propagates, as it
+must.
+-}
+cancelSubFiber :: forall a v. FiberEnv -> IVar v -> (ResultVal v -> IO (Status a)) -> InstanceM ()
+cancelSubFiber env = go True
+  where
+    go :: forall w. Bool -> IVar w -> (ResultVal w -> IO (Status a)) -> InstanceM ()
+    go firstResume ivar k = do
+      rv <-
+        if firstResume
+          then pure (ThrowWorkflow (toException WorkflowFiberCancelled))
+          else liftIO $ fiberSuspend env ivar
+      next <-
+        liftIO $
+          (Just <$> k rv) `UnliftIO.catch` \(WorkflowThrown _) -> pure Nothing
+      case next of
+        Nothing -> pure ()
+        Just (SDone _) -> pure ()
+        Just (SBlocked ivar' k') -> go False ivar' k'
+
+
+{- | A Temporal SDK internal flag: a small, permanent per-SDK id that gates a
+replay-unsafe behaviour change.
+
+The mechanism (shared with the TypeScript\/Python\/Go SDKs): a flag is either
+recorded as used in a workflow's history or not. On a live task 'tryUseSdkFlag'
+turns the behaviour on and records the id; on replay it returns whether the id
+was present in the history up to the current task. So a behaviour introduced
+behind a flag is used by new executions yet stays off when replaying a history
+recorded before the flag existed, keeping replay deterministic. Ids are chosen
+per-SDK starting at 1, never reused or renumbered.
+-}
+newtype SdkFlag = SdkFlag {sdkFlagId :: Word32}
+  deriving stock (Eq, Ord, Show)
+
+
+{- | Gate: run finalizers on a dropped @race@\/@biselect@ loser by resuming it
+with a synthetic 'WorkflowFiberCancelled'. Off for histories recorded before
+this flag, which drop losers silently (see 'cancelSubFiber').
+-}
+sdkFlagRaceLoserCancellation :: SdkFlag
+sdkFlagRaceLoserCancellation = SdkFlag 1
+
+
+{- | Check whether an 'SdkFlag'-gated behaviour is enabled for the current
+workflow task, recording the flag as used when running live.
+
+  * If the id is already known (advertised by core from history, or used
+    earlier this run), return 'True'.
+  * Otherwise, if this is NOT a replay, mark the flag used (so it is echoed in
+    the completion's @used_internal_flags@ and lands in history) and return
+    'True'.
+  * Otherwise (replaying a history without the flag) return 'False'.
+
+This is the default-on variant (live executions always adopt the new
+behaviour); it MUST be called at the same logical point on replay as live.
+-}
+tryUseSdkFlag :: SdkFlag -> InstanceM Bool
+tryUseSdkFlag (SdkFlag fid) = do
+  inst <- ask
+  known <- readIORef inst.workflowKnownFlags
+  if fid `HashSet.member` known
+    then pure True
+    else do
+      replaying <- readIORef inst.workflowIsReplaying
+      if replaying
+        then pure False
+        else do
+          modifyIORef' inst.workflowKnownFlags (HashSet.insert fid)
+          pure True
 
 
 data IVarContents a
@@ -879,6 +1065,13 @@ data WorkflowInstance = WorkflowInstance
   , workflowSequences :: {-# UNPACK #-} !(IORef Sequences)
   , workflowTime :: {-# UNPACK #-} !(IORef SystemTime)
   , workflowIsReplaying :: {-# UNPACK #-} !(IORef Bool)
+  , -- | SDK internal flags (see 'SdkFlag') recorded as usable for this run.
+    -- Seeded each activation from the core's advertised
+    -- @available_internal_flags@ and grown by live 'tryUseSdkFlag' hits; the
+    -- accumulated set is echoed back to core in every completion's
+    -- @used_internal_flags@ so behaviour changes gated on a flag replay
+    -- deterministically (histories predating a flag simply lack its id).
+    workflowKnownFlags :: {-# UNPACK #-} !(IORef (HashSet Word32))
   , workflowCommands :: {-# UNPACK #-} !(TVar (Reversed WorkflowCommand))
   , workflowSequenceMaps :: {-# UNPACK #-} !(TVar SequenceMaps)
   , workflowSignalHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (Vector Payload -> Workflow ())))

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -37,6 +37,7 @@ import Data.ProtoLens
 import Data.Proxy
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.HashSet as HashSet
 import qualified Data.Text as Text
 import Data.Time.Clock.System (SystemTime (..))
 import Data.Vault.Strict (Vault)
@@ -141,6 +142,7 @@ create
           }
     workflowTime <- newIORef $ MkSystemTime 0 0
     workflowIsReplaying <- newIORef False
+    workflowKnownFlags <- newIORef mempty
     workflowSequenceMaps <- newTVarIO $ SequenceMaps mempty mempty mempty mempty mempty mempty mempty
     workflowCommands <- newTVarIO $ Reversed []
     workflowSignalHandlers <- newIORef mempty
@@ -349,6 +351,7 @@ activate act suspension = do
   let completionBase = defMessage & Completion.runId .~ rawRunId info.runId
   writeIORef inst.workflowTime (act ^. Activation.timestamp . to timespecFromTimestamp)
   writeIORef inst.workflowIsReplaying (act ^. Activation.isReplaying)
+  modifyIORef' inst.workflowKnownFlags (HashSet.union (HashSet.fromList (act ^. Activation.availableInternalFlags)))
   eResult <- case inst.workflowDeadlockTimeout of
     Nothing -> applyJobs (act ^. Activation.vec'jobs) suspension
     Just timeoutDuration -> do

--- a/sdk/test/OpenTelemetrySpec.hs
+++ b/sdk/test/OpenTelemetrySpec.hs
@@ -17,7 +17,8 @@ rather than leaking onto the workflow's main fiber.
 module OpenTelemetrySpec where
 
 import Control.Concurrent.Async (async)
-import Control.Exception (SomeException, finally)
+import Control.Exception (Exception, SomeException, finally)
+import qualified Control.Monad.Catch as Catch
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -29,6 +30,7 @@ import RequireCallStack (provideCallStack)
 import Temporal.Activity
 import qualified Temporal.Client as C
 import Temporal.Duration
+import Temporal.Exception (UpdateFailure (..))
 import Temporal.Worker
 import qualified Temporal.Workflow as W
 import Test.Hspec
@@ -94,6 +96,14 @@ shouldBeChildOf child parent = do
   spanId parentCtx `shouldBe` spanId (spanContext parent)
 
 
+-- | Thrown by the suspending update handler in the throw-across-suspension test.
+data OtelHandlerBoom = OtelHandlerBoom
+  deriving stock (Show)
+
+
+instance Exception OtelHandlerBoom
+
+
 spec :: Spec
 spec = aroundAll_ withCaptureTracerProvider $ withTestServer_ tests
 
@@ -148,6 +158,60 @@ tests = describe "OpenTelemetry spans" $ do
     startActivity `shouldBeChildOf` handleUpdate
     -- And the activity execution continues that same trace.
     runActivity `shouldBeChildOf` startActivity
+
+  it "closes and marks the HandleUpdate span Error when a suspending update handler throws after resuming" $ \TestEnv {..} -> do
+    drainSpans
+    let updateDef :: W.KnownUpdate '[Int] Int SomeException
+        updateDef = W.KnownUpdate {knownUpdateCodec = defaultCodec, knownUpdateName = "otelThrowingUpdate"}
+        completeSig = W.KnownSignal @'[] "otelCompleteThrow" defaultCodec
+        workflow :: MyWorkflow Int
+        workflow = do
+          gate <- W.newStateVar False
+          started <- W.newStateVar False
+          done <- W.newStateVar False
+          W.setSignalHandler completeSig $ W.writeStateVar done True
+          W.setUpdateHandler
+            updateDef
+            ( \_ -> do
+                -- First step is not a throw: record arrival, then SUSPEND on the
+                -- gate so the throw below rides the fiber's captured continuation
+                -- across a suspend/resume.
+                W.writeStateVar started True
+                W.waitCondition (W.readStateVar gate)
+                Catch.throwM OtelHandlerBoom
+            )
+            Nothing
+          -- Only open the gate once the handler has run its first step and
+          -- parked, guaranteeing it suspended before it throws.
+          W.waitCondition (W.readStateVar started)
+          W.writeStateVar gate True
+          -- Keep the workflow alive until the client signals completion, so the
+          -- failing update is reported while the workflow is still running.
+          W.waitCondition (W.readStateVar done)
+          pure 99
+        wf = W.provideWorkflow defaultCodec "otelThrowingUpdateWorkflow" workflow
+        conf = provideCallStack $ configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+          updateOpts = C.UpdateOptions {updateId = "otel-throw-update", updateHeaders = mempty}
+      (updateOutcome, wr) <- useClient do
+        h <- C.start wf.reference "otelThrowingUpdateWf" opts
+        outcome <- Catch.try (C.executeUpdate h updateDef updateOpts 7)
+        C.signal h completeSig C.defaultSignalOptions
+        wfResult <- C.waitWorkflowResult h
+        pure (outcome :: Either UpdateFailure Int, wfResult)
+      -- The update must surface as a failure to the client...
+      updateOutcome `shouldSatisfy` \case
+        Left (UpdateFailure _) -> True
+        Right _ -> False
+      -- ...while the workflow itself keeps running and completes normally.
+      wr `shouldBe` 99
+    -- The span is ended in the generalBracket release even though the handler
+    -- threw after resuming, and the ExitCaseException path marks it Error.
+    handleUpdate <- spanNamed "HandleUpdate:otelThrowingUpdate"
+    case spanStatus handleUpdate of
+      Error msg -> Text.unpack msg `shouldContain` "OtelHandlerBoom"
+      other -> expectationFailure $ "expected Error span status, got " <> show other
 
   it "parents signal handler spans to the client's SignalWorkflow span" $ \TestEnv {..} -> do
     drainSpans

--- a/sdk/test/ReplaySpec.hs
+++ b/sdk/test/ReplaySpec.hs
@@ -1,9 +1,14 @@
 module ReplaySpec where
 
 import Control.Monad (void, when)
+import qualified Control.Monad.Catch as Catch
 import Data.Either (isLeft, isRight)
 import Data.ProtoLens.Encoding (encodeMessage)
 import qualified Data.Text as Text
+import Data.Word (Word32)
+import Lens.Family2 ((&), (.~), (^.))
+import qualified Proto.Temporal.Api.History.V1.Message_Fields as HistoryF
+import qualified Proto.Temporal.Api.Sdk.V1.TaskCompleteMetadata_Fields as SdkMetaF
 import RequireCallStack (provideCallStack)
 import System.Directory (getTemporaryDirectory, removeFile)
 import Temporal.Activity
@@ -306,3 +311,99 @@ tests = describe "Workflow Replay" $ do
     specify "rejects garbage proto bytes" $ \_env -> do
       result <- Core.historyProtoToJson "not valid protobuf at all"
       result `shouldSatisfy` isLeft
+
+  describe "race loser cancellation SDK flag" $ do
+    -- Contract: a live run of @race winner loser@ whose dropped loser has a
+    -- finalizer records the race-loser-cancellation SDK flag (id 1) in
+    -- history, so replays of that history keep the new behavior. The winner
+    -- sleeps a timer so the race resolves in a LATER workflow task; the flag
+    -- is used (and its id recorded) in that task's completion.
+    specify "records flag id 1 in history when a race drops a loser with a finalizer" $ \TestEnv {..} -> do
+      let workflow :: W.ProvidedWorkflow (W.Workflow ())
+          workflow = W.provideWorkflow JSON "flag-emit-race-wf" $ provideCallStack $ do
+            gate <- W.newStateVar False
+            cleanupRan <- W.newStateVar False
+            let winner :: MyWorkflow ()
+                winner = W.sleep (milliseconds 5)
+                loser :: MyWorkflow ()
+                loser =
+                  W.waitCondition (W.readStateVar gate)
+                    `Catch.finally` W.writeStateVar cleanupRan True
+            _ <- winner `W.race` loser
+            pure ()
+          conf = provideCallStack $ configure () workflow baseConf
+
+      history <- withWorker conf $ do
+        uuid <- uuidText
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient $ do
+          wfHandle <- C.start workflow (W.WorkflowId uuid) opts
+          C.waitWorkflowResult wfHandle
+          C.fetchHistory wfHandle
+
+      -- Every langUsedFlags list carried by a WorkflowTaskCompleted event's
+      -- sdkMetadata; flag id 1 must appear in at least one of them.
+      let recordedFlags =
+            concat
+              [ meta ^. SdkMetaF.langUsedFlags
+              | ev <- history ^. HistoryF.events
+              , Just attrs <- [ev ^. HistoryF.maybe'workflowTaskCompletedEventAttributes]
+              , Just meta <- [attrs ^. HistoryF.maybe'sdkMetadata]
+              ]
+      recordedFlags `shouldSatisfy` elem (1 :: Word32)
+
+    -- Contract: the flag is LOAD-BEARING on replay. When the loser's finalizer
+    -- schedules a (compensation) activity, cancelling the loser shows up in
+    -- history as an ActivityTaskScheduled. With flag id 1 present the SDK
+    -- reproduces the cancellation and schedules that activity, so replay is
+    -- consistent (Right). Strip flag id 1 from every WorkflowTaskCompleted
+    -- event and the SDK no longer knows the flag on replay: it takes the OLD
+    -- (pre-flag) behavior, drops the loser silently, and never schedules the
+    -- compensation activity the recorded history contains -> non-determinism
+    -- (Left). A genuine pre-flag history looks exactly like the stripped one
+    -- (no id 1 AND no compensation), so it deterministically gets the old
+    -- behavior: the migration is safe.
+    specify "flag id 1 gates whether the loser's compensation activity replays" $ \TestEnv {..} -> do
+      let actOpts = W.defaultStartActivityOptions $ W.StartToClose $ seconds 10
+          workflow :: W.ProvidedWorkflow (W.Workflow ())
+          workflow = W.provideWorkflow JSON "flag-gate-replay-wf" $ provideCallStack $ do
+            gate <- W.newStateVar False
+            let winner :: MyWorkflow ()
+                winner = W.sleep (milliseconds 5)
+                loser :: MyWorkflow ()
+                loser =
+                  Catch.bracket
+                    (pure ())
+                    (\_ -> void (W.executeActivity replayActivityDef.reference actOpts))
+                    (\_ -> W.waitCondition (W.readStateVar gate))
+            _ <- winner `W.race` loser
+            pure ()
+          conf = provideCallStack $ configure () (replayActivityDef, workflow) baseConf
+
+      history <- withWorker conf $ do
+        uuid <- uuidText
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient $ do
+          wfHandle <- C.start workflow (W.WorkflowId uuid) opts
+          C.waitWorkflowResult wfHandle
+          C.fetchHistory wfHandle
+
+      -- (a) With flag id 1 present, the cancellation (and its compensation
+      -- activity) replays consistently.
+      withFlag <- runReplayHistory globalRuntime conf history
+      withFlag `shouldSatisfy` isRight
+
+      -- (b) Strip all lang flags (id 1 included) from every
+      -- WorkflowTaskCompleted event's sdkMetadata, leaving everything else
+      -- (including the recorded compensation activity) untouched.
+      let stripEvent ev = case ev ^. HistoryF.maybe'workflowTaskCompletedEventAttributes of
+            Nothing -> ev
+            Just attrs -> case attrs ^. HistoryF.maybe'sdkMetadata of
+              Nothing -> ev
+              Just meta ->
+                ev
+                  & HistoryF.maybe'workflowTaskCompletedEventAttributes
+                    .~ Just (attrs & HistoryF.maybe'sdkMetadata .~ Just (meta & SdkMetaF.langUsedFlags .~ []))
+          strippedHistory = history & HistoryF.events .~ map stripEvent (history ^. HistoryF.events)
+      withoutFlag <- runReplayHistory globalRuntime conf strippedHistory
+      withoutFlag `shouldSatisfy` isLeft

--- a/sdk/test/WorkflowSpec.hs
+++ b/sdk/test/WorkflowSpec.hs
@@ -1060,3 +1060,103 @@ tests = do
         let opts = defaultStartOpts taskQueue
         useClient (C.execute wf.reference "continuedFailureWf" opts)
           `shouldReturn` True
+
+  describe "race loser cancellation" $ do
+    specify "runs the dropped loser's finally and returns the winner" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Either Text Text, Bool)
+          workflow = do
+            cleanupRan <- W.newStateVar False
+            gate <- W.newStateVar False
+            let winner :: MyWorkflow Text
+                winner = W.sleep (nanoseconds 1) >> pure "winner"
+                loser :: MyWorkflow Text
+                loser =
+                  (W.waitCondition (W.readStateVar gate) >> pure "loser")
+                    `Catch.finally` W.writeStateVar cleanupRan True
+            result <- winner `W.race` loser
+            ran <- W.readStateVar cleanupRan
+            pure (result, ran)
+          wf = W.provideWorkflow defaultCodec "raceLoserFinally" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient (C.execute wf.reference "raceLoserFinally" opts)
+          `shouldReturn` (Left "winner", True)
+
+    specify "catch-all in the loser does not swallow the fiber cancellation" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Bool, Bool)
+          workflow = do
+            cleanupRan <- W.newStateVar False
+            swallowed <- W.newStateVar False
+            gate <- W.newStateVar False
+            let winner :: MyWorkflow Text
+                winner = W.sleep (nanoseconds 1) >> pure "winner"
+                loser :: MyWorkflow Text
+                loser =
+                  ( (W.waitCondition (W.readStateVar gate) >> pure "loser")
+                      `Catch.catch` \(_ :: SomeException) -> W.writeStateVar swallowed True >> pure "swallowed"
+                  )
+                    `Catch.finally` W.writeStateVar cleanupRan True
+            _ <- winner `W.race` loser
+            ran <- W.readStateVar cleanupRan
+            sw <- W.readStateVar swallowed
+            pure (ran, sw)
+          wf = W.provideWorkflow defaultCodec "raceLoserCatchAll" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient (C.execute wf.reference "raceLoserCatchAll" opts)
+          `shouldReturn` (True, False)
+
+    specify "the winning side still runs its bracket release exactly once" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Either Int Text, Int)
+          workflow = do
+            winnerReleases <- W.newStateVar (0 :: Int)
+            gate <- W.newStateVar False
+            let winner :: MyWorkflow Int
+                winner =
+                  Catch.bracket
+                    (pure ())
+                    (\_ -> W.modifyStateVar winnerReleases (+ 1))
+                    (\_ -> W.sleep (nanoseconds 1) >> pure 42)
+                loser :: MyWorkflow Text
+                loser = W.waitCondition (W.readStateVar gate) >> pure "loser"
+            result <- winner `W.race` loser
+            releases <- W.readStateVar winnerReleases
+            pure (result, releases)
+          wf = W.provideWorkflow defaultCodec "raceWinnerBracket" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient (C.execute wf.reference "raceWinnerBracket" opts)
+          `shouldReturn` (Left 42, 1)
+
+    specify "runs all nested finalizers on the dropped loser" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Bool, Bool)
+          workflow = do
+            outerRan <- W.newStateVar False
+            innerRan <- W.newStateVar False
+            gate <- W.newStateVar False
+            let winner :: MyWorkflow Text
+                winner = W.sleep (nanoseconds 1) >> pure "winner"
+                loser :: MyWorkflow Text
+                loser =
+                  Catch.bracket
+                    (pure ())
+                    (\_ -> W.writeStateVar outerRan True)
+                    ( \_ ->
+                        Catch.bracket
+                          (pure ())
+                          (\_ -> W.writeStateVar innerRan True)
+                          (\_ -> W.waitCondition (W.readStateVar gate) >> pure "loser")
+                    )
+            _ <- winner `W.race` loser
+            outer <- W.readStateVar outerRan
+            inner <- W.readStateVar innerRan
+            pure (outer, inner)
+          wf = W.provideWorkflow defaultCodec "raceLoserNested" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient (C.execute wf.reference "raceLoserNested" opts)
+          `shouldReturn` (True, True)


### PR DESCRIPTION
## What

Gives the `Workflow` monad a `Control.Monad.Catch.MonadMask` instance and makes its bracket family behave correctly over the two things that were previously impossible: **suspending interceptor handlers** and **dropped `race` losers** — the latter gated on a Temporal **SDK internal flag** so it is replay-safe.

Builds on `ian/workflow-delimited-continuations` (base of this PR), so the diff here is only this follow-on.

## 1. Unlawful (but "sound") `MonadMask`

Interceptors could `try`/`catch` a suspending update/signal handler but not `bracket`/`finally` it: `Workflow` had `MonadThrow`/`MonadCatch` but no `MonadMask`. A *lawful* `MonadMask` is impossible (async-masking state is thread-state-object local, not on the stack, so `control0#` cannot carry it across a suspend/resume). So this ships a documented, intentionally unlawful instance:

- `mask`/`uninterruptibleMask` are identity; they do **not** block async exceptions (moot: an instance runs on one dedicated GHC thread, cooperative fibers).
- `generalBracket` catches at the **IO level** and re-raises the original exception verbatim, so `bracket`/`finally`/`onException` fire finalizers on every exit, even across suspension (the handler frame rides the fiber's captured continuation).

Sound because `Workflow` **structurally cannot allocate a leakable resource** (`TypeError` on `MonadIO`/`MonadUnliftIO`), and resource safety is the only thing `MonadMask`'s laws protect.

## 2. Finalizers run on cancelled `race` losers

`race`/`biselectOpt` used to abandon a losing side's continuation, so a `bracket`/`finally` guarding it never ran. Now `cancelSubFiber` resumes the dropped continuation **once** with a synthetic `WorkflowFiberCancelled`, so its finalizers run through `generalBracket`'s `ExitCaseException` path, mirroring `Control.Concurrent.Async.cancel`. A finalizer that itself suspends is driven to completion, so `race` waits on the loser (as `async`'s `race` does).

**Safer than raw Haskell:** the user-facing `catch`/`try`/`<|>` refuse to swallow `WorkflowFiberCancelled`, so a catch-all in a loser cannot resurrect a cancelled fiber; only the bracket family observes it.

## 3. Replay safety via an SDK internal flag

Running loser finalizers changes the command stream, so a history recorded before this change would break on replay. Handled the way the TypeScript/Python/Go SDKs handle behavior-changing bug fixes — a **lang SDK internal flag** (`sdkFlagRaceLoserCancellation`, id 1):

- `WorkflowInstance.activate` unions each activation's `available_internal_flags` into the instance; `flushCommands` echoes the accumulated set back as `Success.used_internal_flags`, which core records into history as `WorkflowTaskCompletedMetadata.lang_used_flags`.
- `tryUseSdkFlag`: on a live task, enable the behavior and record the id; on replay, return whether the id was recorded in history up to that task.
- `biselectOpt` cancels a dropped loser **only when the flag is enabled**; when disabled it drops silently and does not even force the loser's step (byte-identical to the old behavior).

Result: histories recorded before this change lack id 1 → replay with old behavior; new executions record id 1 → cancel losers. This SDK had never recorded any lang flag, so id 1 is free and the migration is clean.

## Also

- `Contrib.OpenTelemetry.inWorkflowHandlerSpan` uses `generalBracket`, so update/signal handler spans close across suspension, `Error` status on the throwing path.
- Corrected a now-inaccurate `withFiberContext` comment (fibers never migrate threads).

## Risk

- The `MonadMask` instance is deliberately unlawful (no async masking); safe only because `Workflow` cannot hold a leakable resource.
- A loser finalizer that suspends forever makes `race` hang, exactly as `Control.Concurrent.Async.race` does under `uninterruptibleCancel`.

## Verification

- Full `cabal test temporal-sdk`: **527 examples, 0 failures, 66 pending** on GHC 9.10.1 against an ephemeral dev server.
- New specs: 4 race-loser-cancellation (`WorkflowSpec`), 2 SDK-flag replay-gating (`ReplaySpec`: flag id 1 is recorded in history on a live race-drop; stripping it from history flips replay to a `TMPRL1100` nondeterminism error, proving the flag is load-bearing and pre-flag histories get old behavior), and the OTel throwing-across-suspension update test. Teeth proven by assertion-flip.
- Not yet run: 3-way `nix build` for GHC 9.6/9.8 CI parity (change uses only version-agnostic API).

Agent: claude-opus-4-8