### PR TITLE
sdk: rework `biselectOpt` concurrency exploration

### DIFF
--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -1713,15 +1713,31 @@ biselectOpt
   -> Workflow r
   -> Workflow t
 biselectOpt discrimA discrimB left right wfL wfR = Workflow $ \env -> do
+  let cenv = fiberContEnv env
+      locals = fiberLocals env
+  -- Tombstone IVar; on exit, 'wakeupRef' points here to retire any wakers
+  -- still parked on a task that lost the race.
+  tombstone <- newIVar
+  liftIO $ putIVar tombstone (Ok ()) cenv
+  -- Shared mutable reference wakers can use to fill the tombstone.
+  wakeupRef <- newIORef tombstone
+  -- Whether each side needs a waker armed; set again whenever its waker fires.
+  rearmA <- newIORef True
+  rearmB <- newIORef True
   let
-    -- Cancel a side whose result we no longer need, gated on the
-    -- race-loser-cancellation SDK flag (see 'sdkFlagRaceLoserCancellation').
-    -- A history recorded before the flag existed takes the disabled branch:
-    -- the loser is dropped silently and @step@ is not even forced, exactly as
-    -- the SDK behaved before. When enabled we force @step@ (starting a
-    -- not-yet-started loser, as 'Control.Concurrent.Async.race' forks both
-    -- sides) and, if it is blocked, deliver a synthetic
-    -- 'WorkflowFiberCancelled' so its finalizers run (see 'cancelSubFiber').
+    -- Arm this side's waker if it needs one.
+    armWaker :: forall x. IORef Bool -> IVar x -> InstanceM ()
+    armWaker rearm iv = do
+      needed <- readIORef rearm
+      when needed $ do
+        wakerRes <- newIVar
+        let waker = FreshTask $ ilift $ do
+              writeIORef rearm True
+              wakeup <- readIORef wakeupRef
+              liftIO $ putIVar wakeup (Ok ()) cenv
+        parkTask cenv locals waker wakerRes iv
+        writeIORef rearm False
+    -- Cancel a side we no longer need.
     cancelSide :: forall x. InstanceM (SubStatus x) -> InstanceM ()
     cancelSide step = do
       enabled <- tryUseSdkFlag sdkFlagRaceLoserCancellation
@@ -1730,19 +1746,13 @@ biselectOpt discrimA discrimB left right wfL wfR = Workflow $ \env -> do
         case s of
           SubBlocked ivar k -> cancelSubFiber env ivar k
           _ -> pure ()
-    -- Like 'cancelSide', but for a loser we already hold as a blocked
-    -- continuation (so there is nothing to force). Same flag gate.
+    -- Like 'cancelSide', for a loser already held as a blocked continuation.
     cancelBlocked :: forall x w. IVar w -> (ResultVal w -> IO (Status x)) -> InstanceM ()
     cancelBlocked ivar k = do
       enabled <- tryUseSdkFlag sdkFlagRaceLoserCancellation
       when enabled $ cancelSubFiber env ivar k
-    -- Each round: step the left side first (resuming it only if the IVar it
-    -- was blocked on has been filled), then, unless the left side
-    -- short-circuited, step the right side. When both sides remain blocked,
-    -- park unit jobs on both blocked IVars that fill a fresh
-    -- synchronisation IVar 'i', and block the parent on 'i' so that it
-    -- wakes up whenever either side's IVar is filled. Whenever one side wins
-    -- or throws, the still-running other side is cancelled.
+    -- Step the left side, then the right; if both are blocked, sleep until a
+    -- waker signals that execution should resume.
     go :: InstanceM (SubStatus l) -> InstanceM (SubStatus r) -> InstanceM t
     go stepA stepB = do
       sa <- stepA
@@ -1774,12 +1784,27 @@ biselectOpt discrimA discrimB left right wfL wfR = Workflow $ \env -> do
                   Right b -> pure (right (b, c))
             SubThrown e -> cancelBlocked ia ka *> throwWorkflow e
             SubBlocked ib kb -> do
