### PR TITLE
sdk: introduce 'Inflight' concurrency abstraction

### DIFF
--- a/sdk/src/Temporal/Workflow/Internal/Inflight.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Inflight.hs
@@ -1,0 +1,122 @@
+{- | A collection of concurrently-running workflow actions, harvested according
+to the order that they complete.
+
+An action is started once and only ever resumed, so a wait that emits commands
+as it runs (e.g. a local activity backing off between attempts) never re-emits
+them.
+
+An 'Inflight' must always use the value returned by the latest 'push' or 'next',
+since reusing an older one resumes a continuation twice.
+
+Dropping a non-empty 'Inflight' abandons its members: the underlying operations
+keep running, and because the members are neither completed nor cancelled,
+their finalizers never run.
+-}
+module Temporal.Workflow.Internal.Inflight
+  ( Inflight
+  , empty
+  , size
+  , push
+  , fromFoldable
+  , next
+  ) where
+
+import Control.Exception (SomeException)
+import Control.Monad (foldM)
+import Control.Monad.IO.Class (liftIO)
+import Data.Foldable (traverse_)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import Temporal.Workflow.Internal.Monad hiding (push)
+
+
+-- | A set of in-flight actions, each yielding an @a@.
+newtype Inflight a = Inflight (Seq (SubStatus a))
+
+
+-- | The empty set.
+empty :: Inflight a
+empty = Inflight Seq.empty
+
+
+-- | Returns the number of actions still running.
+size :: Inflight a -> Int
+size (Inflight ms) = Seq.length ms
+
+
+{- | Starts the action and adds it to the set; the action runs immediately up
+to its first suspension and is only ever resumed afterwards, never restarted.
+-}
+push :: Inflight a -> Workflow a -> Workflow (Inflight a)
+push (Inflight ms) act = Workflow $ \env -> do
+  st <- runSubFiber env act
+  pure $ Inflight $ ms Seq.|> st
+
+
+-- | Starts every action, in the collection's fold order.
+fromFoldable :: Foldable f => f (Workflow a) -> Workflow (Inflight a)
+fromFoldable = foldM push empty
+
+
+{- | Return the first action in an 'Inflight' that completes, alongside an
+'Inflight' with the remaining actions that are still pending.
+
+Exceptions raised by the completed action are returned promptly as
+@'Left' 'SomeException'@ so the caller can handle them separately from the
+remaining in-flight actions.
+
+When several actions have finished, they are returned in insertion-order.
+-}
+next :: forall a. Inflight a -> Workflow (Maybe (Either SomeException a, Inflight a))
+next (Inflight members0)
+  | Seq.null members0 = Workflow $ \_ -> pure Nothing
+  | otherwise = Workflow $ \env -> do
+      let cenv = fiberContEnv env
+          locals = fiberLocals env
+
+          -- Park a waker on a blocked action that fills this round's wakeup.
+          -- 
+          -- Wakers left over from an earlier round fill a wakeup that is already
+          -- full, so 'putIVar' makes them no-ops.
+          arm :: IVar () -> SubStatus a -> InstanceM ()
+          arm wakeup (SubBlocked iv _) = do
+            wakerRes <- newIVar
+            let waker = FreshTask $ Workflow $ \_ -> liftIO $ putIVar wakeup (Ok ()) cenv
+            parkTask cenv locals waker wakerRes iv
+          arm _ _ = pure ()
+
+          loop :: Seq (SubStatus a) -> InstanceM (Maybe (Either SomeException a, Inflight a))
+          loop members = do
+            res <- scan members
+            case res of
+              Left (result, rest) -> pure (Just (result, Inflight rest))
+              Right blocked -> do
+                wakeup <- newIVar
+                traverse_ (arm wakeup) blocked
+                rv <- liftIO $ fiberSuspend env wakeup
+                -- A wakeup value other than 'Ok' means the caller was cancelled.
+                _ <- deliverResultVal rv
+                loop blocked
+
+      loop members0
+  where
+    -- Advance a blocked sub-fiber.
+    step :: SubStatus a -> InstanceM (SubStatus a)
+    step (SubBlocked iv k) = stepSubFiber iv k
+    step st = pure st
+
+    -- Resume every ready action; returns either of the first thrown exception
+    -- or the leftmost completed result.
+    scan
+      :: Seq (SubStatus a)
+      -> InstanceM (Either (Either SomeException a, Seq (SubStatus a)) (Seq (SubStatus a)))
+    scan members = do
+      stepped <- traverse step members
+      pure $ case Seq.foldlWithIndex choose Nothing stepped of
+        Nothing -> Right stepped
+        Just (i, r) -> Left (r, Seq.deleteAt i stepped)
+      where
+        choose best i = \case
+          SubThrown e -> case best of Just (_, Left _) -> best; _ -> Just (i, Left e)
+          SubDone a -> case best of Nothing -> Just (i, Right a); _ -> best
+          SubBlocked {} -> best

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -42,6 +42,7 @@ library
       Temporal.Worker
       Temporal.Workflow
       Temporal.Workflow.Internal.DelimCC
