### PR TITLE
workflow: fix signal-with-start delivery

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -167,6 +167,7 @@ tests:
       ReplaySpec,
       ScheduleSpec,
       SignalSpec,
+      SignalWithStartDropSpec,
       TestHelpers,
       THCompiles,
       WorkerTunerSpec

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -51,7 +51,8 @@ data EvictionWithRunID = EvictionWithRunID
   deriving stock (Show)
 
 
-data WorkflowWorker = forall ty.
+data WorkflowWorker
+  = forall ty.
   Core.KnownWorkerType ty =>
   WorkflowWorker
   { workerWorkflowFunctions :: {-# UNPACK #-} !(HashMap Text WorkflowDefinition)
@@ -156,7 +157,14 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
     then do
       mInst <- createOrFetchWorkflowInstance
       forM_ mInst $ \inst -> do
-        let withoutStart = filter (\job -> isNothing (job ^. Activation.maybe'initializeWorkflow)) (activation ^. Activation.jobs)
+        -- Signals in the initialization activation were already buffered into the
+        -- instance (see applyStartWorkflow), so drop them here rather than
+        -- delivering them a second time through the channel.
+        let isInitActivation = not $ V.null activationInitializeWorkflowJobs
+            keepJob job =
+              isNothing (job ^. Activation.maybe'initializeWorkflow)
+                && not (isInitActivation && isJust (job ^. Activation.maybe'signalWorkflow))
+            withoutStart = filter keepJob (activation ^. Activation.jobs)
         case withoutStart of
           [] -> pure ()
           otherJobs -> atomically $ writeTQueue inst.activationChannel (activation & Activation.jobs .~ otherJobs)
@@ -244,11 +252,14 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                       rootWf <- initializeWorkflow ^. Activation.maybe'rootWorkflow
                       let rWfId = rootWf ^. CommonProto.workflowId
                           rRunId = rootWf ^. CommonProto.runId
-                      if Text.null rWfId then Nothing
-                      else Just RootExecution
-                        { rootWorkflowId = WorkflowId rWfId
-                        , rootRunId = RunId rRunId
-                        }
+                      if Text.null rWfId
+                        then Nothing
+                        else
+                          Just
+                            RootExecution
+                              { rootWorkflowId = WorkflowId rWfId
+                              , rootRunId = RunId rRunId
+                              }
                     workflowInfo =
                       Temporal.WorkflowInstance.Info
                         { historyLength = activation ^. Activation.historyLength
@@ -301,6 +312,12 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     liftIO (Core.completeWorkflowActivation workerCore completionMessage >>= either throwIO pure)
                     pure Nothing
                   Just (WorkflowDefinition _ f) -> do
+                    -- Signals arriving with the start job (e.g. signalWithStart) get
+                    -- buffered before the workflow body runs; handleActivation drops
+                    -- them from the activation channel so they aren't delivered twice.
+                    let initialSignals =
+                          V.toList $
+                            V.mapMaybe (\j -> j ^. Activation.maybe'signalWorkflow) (activation ^. Activation.vec'jobs)
                     inst <-
                       create
                         ( \wf -> do
@@ -315,6 +332,7 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                         worker.processor
                         workflowInfo
                         initializeWorkflow
+                        initialSignals
                     liftIO $ addBuiltinQueryHandlers inst
                     Just <$> upsertWorkflowInstance runId_ inst
           pure $ join (vExistingInstance V.!? 0)

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -27,7 +27,9 @@ import qualified Data.Aeson as Aeson
 
 
 #if __GLASGOW_HASKELL__ < 910
-import Data.Foldable (foldl')
+import Data.Foldable (foldl', traverse_)
+#else
+import Data.Foldable (traverse_)
 #endif
 import Data.Functor.Identity
 import qualified Data.HashMap.Strict as HashMap
@@ -110,6 +112,9 @@ create
   -> PayloadProcessor
   -> Info
   -> InitializeWorkflow
+  -> [SignalWorkflow]
+  -- ^ Signals delivered in the same activation as the start job (e.g. via
+  -- @signalWithStart@). Buffered before the workflow body runs; see 'applyStartWorkflow'.
   -> m WorkflowInstance
 create
   workflowCompleteActivation
@@ -121,7 +126,8 @@ create
   workflowVault
   payloadProcessor
   info
-  start = do
+  start
+  initialSignals = do
     Logging.logDebug "Instantiating workflow instance"
     workflowInstanceLogger <- askLoggerIO
     workflowRandomnessSeed <- WorkflowGenM <$> newIORef (mkStdGen 0)
@@ -165,7 +171,7 @@ create
       exec <- setUpWorkflowExecution start
       res <- liftIO $ inboundInterceptor.executeWorkflow exec $ \exec' -> runInstanceM inst $ runTopLevel $ do
         Logging.logDebug "Executing workflow"
-        wf <- applyStartWorkflow exec' workflowFn
+        wf <- applyStartWorkflow initialSignals exec' workflowFn
         runWorkflowToCompletion wf
       Logging.logDebug "Workflow execution completed"
       addCommand =<< convertExitVariantToCommand res
@@ -397,8 +403,8 @@ setUpWorkflowExecution initializeWorkflow = do
       }
 
 
-applyStartWorkflow :: ExecuteWorkflowInput -> (Vector Payload -> IO (Either String (Workflow Payload))) -> InstanceM (SuspendableWorkflowExecution Payload)
-applyStartWorkflow execInput workflowFn = do
+applyStartWorkflow :: [SignalWorkflow] -> ExecuteWorkflowInput -> (Vector Payload -> IO (Either String (Workflow Payload))) -> InstanceM (SuspendableWorkflowExecution Payload)
+applyStartWorkflow initialSignals execInput workflowFn = do
   inst <- ask
   let executeWorkflowBase input = runInstanceM inst $ do
         Logging.logInfo $
@@ -423,7 +429,15 @@ applyStartWorkflow execInput workflowFn = do
             throwIO (ValueError msg)
           Right act -> do
             Logging.logDebug "Calling runWorkflow"
-            pure (runWorkflow act)
+            -- Apply any signals that arrived with the start job before running the
+            -- workflow body.
+            --
+            -- No handler is registered yet, so they land in the signal buffer,
+            -- which setSignalHandler drains when the body installs its handler.
+            --
+            -- Safe on replay: the first activation carries the same signals,
+            -- and buffering emits no commands.
+            pure . runWorkflow $ traverse_ applySignalWorkflow initialSignals *> act
 
   liftIO $ executeWorkflowBase execInput
 

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -158,7 +158,7 @@ test-suite temporal-sdk-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      Spec, ClientHistorySpec, ContinueAsNewSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, LocalActivitySpec, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, RegisterWorkflowsSpec, ReplaySpec, ScheduleSpec, SignalSpec, TestHelpers, THCompiles, WorkerTunerSpec
+      Spec, ClientHistorySpec, ContinueAsNewSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, LocalActivitySpec, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, RegisterWorkflowsSpec, ReplaySpec, ScheduleSpec, SignalSpec, SignalWithStartDropSpec, TestHelpers, THCompiles, WorkerTunerSpec
   hs-source-dirs:
       test
   default-extensions:

--- a/sdk/test/SignalWithStartDropSpec.hs
+++ b/sdk/test/SignalWithStartDropSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module SignalWithStartDropSpec where
+
+import RequireCallStack (provideCallStack)
+import qualified Temporal.Client as C
+import Temporal.Duration (nanoseconds, seconds)
+import Temporal.Worker (configure)
+import qualified Temporal.Workflow as W
+import Test.Hspec
+import TestHelpers
+
+
+kickSignal :: W.KnownSignal '[Int]
+kickSignal = W.KnownSignal "kick" defaultCodec
+
+
+spec :: Spec
+spec = withTestServer_ $ describe "signalWithStart signal delivery" $ do
+  -- a handler installed at the top of the workflow must observe a signal
+  -- delivered atomically with start, even with no intervening yield.
+  it "delivers the signal to an unguarded top-of-workflow handler" $ \TestEnv {..} -> do
+    let wfBody :: W.Workflow (Maybe Int)
+        wfBody = provideCallStack $ do
+          received <- W.newStateVar (Nothing :: Maybe Int)
+          W.setSignalHandler kickSignal $ \n -> W.writeStateVar received (Just n)
+          W.readStateVar received
+        wf = W.provideWorkflow defaultCodec "SignalWithStartDropSpec.unguarded" wfBody
+    withWorker (configure () wf baseConf) $ do
+      wfId <- W.WorkflowId <$> uuidText
+      h <- useClient (C.signalWithStart wf wfId (defaultStartOptsWithTimeout taskQueue (seconds 30)) kickSignal 42)
+      useClient (C.waitWorkflowResult h) `shouldReturn` Just 42


### PR DESCRIPTION
## description

there's an issue where if you call `signalWithStart` on a workflow that can be completed on initial activation, the signal never arrives and the whole thing just ends on the spot.

adding a trivial `sleep` (e.g. for 1 nanosecond) acts as a yield, which kicks the activation loop over and processes the signal properly; that's obviously a bug.

this change extends `create` to take a list of signals delivered in the same activation as the start job, and changes some of the filtering logic to ensure that they don't get double counted.