### PR TITLE
sdk: speed up test suite

### DIFF
--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -474,6 +474,7 @@ applyQueryWorkflow queryWorkflow = do
       -- TODO, more useful error message
       pure $
         defMessage
+          & Command.queryId .~ rawQueryId baseInput.handleQueryId
           & Command.failed
             .~ ( defMessage
                   & F.message .~ Text.pack (show err)

--- a/sdk/test/ActivitySpec.hs
+++ b/sdk/test/ActivitySpec.hs
@@ -278,35 +278,6 @@ tests = describe "Activities" $ do
         useClient (C.execute wf.reference "immCancelAct" opts)
           `shouldReturn` 1
 
-    specify "activity cancellation on heartbeat" $ \TestEnv {..} -> do
-      let act :: Activity () Int
-          act = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
-            liftIO $ threadDelay 2_000_000
-            heartbeat ()
-            pure 0
-          actDef = provideActivity defaultCodec "hbCancelAct" act
-          workflow :: MyWorkflow Int
-          workflow = do
-            h <- W.startActivity actDef.reference
-              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 1)
-            W.sleep $ nanoseconds 1
-            W.cancel (h :: W.Task Int)
-            W.wait h `Catch.catch` \(_ :: ActivityCancelled) -> pure 1
-          wf = W.provideWorkflow defaultCodec "hbCancelActWf" workflow
-          conf = configure () (wf, actDef) $ do baseConf
-      withWorker conf $ do
-        let opts =
-              (C.startWorkflowOptions taskQueue)
-                { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                , C.timeouts = C.TimeoutOptions
-                    { C.runTimeout = Just $ seconds 4
-                    , C.executionTimeout = Nothing
-                    , C.taskTimeout = Nothing
-                    }
-                }
-        useClient (C.execute wf.reference "hbCancelAct" opts)
-          `shouldReturn` 1
-
   describe "Info" $ do
     specify "can access activity info" $ \TestEnv {..} -> do
       let act :: Activity () Text
@@ -332,7 +303,10 @@ tests = describe "Activities" $ do
               else pure (fromIntegral i.attempt)
           actDef = provideActivity defaultCodec "attemptCountAct" act
           workflow :: MyWorkflow Int
-          workflow = W.executeActivity actDef.reference (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          -- Fast retry interval to keep the test quick
+          workflow = W.executeActivity actDef.reference
+            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+              { retryPolicy = Just $ W.defaultRetryPolicy {W.initialInterval = milliseconds 50} }
           wf = W.provideWorkflow defaultCodec "attemptCountWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -489,7 +463,8 @@ tests = describe "Activities" $ do
   describe "Activity Timeout (Py/TS: activity timeout)" $ do
     specify "activity times out with StartToClose (TS: multipleActivitiesSingleTimeout)" $ \TestEnv {..} -> do
       let act :: Activity () ()
-          act = liftIO $ threadDelay 10_000_000
+          -- Only needs to outlast the 1s StartToClose timeout.
+          act = liftIO $ threadDelay 2_000_000
           actDef = provideActivity defaultCodec "slowTimeoutAct" act
           workflow :: MyWorkflow ()
           workflow = W.executeActivity actDef.reference
@@ -641,7 +616,7 @@ tests = describe "Activities" $ do
 
     specify "activity schedule-to-close timeout" $ \TestEnv {..} -> do
       let act :: Activity () ()
-          act = liftIO $ threadDelay 5_000_000
+          act = liftIO $ threadDelay 2_000_000
           actDef = provideActivity defaultCodec "schedToCloseAct" act
           workflow :: MyWorkflow ()
           workflow = W.executeActivity actDef.reference
@@ -658,7 +633,7 @@ tests = describe "Activities" $ do
 
     specify "activity heartbeat timeout" $ \TestEnv {..} -> do
       let act :: Activity () ()
-          act = liftIO $ threadDelay 5_000_000
+          act = liftIO $ threadDelay 2_000_000
           actDef = provideActivity defaultCodec "heartbeatTimeoutAct" act
           workflow :: MyWorkflow ()
           workflow = W.executeActivity actDef.reference

--- a/sdk/test/CancellationSpec.hs
+++ b/sdk/test/CancellationSpec.hs
@@ -174,9 +174,12 @@ tests = describe "Cancellation" $ do
     specify "Activity cancellation on heartbeat" $ \TestEnv {..} -> do
       let testActivity :: Activity () Int
           testActivity = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
-            liftIO $ threadDelay 2_000_000
-            heartbeat ()
-            pure 0
+            let loop :: Activity () Int
+                loop = do
+                  heartbeat ()
+                  liftIO $ threadDelay 200_000
+                  loop
+            loop
           testActivityAct = provideActivity defaultCodec "heartbeatCancelActivity" testActivity
           workflow :: MyWorkflow Int
           workflow = do

--- a/sdk/test/IntegrationSpec.hs
+++ b/sdk/test/IntegrationSpec.hs
@@ -497,7 +497,7 @@ testImpls =
       , basicActivity = pure 1
       , heartbeatWorks = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
           heartbeat ()
-          liftIO $ threadDelay 1_000_000
+          liftIO $ threadDelay 200_000
           pure 1
       , runHeartbeat = do
           h <-
@@ -777,42 +777,6 @@ needsClient = do
                         }
                   }
           useClient (C.execute wf.reference "immediateActivityCancellation" opts)
-            `shouldReturn` 1
-      specify "Activity cancellation on heartbeat returns the expected result to workflows" $ \TestEnv {..} -> do
-        let testActivity :: Activity () Int
-            testActivity = withHeartbeat JSON $ \heartbeat _readHeartbeat -> do
-              liftIO $ threadDelay 2_000_000
-              heartbeat ()
-              pure 0
-
-            testActivityAct :: ProvidedActivity () (Activity () Int)
-            testActivityAct = provideActivity defaultCodec "heartbeatAllowsOpportunityToCancel" testActivity
-
-            testFn :: MyWorkflow Int
-            testFn = do
-              h1 <-
-                W.startActivity
-                  testActivityAct.reference
-                  (W.defaultStartActivityOptions $ W.StartToClose $ seconds 1)
-              W.sleep $ nanoseconds 1
-              W.cancel (h1 :: W.Task Int)
-              W.wait h1 `Catch.catch` \(_ :: ActivityCancelled) -> pure 1
-
-            wf = W.provideWorkflow defaultCodec "activityCancellationOnHeartbeat" testFn
-            conf = configure () (wf, testActivityAct) $ do
-              baseConf
-        withWorker conf $ do
-          let opts =
-                (C.startWorkflowOptions taskQueue)
-                  { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                  , C.timeouts =
-                      C.TimeoutOptions
-                        { C.runTimeout = Just $ seconds 30
-                        , C.executionTimeout = Nothing
-                        , C.taskTimeout = Nothing
-                        }
-                  }
-          useClient (C.execute wf.reference "activityCancellationOnHeartbeat" opts)
             `shouldReturn` 1
       specify "Activity retry exhaustion returns that in the RetryState" $ \TestEnv {..} -> do
         wfId <- uuidText


### PR DESCRIPTION
## description

* tighten up threadDelay calls
* remove duplicate heartbeat tests
* fix QueryWorkflow RPC call to include queryId on the failing branch, which results in substantially shorter round-trip time (30s -> <100ms)