+      Temporal.Workflow.Internal.Inflight
       Temporal.Workflow.Internal.Monad
       Temporal.Workflow.Saga
       Temporal.Workflow.Unsafe
@@ -167,6 +168,7 @@ test-suite temporal-sdk-tests
       DurationSpec
       ExceptionSpec
       FiberGuardSpec
+      InflightSpec
       IntegrationSpec
       IntegrationSpec.HangingWorkflow
       IntegrationSpec.NoOpWorkflow

--- a/sdk/test/InflightSpec.hs
+++ b/sdk/test/InflightSpec.hs
@@ -1,0 +1,228 @@
+module InflightSpec where
+
+import Control.Exception (SomeException)
+import qualified Control.Monad.Catch as Catch
+import Data.Either (isLeft, isRight)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Temporal.Client as C
+import Temporal.Duration
+import Temporal.Worker
+import qualified Temporal.Workflow as W
+import qualified Temporal.Workflow.Internal.Inflight as Inflight
+import Test.Hspec
+import TestHelpers
+
+
+spec :: Spec
+spec = withTestServer_ tests
+
+
+-- | Drains an 'Inflight' to empty, collecting each result in the order 'next'
+-- returns them.
+drainAll :: W.RequireCallStack => Inflight.Inflight a -> W.Workflow [Either SomeException a]
+drainAll inf = do
+  m <- Inflight.next inf
+  case m of
+    Nothing -> pure []
+    Just (r, inf') -> (r :) <$> drainAll inf'
+
+
+-- | Runs the sources with at most @n@ actions in flight, pushing a replacement
+-- after each completion.
+boundedDrain :: W.RequireCallStack => Int -> [W.Workflow a] -> W.Workflow [Either SomeException a]
+boundedDrain n sources0 = do
+  let (initial, rest0) = splitAt n sources0
+  inf0 <- Inflight.fromFoldable initial
+  go inf0 rest0
+  where
+    go inf rest = do
+      m <- Inflight.next inf
+      case m of
+        Nothing -> pure []
+        Just (r, inf') -> do
+          (inf'', rest') <- case rest of
+            [] -> pure (inf', [])
+            s : ss -> do
+              inf'' <- Inflight.push inf' s
+              pure (inf'', ss)
+          (r :) <$> go inf'' rest'
+
+
+-- | Sleeps for the given duration, then returns the label.
+timerAction :: W.RequireCallStack => Duration -> Text -> W.Workflow Text
+timerAction d label = do
+  mt <- W.createTimer d
+  mapM_ W.wait mt
+  pure label
+
+
+-- | An action that issues a command (a second timer) after its first
+-- suspension. If 'Inflight.next' re-ran a held member from the top instead of
+-- resuming it, the second 'createTimer' would be issued again on a later round
+-- and desync the workflow.
+twoPhaseTimer :: W.RequireCallStack => Text -> W.Workflow Text
+twoPhaseTimer label = do
+  mt1 <- W.createTimer (milliseconds 40)
+  mapM_ W.wait mt1
+  mt2 <- W.createTimer (milliseconds 40)
+  mapM_ W.wait mt2
+  pure label
+
+
+-- | Throws a workflow-level exception, which 'next' returns as 'Left'.
+failing :: W.RequireCallStack => W.Workflow Text
+failing = Catch.throwM (userError "boom")
+
+
+rightsOf :: [Either e a] -> [a]
+rightsOf rs = [x | Right x <- rs]
+
+
+tests :: SpecWith TestEnv
+tests = describe "Inflight" $ do
+  specify "next on an empty collection returns Nothing" $ \TestEnv {..} -> do
+    let workflow :: MyWorkflow Bool
+        workflow = do
+          m <- Inflight.next (Inflight.empty :: Inflight.Inflight ())
+          pure $ case m of
+            Nothing -> True
+            Just _ -> False
+        wf = W.provideWorkflow defaultCodec "inflightEmpty" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOpts taskQueue
+      useClient (C.execute wf.reference "inflightEmpty" opts) `shouldReturn` True
+
+  specify "harvests in completion order, not push order" $ \TestEnv {..} -> do
+    -- "third" is pushed first but takes two timer rounds to finish, so the two
+    -- single-round members overtake it.
+    let workflow :: MyWorkflow [Text]
+        workflow = do
+          inf <-
+            Inflight.fromFoldable
+              [ twoPhaseTimer "third"
+              , timerAction (milliseconds 40) "first"
+              , timerAction (milliseconds 40) "second"
+              ]
+          rightsOf <$> drainAll inf
+        wf = W.provideWorkflow defaultCodec "inflightOrder" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+      useClient (C.execute wf.reference "inflightOrder" opts) `shouldReturn` ["first", "second", "third"]
+
+  specify "leftmost member wins a simultaneous completion" $ \TestEnv {..} -> do
+    let workflow :: MyWorkflow [Text]
+        workflow = do
+          inf <-
+            Inflight.fromFoldable
+              [ timerAction (milliseconds 100) "L"
+              , timerAction (milliseconds 100) "R"
+              ]
+          rightsOf <$> drainAll inf
+        wf = W.provideWorkflow defaultCodec "inflightTie" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+      useClient (C.execute wf.reference "inflightTie" opts) `shouldReturn` ["L", "R"]
+
+  specify "bounded drain (cap 2) returns every source" $ \TestEnv {..} -> do
+    let workflow :: MyWorkflow [Text]
+        workflow =
+          sort . rightsOf
+            <$> boundedDrain
+              2
+              [ timerAction d (T.pack (show i))
+              | (i, d) <-
+                  zip
+                    [(0 :: Int) ..]
+                    [milliseconds 100, milliseconds 200, milliseconds 150, milliseconds 250, milliseconds 120]
+              ]
+        wf = W.provideWorkflow defaultCodec "inflightBounded" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+      useClient (C.execute wf.reference "inflightBounded" opts) `shouldReturn` ["0", "1", "2", "3", "4"]
+
+  specify "held members are resumed, not re-run (no command re-issue)" $ \TestEnv {..} -> do
+    let workflow :: MyWorkflow [Text]
+        workflow = do
+          inf <-
+            Inflight.fromFoldable
+              [ twoPhaseTimer "slow"
+              , timerAction (milliseconds 20) "fast1"
+              , timerAction (milliseconds 30) "fast2"
+              ]
+          sort . rightsOf <$> drainAll inf
+        wf = W.provideWorkflow defaultCodec "inflightResume" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+      useClient (C.execute wf.reference "inflightResume" opts) `shouldReturn` ["fast1", "fast2", "slow"]
+
+  specify "a failing member yields Left and the drain continues" $ \TestEnv {..} -> do
+    let workflow :: MyWorkflow (Bool, Bool, Int)
+        workflow = do
+          inf <- Inflight.fromFoldable [failing, timerAction (milliseconds 50) "ok"]
+          rs <- drainAll inf
+          pure (any isLeft rs, any isRight rs, length rs)
+        wf = W.provideWorkflow defaultCodec "inflightFailing" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOpts taskQueue
+      useClient (C.execute wf.reference "inflightFailing" opts) `shouldReturn` (True, True, 2)
+
+  specify "a thrown member is returned ahead of an earlier completed one" $ \TestEnv {..} -> do
+    -- Element 1 throws while elements 0 and 2 complete. Fail-fast means the
+    -- throw is returned first, ahead of the already-completed element 0.
+    let workflow :: MyWorkflow Text
+        workflow = do
+          inf <- Inflight.fromFoldable [pure "a", failing, pure "c"]
+          m <- Inflight.next inf
+          pure $ case m of
+            Just (Left _, _) -> "thrown-first"
+            Just (Right r, _) -> "done-first:" <> r
+            Nothing -> "empty"
+        wf = W.provideWorkflow defaultCodec "inflightThrownFirst" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOpts taskQueue
+      useClient (C.execute wf.reference "inflightThrownFirst" opts) `shouldReturn` "thrown-first"
+
+  specify "multiple members completing in one activation each return once, in order" $ \TestEnv {..} -> do
+    let workflow :: MyWorkflow [Text]
+        workflow = do
+          inf <- Inflight.fromFoldable [timerAction (milliseconds 100) (T.pack (show i)) | i <- [(0 :: Int) .. 3]]
+          rightsOf <$> drainAll inf
+        wf = W.provideWorkflow defaultCodec "inflightMultiFill" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+      useClient (C.execute wf.reference "inflightMultiFill" opts) `shouldReturn` ["0", "1", "2", "3"]
+
+  specify "an Inflight drained as a race loser is cancelled and runs finalizers" $ \TestEnv {..} -> do
+    -- The loser blocks in 'next' on two never-firing members; the winner wins
+    -- immediately, so the loser is cancelled while suspended in the drain. The
+    -- cancellation must reach 'next' and unwind through 'finally'.
+    let workflow :: MyWorkflow (Text, Bool)
+        workflow = do
+          st <- W.newStateVar False
+          r <-
+            W.race
+              (pure "win" :: W.Workflow Text)
+              ( Catch.finally
+                  ( do
+                      inf <- Inflight.fromFoldable [timerAction (minutes 100) "a", timerAction (minutes 100) "b"]
+                      T.concat . rightsOf <$> drainAll inf
+                  )
+                  (W.writeStateVar st True)
+              )
+          ran <- W.readStateVar st
+          pure (either id id r, ran)
+        wf = W.provideWorkflow defaultCodec "inflightRaceLoser" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+      useClient (C.execute wf.reference "inflightRaceLoser" opts) `shouldReturn` ("win", True)


### PR DESCRIPTION
## note

depends on #400, #401, and #422

## description

`Inflight` is an opaque wrapper around a `Seq` of running sub-fibers, with an API for pushing new workflows onto the collection and stepping through them in the order which they complete.

this is meant to serve as the basis for bounded concurrency primitives without the baggage of `biselectOpt`, which _necessarily_ has to account for cancellation on the losing branch of its concurrency exploration and which introduces bookkeeping overhead that is prohibitively expensive for large collections of pooled, in-flight workflows.