-              i <- newIVar
-              parkTask (fiberContEnv env) (fiberLocals env) (FreshTask (return ())) i ia
-              parkTask (fiberContEnv env) (fiberLocals env) (FreshTask (return ())) i ib
-              _ <- liftIO $ fiberSuspend env i
+              -- Both blocked: arm each side, then sleep on a fresh wakeup.
+              armWaker rearmA ia
+              armWaker rearmB ib
+              wakeup <- newIVar
+              writeIORef wakeupRef wakeup
+              rv <- liftIO $ fiberSuspend env wakeup
+              -- If the fiber was woken up by cancellation or error instead of
+              -- one of the wakers, retire them and then cancel the children
+              -- before re-raising.
+              case rv of
+                Ok () -> pure ()
+                _ -> do
+                  writeIORef wakeupRef tombstone
+                  cancelBlocked ia ka
+                  cancelBlocked ib kb
+              deliverResultVal rv
               go (stepSubFiber ia ka) (stepSubFiber ib kb)
+  -- On exit, retire this call's wakers: a leftover waker fills the full
+  -- tombstone and does nothing.
   go (runSubFiber env wfL) (runSubFiber env wfR)
+    `UnliftIO.finally` writeIORef wakeupRef tombstone
 
 
 {- | This function takes two Workflow computations as input, and returns the

--- a/sdk/test/ReplaySpec.hs
+++ b/sdk/test/ReplaySpec.hs
@@ -1,6 +1,6 @@
 module ReplaySpec where
 
-import Control.Monad (void, when)
+import Control.Monad (replicateM_, void, when)
 import qualified Control.Monad.Catch as Catch
 import Data.Either (isLeft, isRight)
 import Data.ProtoLens.Encoding (encodeMessage)
@@ -407,3 +407,74 @@ tests = describe "Workflow Replay" $ do
           strippedHistory = history & HistoryF.events .~ map stripEvent (history ^. HistoryF.events)
       withoutFlag <- runReplayHistory globalRuntime conf strippedHistory
       withoutFlag `shouldSatisfy` isLeft
+
+  -- NOTE: We can't inspect an IVar's waiter list directly, so we test against
+  -- replay history: any reordering desyncs replay & returns a 'Left'.
+  describe "biselect/race gate indirection" $ do
+    specify "race: deterministically left-biased on simultaneous successful returns" $ \TestEnv {..} -> do
+      let wf :: W.ProvidedWorkflow (W.Workflow (Either Int Int))
+          wf =
+            W.provideWorkflow JSON "pr1-race-tie-wf" $
+              provideCallStack $
+                W.race
+                  (replicateM_ 3 (W.sleep (milliseconds 10)) >> pure (1 :: Int))
+                  (replicateM_ 3 (W.sleep (milliseconds 10)) >> pure (2 :: Int))
+          conf = provideCallStack $ configure () wf baseConf
+      (result, history) <- withWorker conf $ do
+        uuid <- uuidText
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient $ do
+          h <- C.start wf (W.WorkflowId uuid) opts
+          r <- C.waitWorkflowResult h
+          hist <- C.fetchHistory h
+          pure (r, hist)
+      result `shouldBe` Left 1
+      replay <- runReplayHistory globalRuntime conf history
+      replay `shouldSatisfy` isRight
+
+    specify "biselect: deterministically replays multiple rounds of biased results" $ \TestEnv {..} -> do
+      let wf :: W.ProvidedWorkflow (W.Workflow (Either () (Int, Int)))
+          wf =
+            W.provideWorkflow JSON "pr1-biselect-wf" $
+              provideCallStack $
+                W.biselect
+                  (replicateM_ 2 (W.sleep (milliseconds 10)) >> pure (Right 1 :: Either () Int))
+                  (replicateM_ 2 (W.sleep (milliseconds 10)) >> pure (Right 2 :: Either () Int))
+          conf = provideCallStack $ configure () wf baseConf
+      (result, history) <- withWorker conf $ do
+        uuid <- uuidText
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient $ do
+          h <- C.start wf (W.WorkflowId uuid) opts
+          r <- C.waitWorkflowResult h
+          hist <- C.fetchHistory h
+          pure (r, hist)
+      result `shouldBe` Right (1, 2)
+      replay <- runReplayHistory globalRuntime conf history
+      replay `shouldSatisfy` isRight
+
+    specify "repeated 'race' calls against blocked tasks are deterministic" $ \TestEnv {..} -> do
+      let n = 20 :: Int
+          wf :: W.ProvidedWorkflow (W.Workflow Int)
+          wf = W.provideWorkflow JSON "pr1-many-races-wf" $ provideCallStack $ do
+            let go :: Int -> MyWorkflow Int
+                go i
+                  | i >= n = pure i
+                  | otherwise = do
+                      r <- W.race (W.sleep (milliseconds 1)) (W.waitCondition (pure False))
+                      case r of
+                        Left () -> go (i + 1)
+                        Right () -> pure (negate 1)
+            go 0
+          conf = provideCallStack $ configure () wf baseConf
+      (result, history) <- withWorker conf $ do
+        uuid <- uuidText
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 30)
+        useClient $ do
+          h <- C.start wf (W.WorkflowId uuid) opts
+          r <- C.waitWorkflowResult h
+          hist <- C.fetchHistory h
+          pure (r, hist)
+      result `shouldBe` n
+      replay <- runReplayHistory globalRuntime conf history
+      replay `shouldSatisfy` isRight

