### PR TITLE
sdk: fix activity worker space leak

### DIFF
--- a/sdk/src/Temporal/Activity/Worker.hs
+++ b/sdk/src/Temporal/Activity/Worker.hs
@@ -80,19 +80,28 @@ runActivityWorker w m = runReaderT (unActivityWorkerM m) w
 
 
 execute :: (MonadUnliftIO m, MonadLogger m) => ActivityWorker actEnv -> m ()
-execute worker = runActivityWorker worker go
-  where
-    go = do
-      eTask <- liftIO $ Core.pollActivityTask worker.workerCore
-      case eTask of
-        Left (Core.WorkerError Core.PollShutdown _) -> do
-          pure ()
-        Left e -> do
-          Logging.logError (T.pack (show e))
-          throwIO e
-        Right task -> do
-          applyActivityTask task
-          go
+execute worker = withRunInIO $ \runInIO -> do
+  -- NOTE: The poll loop /must/ recurse in a concrete type (in this case that's
+  -- 'IO', but it could be a concrete transformer stack) as opposed to the
+  -- polymorphic 'm' that this function is constrained by.
+  --
+  -- Recursing in 'm' means that GHC can't specialize binds, which results in
+  -- a space leak per iteration; in this case that gives us an unbounded space
+  -- leak roughly proportional to the number of activity tasks handled by this
+  -- worker.
+  --
+  -- Pinning the type to 'IO' and dispatching the task's work to whatever its
+  -- 'm' is via 'runInIO' eliminates the space leak.
+  let go = do
+        eTask <- Core.pollActivityTask worker.workerCore
+        case eTask of
+          Left (Core.WorkerError Core.PollShutdown _) -> pure ()
+          Left e -> do
+            runInIO $ Logging.logError (T.pack $ show e)
+            throwIO e
+          Right task ->
+            runInIO (runActivityWorker worker $ applyActivityTask task) *> go
+  go
 
 
 activityInfoFromProto :: MonadIO m => TaskToken -> TaskQueue -> AT.Start -> ActivityWorkerM actEnv m ActivityInfo


### PR DESCRIPTION
## description

so it looks like we had a space leak in the activity worker's execution polling loop.

recursing over an unspecialized `m` would leak `>>=`/`*>` thunks proportional to the number of tasks the worker is handling; this would grow unbounded for the lifetime of the worker.

"specializing" the loop to `IO` and instead unlifting the `runActivityWorker` call via `runInIO` fixes this & appears to eliminate the space leak.

### before

<img width="1000" alt="detailed allocations before fix" src="https://github.com/user-attachments/assets/787d4b92-2a73-4ffe-9cf7-709c87e6d499" />

<img width="1000" alt="normalized heap profile before fix" src="https://github.com/user-attachments/assets/6d4974f8-69cf-4613-83f4-4254983251aa" />

### after

<img width="1000" alt="detailed allocations after fix" src="https://github.com/user-attachments/assets/96014704-c515-4646-988a-cc05c0b603d2" />

<img width="1000" alt="normalized heap profile after fix" src="https://github.com/user-attachments/assets/09031c70-ae74-4a0f-a6d4-27411ec16ec7" />
