### PR TITLE
sdk: introduce 'Pending' and 'Awaitable'

### DIFF
--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -130,6 +130,12 @@ module Temporal.Workflow (
   ChildWorkflowHandle,
   Wait (..),
   Cancel (..),
+  -- * Awaitables (return the first, keep the rest running)
+  Pending,
+  Awaitable (..),
+  awaitableWait,
+  poll,
+  select,
   WorkflowHandle (..),
   waitChildWorkflowResult,
   waitChildWorkflowStart,
@@ -337,7 +343,7 @@ import Temporal.Workflow.Unsafe.Handle
 import Temporal.Workflow.Update
 import Temporal.Workflow.WorkflowInstance
 import Temporal.WorkflowInstance
-import UnliftIO
+import UnliftIO hiding (poll)
 
 
 -- class MonadWorkflow m where
@@ -1519,12 +1525,14 @@ sleepUntilUTCTime :: RequireCallStack => UTCTime -> Workflow ()
 sleepUntilUTCTime = sleepUntilSystemTime . utcToSystemTime
 
 
+instance Awaitable Timer where
+  type Awaited Timer = ()
+  toPending t = Pending (timerHandle t) deliverResultVal
+
+
 instance Wait Timer where
   type WaitResult Timer = Workflow ()
-  wait :: RequireCallStack => Timer -> WaitResult Timer
-  wait t = do
-    updateCallStackW
-    getIVar $ timerHandle t
+  wait = awaitableWait
 
 
 instance Cancel Timer where

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -11,11 +11,14 @@ import qualified Control.Monad.Catch as Catch
 import Control.Monad.Logger
 import Control.Monad.Reader
 import Data.Atomics (atomicModifyIORefCAS)
+import Data.Foldable (for_)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
 import Data.Kind
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import Data.Monoid (Endo (..))
 import Data.Set (Set)
@@ -894,6 +897,100 @@ tryReadIVar IVar {ivarRef = ref} = Workflow $ \_ -> do
     IVarFull (ThrowWorkflow e') -> throwWorkflow e'
     IVarFull (ThrowInternal e') -> throwIO e'
     IVarEmpty _ -> pure Nothing
+
+
+-- | A type-erased 'IVar', for 'awaitAny'.
+data SomeIVar = forall v. SomeIVar (IVar v)
+
+
+{- | A first-class handle to a single pending result: the 'IVar' the result will
+be delivered on, paired with a decoder from its raw 'ResultVal' to @a@.
+
+It is a 'Functor' but deliberately not an 'Applicative'\/'Monad': those would
+admit an effect between a bind and the suspension point, and a 'Pending's 
+only valid suspension point is the 'IVar' it wraps.
+-}
+data Pending a = forall v. Pending !(IVar v) !(ResultVal v -> IO a)
+
+
+instance Functor Pending where
+  fmap f (Pending ivar dec) = Pending ivar (fmap f . dec)
+
+
+-- | The 'IVar' underlying a 'Pending', type-erased.
+pendingIVar :: Pending a -> SomeIVar
+pendingIVar (Pending ivar _) = SomeIVar ivar
+
+
+-- | Block until the 'Pending' resolves, then decode.
+-- 
+-- __NOTE__: Callers should prefer the polymorphic 'Temporal.Workflow.wait'.
+awaitPending :: Pending a -> Workflow a
+awaitPending (Pending i@(IVar {ivarId = vid, ivarRef = ref}) dec) = Workflow $ \env -> do
+  e <- readIORef ref
+  rv <- case e of
+    IVarFull r -> do
+      when (vid /= 0) $ removeBlockedStack vid
+      pure r
+    IVarEmpty _ -> do
+      when (vid /= 0) $ recordBlockedStack vid
+      r <- liftIO $ fiberSuspend env i
+      when (vid /= 0) $ removeBlockedStack vid
+      pure r
+  liftIO $ dec rv
+
+
+-- | Non-blocking read.
+-- 
+-- __NOTE__: Callers should prefer the polymorphic 'Temporal.Workflow.poll'.
+pollPending :: Pending a -> Workflow (Maybe a)
+pollPending (Pending IVar {ivarRef = ref} dec) = Workflow $ \_ -> do
+  e <- readIORef ref
+  case e of
+    IVarFull r -> Just <$> liftIO (dec r)
+    IVarEmpty _ -> pure Nothing
+
+
+-- | Block until one of @sources@ resolves; return its index, or the lowest of
+-- two indices if both resolve simultaneously.
+awaitAny :: FiberEnv -> NonEmpty SomeIVar -> InstanceM Int
+awaitAny env sources = do
+  let cenv = fiberContEnv env
+      locals = fiberLocals env
+      srcs = NE.toList sources
+      scanFull :: Int -> [SomeIVar] -> InstanceM (Maybe Int)
+      scanFull _ [] = pure Nothing
+      scanFull !i (SomeIVar ivar : rest) = do
+        c <- readIORef (ivarRef ivar)
+        case c of
+          IVarFull _ -> pure (Just i)
+          IVarEmpty _ -> scanFull (i + 1) rest
+  mFast <- scanFull 0 srcs
+  case mFast of
+    Just i -> pure i
+    Nothing -> do
+      wakeup <- newIVar
+      for_ (reverse (zip [0 :: Int ..] srcs)) $ \(idx, SomeIVar iv) -> do
+        wakerRes <- newIVar
+        let waker = FreshTask $ Workflow $ \_ ->
+              liftIO $ putIVar wakeup (Ok idx) cenv
+        parkTask cenv locals waker wakerRes iv
+      liftIO (fiberSuspend env wakeup) >>= deliverResultVal
+
+
+{- | Return whichever of two 'Pending's resolves first; unlike 'race', the 'Pending'
+that doesn't resolve is __not__ canceled.
+
+If both 'Pending's resolve simultaneously, the first is returned on the 'Left'.
+
+-- __NOTE__: Callers should prefer the polymorphic 'Temporal.Workflow.select'.
+-}
+selectPending :: Pending a -> Pending b -> Workflow (Either a b)
+selectPending l r = Workflow $ \env -> do
+  idx <- awaitAny env (pendingIVar l :| [pendingIVar r])
+  if idx == 0
+    then Left <$> unWorkflow (awaitPending l) env
+    else Right <$> unWorkflow (awaitPending r) env
 
 
 {- | A very restricted Monad that allows for reading 'StateVar' values. This Monad

--- a/sdk/src/Temporal/Workflow/Unsafe/Handle.hs
+++ b/sdk/src/Temporal/Workflow/Unsafe/Handle.hs
@@ -17,7 +17,7 @@ import Temporal.Exception
 import Temporal.Payload
 import Temporal.Workflow.Internal.Instance
 import Temporal.Workflow.Internal.Monad
-import UnliftIO
+import UnliftIO hiding (poll)
 
 
 {- | Some tasks in a Workflow return a handle that can be used to wait for the task to complete.
@@ -42,6 +42,57 @@ class Cancel h where
 
   -- | Signal to Temporal that a handle representing an async action should be cancelled.
   cancel :: RequireCallStack => h -> CancelResult h
+
+
+{- | Handles with a single result 'IVar', which can therefore be reified as a
+'Pending' for 'poll'\/'select'.
+
+Anything convertible to a 'Pending' is trivially waitable, so every 'Awaitable'
+instance is a 'Wait' instance.
+
+The reverse is not true: a handle that blocks on more than one IVar is 'Wait'
+but not 'Awaitable' (e.g. 'ChildWorkflowHandle').
+-}
+class Wait h => Awaitable h where
+  type Awaited h :: Type
+  toPending :: h -> Pending (Awaited h)
+
+
+{- | The canonical 'wait' for an 'Awaitable' handle; 'Wait' instances that are
+also 'Awaitable' should typically only have to write @wait = awaitableWait@.
+-}
+awaitableWait :: (RequireCallStack, Awaitable h) => h -> Workflow (Awaited h)
+awaitableWait h = do
+  updateCallStackW
+  awaitPending (toPending h)
+
+
+-- | A 'Pending' is itself waitable: 'wait' blocks on it and decodes.
+instance Wait (Pending a) where
+  type WaitResult (Pending a) = Workflow a
+  wait = awaitableWait
+
+
+-- | 'toPending' on a 'Pending' is the identity, so 'poll'\/'select' accept a
+-- bare 'Pending' (e.g. one built with 'fmap'), not only handles.
+instance Awaitable (Pending a) where
+  type Awaited (Pending a) = a
+  toPending = id
+
+
+{- | Return whichever of two awaitable handles resolves first; the handle that
+does not return keeps running (see 'Temporal.Workflow.race' if you need
+cancellation).
+
+Left-biased when both handles return simultaneously.
+-}
+select :: (Awaitable x, Awaitable y) => x -> y -> Workflow (Either (Awaited x) (Awaited y))
+select x y = selectPending (toPending x) (toPending y)
+
+
+-- | Non-blocking peek at an awaitable handle: 'Just' if it has already resolved.
+poll :: Awaitable h => h -> Workflow (Maybe (Awaited h))
+poll = pollPending . toPending
 
 
 instance Wait (Task a) where

--- a/sdk/test/TimerSpec.hs
+++ b/sdk/test/TimerSpec.hs
@@ -2,6 +2,7 @@ module TimerSpec where
 
 import Control.Exception (SomeException)
 import qualified Control.Monad.Catch as Catch
+import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime, diffUTCTime)
 import qualified Temporal.Client as C
@@ -266,3 +267,115 @@ tests = describe "Timers and Sleep" $ do
       withWorker conf $ do
         let opts = defaultStartOpts taskQueue
         useClient (C.execute wf.reference "timerInCatch" opts) `shouldReturn` "recovered"
+
+  describe "Awaitable (select / poll / await)" $ do
+    specify "select returns the source that resolves first (left-biased)" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow Text
+          workflow = do
+            mfast <- W.createTimer (nanoseconds 1)
+            mslow <- W.createTimer (minutes 100)
+            case (mfast, mslow) of
+              (Just fast, Just slow) -> do
+                r <- W.select fast slow
+                pure $ either (const "fast") (const "slow") r
+              _ -> pure "no-timer"
+          wf = W.provideWorkflow defaultCodec "awaitableSelect" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient (C.execute wf.reference "awaitableSelect" opts) `shouldReturn` "fast"
+
+    specify "poll is Nothing before the source resolves and Just after" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Bool, Bool)
+          workflow = do
+            mt <- W.createTimer (nanoseconds 10)
+            case mt of
+              Nothing -> pure (False, False)
+              Just t -> do
+                before <- W.poll t
+                W.wait t
+                after <- W.poll t
+                pure (isNothing before, isJust after)
+          wf = W.provideWorkflow defaultCodec "awaitablePoll" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOpts taskQueue
+        useClient (C.execute wf.reference "awaitablePoll" opts) `shouldReturn` (True, True)
+
+    specify "wait on a reified Awaitable blocks until it resolves" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow Bool
+          workflow = do
+            earlier <- W.now
+            mt <- W.createTimer (nanoseconds 10)
+            case mt of
+              Nothing -> pure False
+              Just t -> do
+                W.wait (W.toPending t)
+                later <- W.now
+                pure (later > earlier)
+          wf = W.provideWorkflow defaultCodec "awaitableAwait" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOpts taskQueue
+        useClient (C.execute wf.reference "awaitableAwait" opts) `shouldReturn` True
+
+    specify "select is left-biased when both sources are already resolved" $ \TestEnv {..} -> do
+      -- Resolve a timer, then select it against itself. Both sources are full
+      -- when select runs, so the index-order scan must return the left one
+      -- without parking (parking a full source jumps the run queue and would
+      -- flip the bias).
+      let workflow :: MyWorkflow Text
+          workflow = do
+            mt <- W.createTimer (nanoseconds 10)
+            case mt of
+              Nothing -> pure "no-timer"
+              Just t -> do
+                W.wait t
+                r <- W.select (fmap (const ("l" :: Text)) (W.toPending t)) (fmap (const "r") (W.toPending t))
+                pure (either id id r)
+          wf = W.provideWorkflow defaultCodec "awaitableSelectFastTie" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOpts taskQueue
+        useClient (C.execute wf.reference "awaitableSelectFastTie" opts) `shouldReturn` "l"
+
+    specify "select is left-biased when both sources alias one unresolved IVar" $ \TestEnv {..} -> do
+      -- Both sources are 'Pending's over the same, still-unresolved timer, so
+      -- awaitAny parks two wakers on one IVar and resolves them together. The
+      -- left index must win regardless of park order.
+      let workflow :: MyWorkflow Text
+          workflow = do
+            mt <- W.createTimer (nanoseconds 10)
+            case mt of
+              Nothing -> pure "no-timer"
+              Just t -> do
+                r <- W.select (fmap (const ("l" :: Text)) (W.toPending t)) (fmap (const "r") (W.toPending t))
+                pure (either id id r)
+          wf = W.provideWorkflow defaultCodec "awaitableSelectAliasTie" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOpts taskQueue
+        useClient (C.execute wf.reference "awaitableSelectAliasTie" opts) `shouldReturn` "l"
+
+    specify "a select blocked on the losing side is cancelled and runs its finalizer" $ \TestEnv {..} -> do
+      let workflow :: MyWorkflow (Text, Bool)
+          workflow = do
+            st <- W.newStateVar False
+            let loser :: MyWorkflow Text
+                loser = do
+                  mt1 <- W.createTimer (minutes 100)
+                  mt2 <- W.createTimer (minutes 100)
+                  case (mt1, mt2) of
+                    (Just a, Just b) ->
+                      Catch.finally
+                        (either (const "a") (const "b") <$> W.select a b)
+                        (W.writeStateVar st True)
+                    _ -> pure "no-timer"
+            r <- W.race (pure "win" :: MyWorkflow Text) loser
+            ran <- W.readStateVar st
+            pure (either id id r, ran)
+          wf = W.provideWorkflow defaultCodec "awaitableRaceLoser" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient (C.execute wf.reference "awaitableRaceLoser" opts) `shouldReturn` ("win", True)


### PR DESCRIPTION
## notes

i’m not thrilled with the `awaitAny` formulation, i want to revisit it before i call this ready for review. #415 on the other hand is ready to go so maybe i’ll reorder these commits so that can merge first and this one after.

## description

this PR introduces the `Pending` type which wraps up a single `IVar` & its decode function, as well as an `Awaitable` typeclass which abstracts over `Pending`.

the goal here is to provide a primitive that explicitly only captures in-flight operations which do not admit cancellation and do not modify the command stream.