### PR TITLE
client: fix event streaming pagination bug

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -151,6 +151,7 @@ tests:
     source-dirs: test
     other-modules:
       Spec,
+      ClientHistorySpec,
       ContinueAsNewSpec,
       DurationSpec,
       IntegrationSpec,

--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -82,6 +82,7 @@ module Temporal.Client (
   -- * Workflow history utilities
   fetchHistory,
   streamEvents,
+  streamEventsWith,
   FollowOption (..),
 
   -- * List workflows
@@ -1011,15 +1012,28 @@ streamEvents
   => FollowOption
   -> GetWorkflowExecutionHistoryRequest
   -> ConduitT i HistoryEvent m ()
-streamEvents followOpt baseReq = askWorkflowClient >>= \c -> go c baseReq
+streamEvents followOpt baseReq = do
+  c <- askWorkflowClient
+  let fetch req =
+        liftIO (getWorkflowExecutionHistory c.clientCore req)
+          >>= either (throwIO . Temporal.Exception.coreRpcErrorToRpcError) pure
+  streamEventsWith fetch followOpt baseReq
+
+
+{- | 'streamEvents' with the history fetch injected. Factored out so the
+follow / pagination loop can be tested without a live server. -}
+streamEventsWith
+  :: (Monad m)
+  => (GetWorkflowExecutionHistoryRequest -> m GetWorkflowExecutionHistoryResponse)
+  -> FollowOption
+  -> GetWorkflowExecutionHistoryRequest
+  -> ConduitT i HistoryEvent m ()
+streamEventsWith fetch followOpt = go
   where
-    go c req = do
-      res <- liftIO $ getWorkflowExecutionHistory c.clientCore req
-      case res of
-        Left err -> throwIO $ Temporal.Exception.coreRpcErrorToRpcError err
-        Right x -> do
-          yieldMany (x ^. RR.history . History.events)
-          for_ (decideLoop baseReq x) (go c)
+    go req = do
+      x <- lift (fetch req)
+      yieldMany (x ^. RR.history . History.events)
+      for_ (decideLoop req x) go
     decideLoop :: GetWorkflowExecutionHistoryRequest -> GetWorkflowExecutionHistoryResponse -> Maybe GetWorkflowExecutionHistoryRequest
     decideLoop req res =
       if V.null (res ^. RR.history . History.vec'events)
@@ -1047,7 +1061,9 @@ streamEvents followOpt baseReq = askWorkflowClient >>= \c -> go c baseReq
                           & RR.nextPageToken .~ ""
                           & RR.execution %~ (RR.runId .~ (attrs ^. History.newExecutionRunId))
                 ThisRunOnly -> Nothing
-              _ -> Nothing
+              -- A non-terminal last event means the run's history continues on
+              -- the next page; keep paginating rather than truncating here.
+              _ -> nextPage
       where
         nextPage =
           if res ^. RR.nextPageToken == ""

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -158,7 +158,7 @@ test-suite temporal-sdk-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      Spec, ContinueAsNewSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, LocalActivitySpec, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, RegisterWorkflowsSpec, ReplaySpec, ScheduleSpec, SignalSpec, TestHelpers, THCompiles, WorkerTunerSpec
+      Spec, ClientHistorySpec, ContinueAsNewSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, LocalActivitySpec, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, RegisterWorkflowsSpec, ReplaySpec, ScheduleSpec, SignalSpec, TestHelpers, THCompiles, WorkerTunerSpec
   hs-source-dirs:
       test
   default-extensions:

--- a/sdk/test/ClientHistorySpec.hs
+++ b/sdk/test/ClientHistorySpec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ClientHistorySpec where
+
+import Conduit (runConduit, sinkList, (.|))
+import Data.IORef
+import Data.ProtoLens (defMessage)
+import Lens.Family2 ((&), (.~), (^.))
+import Proto.Temporal.Api.History.V1.Message (HistoryEvent)
+import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
+import Proto.Temporal.Api.Workflowservice.V1.RequestResponse
+  ( GetWorkflowExecutionHistoryRequest
+  , GetWorkflowExecutionHistoryResponse
+  )
+import qualified Proto.Temporal.Api.Workflowservice.V1.RequestResponse_Fields as RR
+import Temporal.Client (FollowOption (..), streamEventsWith)
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "streamEvents follow/pagination loop" $ do
+  it "carries the followed run's id across pages and paginates fully" $ do
+    let historyResp evs tok =
+          defMessage
+            & RR.history .~ (defMessage & History.events .~ evs)
+            & RR.nextPageToken .~ tok ::
+            GetWorkflowExecutionHistoryResponse
+        canEvent runId =
+          defMessage
+            & History.workflowExecutionContinuedAsNewEventAttributes
+              .~ (defMessage & History.newExecutionRunId .~ runId) ::
+            HistoryEvent
+        wftEvent = defMessage & History.workflowTaskCompletedEventAttributes .~ defMessage :: HistoryEvent
+        completedEvent = defMessage & History.workflowExecutionCompletedEventAttributes .~ defMessage :: HistoryEvent
+        req0 =
+          defMessage & RR.execution .~ (defMessage & RR.runId .~ "run-A") ::
+            GetWorkflowExecutionHistoryRequest
+        responses =
+          [ historyResp [canEvent "run-B"] "" -- run A ends by continuing as new to run B
+          , historyResp [wftEvent] "page-2-token" -- run B, first page: more to come
+          , historyResp [completedEvent] "" -- run B, final page
+          ]
+    respsRef <- newIORef responses
+    reqsRef <- newIORef []
+    let fetch req = do
+          modifyIORef' reqsRef (<> [req])
+          readIORef respsRef >>= \case
+            (r : rest) -> writeIORef respsRef rest >> pure r
+            [] -> pure (historyResp [completedEvent] "") -- terminate if over-fetched
+    _ <- runConduit (streamEventsWith fetch FollowRuns req0 .| sinkList)
+    reqs <- readIORef reqsRef
+    -- Did not truncate on the non-terminal middle page (all three pages fetched).
+    length reqs `shouldBe` 3
+    -- The page after the continue-as-new targets run B, not the original run A.
+    ((reqs !! 2) ^. RR.execution . RR.runId) `shouldBe` "run-B"

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -58,7 +58,6 @@ import IntegrationSpec.Updates
 import Lens.Family2
 import OpenTelemetry.Trace
 import qualified Proto.Temporal.Api.Failure.V1.Message_Fields as Failure
-import Proto.Temporal.Api.History.V1.Message (WorkflowExecutionFailedEventAttributes (..))
 import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
 import RequireCallStack
 import System.Directory


### PR DESCRIPTION
## description

ran into a continue-as-new bug with the error: `RunId in the request does not match the NextPageToken.`

turns out this is the same bug as in #294, so we can resolve both & add a small regression test to confirm that this works as expected.