--- a/sdk/test/SchedulerStressSpec.hs
+++ b/sdk/test/SchedulerStressSpec.hs
@@ -107,9 +107,10 @@ tests = describe "Scheduler stress" $ do
           let protected :: MyWorkflow Text
               protected =
                 Catch.catch
-                  (do
-                    W.waitCondition (W.readStateVar st)
-                    error "post-resume boom")
+                  ( do
+                      W.waitCondition (W.readStateVar st)
+                      error "post-resume boom"
+                  )
                   (\(_ :: SomeException) -> pure "fallback")
               sibling :: MyWorkflow Text
               sibling = do
@@ -148,3 +149,57 @@ tests = describe "Scheduler stress" $ do
     withWorker conf $ do
       let opts = defaultStartOptsWithTimeout taskQueue (seconds 60)
       useClient (C.execute wf.reference "schedStressRaceDrop" opts) `shouldReturn` n
+
+  specify "a biselect cancelled as a race loser propagates cancellation and runs its finalizer" $ \TestEnv {..} -> do
+    -- When a 'biselect' is itself the losing side of an outer 'race', its
+    -- parent fiber is suspended on the wakeup IVar inside the both-blocked
+    -- branch.
+    --
+    -- Cancelling that loser must deliver the synthetic 'WorkflowFiberCancelled'
+    -- THROUGH the wakeup suspend so the loser unwinds and its 'finally' runs.
+    let workflow :: MyWorkflow Bool
+        workflow = do
+          ran <- W.newStateVar False
+          let blocked :: MyWorkflow (Either () ())
+              blocked = W.waitCondition (pure False) >> pure (Left ())
+              innerBiselect :: MyWorkflow (Either () ((), ()))
+              innerBiselect = W.biselect blocked blocked
+              loser :: MyWorkflow (Either () ((), ()))
+              loser = innerBiselect `Catch.finally` W.writeStateVar ran True
+              winner :: MyWorkflow ()
+              winner = W.sleep (milliseconds 5)
+          _ <- winner `W.race` loser
+          W.readStateVar ran
+        wf = W.provideWorkflow defaultCodec "schedStressBiselectCancel" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 60)
+      useClient (C.execute wf.reference "schedStressBiselectCancel" opts) `shouldReturn` True
+
+  specify "cancelling a biselect as a race loser runs BOTH children's finalizers" $ \TestEnv {..} -> do
+    -- Cancelling a 'biselect' loser must cancel the two sub-fibers it is
+    -- waiting on, not just unwind the biselect itself; this means that the
+    -- children's finalizers MUST run.
+    let workflow :: MyWorkflow (Bool, Bool)
+        workflow = do
+          ranA <- W.newStateVar False
+          ranB <- W.newStateVar False
+          let childA :: MyWorkflow (Either () ())
+              childA =
+                (W.waitCondition (pure False) >> pure (Left ()))
+                  `Catch.finally` W.writeStateVar ranA True
+              childB :: MyWorkflow (Either () ())
+              childB =
+                (W.waitCondition (pure False) >> pure (Left ()))
+                  `Catch.finally` W.writeStateVar ranB True
+              loser :: MyWorkflow (Either () ((), ()))
+              loser = W.biselect childA childB
+              winner :: MyWorkflow ()
+              winner = W.sleep (milliseconds 5)
+          _ <- winner `W.race` loser
+          (,) <$> W.readStateVar ranA <*> W.readStateVar ranB
+        wf = W.provideWorkflow defaultCodec "schedStressBiselectChildFinalizers" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 60)
+      useClient (C.execute wf.reference "schedStressBiselectChildFinalizers" opts) `shouldReturn` (True, True)


### PR DESCRIPTION
## notes

depends on #400 and #401.

## description

Uses a persistent `waker` IVar that is reused throughout the process of exploring both sides of `biselectOpt`, and ensures that child tasks are finalized even if the `biselectOpt` is, itself, cancelled as a result of being on the losing branch of a parent `biselectOpt`.