### PR TITLE
workflow: fix search attribute upsert precedence

### DIFF
--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -993,7 +993,7 @@ upsertSearchAttributes values = ilift $ do
   addCommand cmd
   inst <- ask
   modifyIORef' inst.workflowInstanceInfo $ \Info {..} ->
-    Info {searchAttributes = searchAttributes <> values, ..}
+    Info {searchAttributes = values <> searchAttributes, ..}
 
 
 {- | Updates this Workflow's Memo by merging the provided values with the existing Memo.

--- a/sdk/test/WorkflowSpec.hs
+++ b/sdk/test/WorkflowSpec.hs
@@ -224,6 +224,20 @@ tests = do
         let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
         useClient (C.execute wf.reference "upsertSA" opts) `shouldReturn` expectedAttrs
 
+    specify "later value wins on key collision" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Map SearchAttributeKey SearchAttributeType)
+          workflow = do
+            W.upsertSearchAttributes $ Map.fromList [("attr2", toSearchAttribute True)]
+            W.upsertSearchAttributes $ Map.fromList [("attr2", toSearchAttribute False)]
+            i <- W.info
+            pure i.searchAttributes
+          wf = W.provideWorkflow defaultCodec "saCollision" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue $ seconds 30
+        m <- useClient $ C.execute wf.reference "saCollision" opts
+        Map.lookup "attr2" m `shouldBe` (Just $ toSearchAttribute False)
+
   describe "Memo" $ do
     specify "able to read memo set at start" $ \TestEnv {..} -> do
       let workflow :: W.Workflow (Map Text Payload)


### PR DESCRIPTION
## description

trivial fix + a test that asserts workflow search attributes should be correctly updated in `Info` after they have been upserted.