### PR TITLE
Fix query handler startup race

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -19,7 +19,7 @@ the interceptor to your Temporal client and worker configuration.
 module Temporal.Contrib.OpenTelemetry where
 
 import Control.Monad.Catch
-import Control.Monad (forM_)
+import Control.Monad (forM_, void)
 import Control.Monad.IO.Class
 import Data.IORef
 import qualified Data.HashMap.Strict as HashMap
@@ -34,7 +34,7 @@ import GHC.IO (unsafePerformIO)
 import OpenTelemetry.Propagator.W3CBaggage (decodeBaggage, encodeBaggage) 
 import OpenTelemetry.Context (Context)
 import qualified OpenTelemetry.Context as Ctxt
-import OpenTelemetry.Context.ThreadLocal (attachContext, getContext)
+import OpenTelemetry.Context.ThreadLocal (attachContext, detachContext, getContext)
 import OpenTelemetry.Propagator
 import OpenTelemetry.Propagator.W3CTraceContext (decodeSpanContext, encodeSpanContext)
 import OpenTelemetry.Trace.Core
@@ -236,10 +236,13 @@ makeOpenTelemetryInterceptor = do
                                 ]
                         }
                 span <- createSpan tracer ctxt ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs
-                _ <- attachContext $ Ctxt.insertSpan span ctxt
+                priorContext <- attachContext $ Ctxt.insertSpan span ctxt
                 atomicModifyIORef' workflowSpans $ \spans ->
                   (HashMap.insert (rawRunId input.executeWorkflowInputInfo.runId) span spans, ())
-                next input
+                let restoreContext = case priorContext of
+                      Nothing -> void detachContext
+                      Just prior -> void $ attachContext prior
+                next input `finally` restoreContext
             , finalizeWorkflow = finalizeWorkflow
             , handleQuery = \input next -> do
                 -- Only trace this if there is a header, and make that span the parent.

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -49,6 +49,7 @@ import Temporal.Workflow ()
 import Temporal.Workflow.Internal.Monad (WorkflowInstance (..))
 import Temporal.Workflow.Types
 import Temporal.Workflow.Unsafe
+import Temporal.WorkflowInstance (WorkflowExecutionContext (..), workflowExecutionContextKey)
 import Prelude hiding (span)
 
 
@@ -202,7 +203,8 @@ makeOpenTelemetryInterceptor = do
         mSpan <-
           atomicModifyIORef' inst.workflowVault $ \vault ->
             let found = Vault.lookup workflowSpanKey vault
-            in (Vault.delete workflowSpanKey vault, found)
+                cleared = Vault.delete workflowExecutionContextKey $ Vault.delete workflowSpanKey vault
+            in (cleared, found)
         forM_ mSpan $ \span -> do
           forM_ result $ \case
             WorkflowExitFailed err -> do
@@ -272,13 +274,20 @@ makeOpenTelemetryInterceptor = do
                                 ]
                         }
                 span <- createSpan tracer ctxt ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs
-                priorContext <- attachContext $ Ctxt.insertSpan span ctxt
-                atomicModifyIORef' input.executeWorkflowInputVault $ \vault ->
-                  (Vault.insert workflowSpanKey span vault, ())
-                let restoreContext = case priorContext of
+                let workflowContext = Ctxt.insertSpan span ctxt
+                    restoreContext = \case
                       Nothing -> void detachContext
                       Just prior -> void $ attachContext prior
-                next input `finally` restoreContext
+                    withWorkflowContext :: IO a -> IO a
+                    withWorkflowContext action = do
+                      priorContext <- attachContext workflowContext
+                      action `finally` restoreContext priorContext
+                atomicModifyIORef' input.executeWorkflowInputVault $ \vault ->
+                  ( Vault.insert workflowExecutionContextKey (WorkflowExecutionContext withWorkflowContext) $
+                      Vault.insert workflowSpanKey span vault
+                  , ()
+                  )
+                withWorkflowContext $ next input
             , finalizeWorkflow = finalizeWorkflow
             , handleQuery = \input next -> do
                 -- Only trace this if there is a header, and make that span the parent.

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -151,7 +151,7 @@ tracerKey = unsafePerformIO Vault.newKey
 --    */
 -- CONTINUE_AS_NEW = 'ContinueAsNew',
 
-makeOpenTelemetryInterceptor :: IO (Interceptors env)
+makeOpenTelemetryInterceptor :: MonadIO m => m (Interceptors env)
 
 -- TODO, we will need to account for replays when we support them
 makeOpenTelemetryInterceptor = do

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -19,7 +19,9 @@ the interceptor to your Temporal client and worker configuration.
 module Temporal.Contrib.OpenTelemetry where
 
 import Control.Monad.Catch
+import Control.Monad (forM_)
 import Control.Monad.IO.Class
+import Data.IORef
 import qualified Data.HashMap.Strict as HashMap
 import Data.Int
 import Data.Map.Strict (Map)
@@ -149,22 +151,35 @@ tracerKey = unsafePerformIO Vault.newKey
 --    */
 -- CONTINUE_AS_NEW = 'ContinueAsNew',
 
+makeOpenTelemetryInterceptor :: IO (Interceptors env)
+
 -- TODO, we will need to account for replays when we support them
-makeOpenTelemetryInterceptor :: MonadIO m => m (Interceptors env)
 makeOpenTelemetryInterceptor = do
   tracerProvider <- getGlobalTracerProvider
+  workflowSpans <- liftIO $ newIORef mempty
   let tracer =
         makeTracer
           tracerProvider
           "temporal-sdk"
           tracerOptions
+      finalizeWorkflow runId result = do
+        mSpan <-
+          atomicModifyIORef' workflowSpans $ \spans ->
+            let found = HashMap.lookup (rawRunId runId) spans
+             in (HashMap.delete (rawRunId runId) spans, found)
+        forM_ mSpan $ \span -> do
+          forM_ result $ \case
+            WorkflowExitFailed err -> do
+              setStatus span (Error $ T.pack $ show err)
+              recordException span mempty Nothing err
+            _ -> pure ()
+          endSpan span Nothing
   pure $
     Interceptors
       { workflowInboundInterceptors =
           WorkflowInboundInterceptor
             { executeWorkflow = \input next -> do
                 ctxt <- extract headersPropagator input.executeWorkflowInputHeaders Ctxt.empty
-                _ <- attachContext ctxt
                 let spanArgs =
                       defaultSpanArguments
                         { kind = Server
@@ -220,8 +235,12 @@ makeOpenTelemetryInterceptor = do
                                     input.executeWorkflowInputInfo.retryPolicy
                                 ]
                         }
-                inSpan'' tracer ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs $ \_ ->
-                  next input
+                span <- createSpan tracer ctxt ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs
+                _ <- attachContext $ Ctxt.insertSpan span ctxt
+                atomicModifyIORef' workflowSpans $ \spans ->
+                  (HashMap.insert (rawRunId input.executeWorkflowInputInfo.runId) span spans, ())
+                next input
+            , finalizeWorkflow = finalizeWorkflow
             , handleQuery = \input next -> do
                 -- Only trace this if there is a header, and make that span the parent.
                 -- We do not put anything that happens in a query handler on the workflow

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -220,15 +220,8 @@ makeOpenTelemetryInterceptor = do
                                     input.executeWorkflowInputInfo.retryPolicy
                                 ]
                         }
-                inSpan'' tracer ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs $ \span -> do
-                  execution <- next input
-                  case execution of
-                    WorkflowExitFailed e -> do
-                      -- TODO use our enrichment handlers here
-                      setStatus span (Error $ T.pack $ show e)
-                      recordException span mempty Nothing e
-                    _ -> pure ()
-                  pure execution
+                inSpan'' tracer ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs $ \_ ->
+                  next input
             , handleQuery = \input next -> do
                 -- Only trace this if there is a header, and make that span the parent.
                 -- We do not put anything that happens in a query handler on the workflow

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -18,11 +18,11 @@ the interceptor to your Temporal client and worker configuration.
 -}
 module Temporal.Contrib.OpenTelemetry where
 
-import Control.Monad.Catch
 import Control.Monad (forM_, void)
+import Control.Monad.Catch
 import Control.Monad.IO.Class
-import Data.IORef
 import qualified Data.HashMap.Strict as HashMap
+import Data.IORef
 import Data.Int
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -31,11 +31,11 @@ import qualified Data.Text as T
 import qualified Data.Vault.Strict as Vault
 import Data.Word (Word32)
 import GHC.IO (unsafePerformIO)
-import OpenTelemetry.Propagator.W3CBaggage (decodeBaggage, encodeBaggage) 
 import OpenTelemetry.Context (Context)
 import qualified OpenTelemetry.Context as Ctxt
 import OpenTelemetry.Context.ThreadLocal (attachContext, detachContext, getContext)
 import OpenTelemetry.Propagator
+import OpenTelemetry.Propagator.W3CBaggage (decodeBaggage, encodeBaggage)
 import OpenTelemetry.Propagator.W3CTraceContext (decodeSpanContext, encodeSpanContext)
 import OpenTelemetry.Trace.Core
 import Temporal.Activity.Types
@@ -46,18 +46,10 @@ import Temporal.Duration
 import Temporal.Interceptor
 import Temporal.Payload (Payload (..))
 import Temporal.Workflow ()
+import Temporal.Workflow.Internal.Monad (WorkflowInstance (..))
 import Temporal.Workflow.Types
 import Temporal.Workflow.Unsafe
 import Prelude hiding (span)
-
-
--- The 'Propagator' record field @propagatorNames@ was renamed to
--- @propagatorFields@ in hs-opentelemetry-api 1.0.
-#if MIN_VERSION_hs_opentelemetry_api(1,0,0)
-#define PROPAGATOR_FIELDS propagatorFields
-#else
-#define PROPAGATOR_FIELDS propagatorNames
-#endif
 
 
 -- | "_tracer-data"
@@ -78,11 +70,11 @@ defaultOpenTelemetryInterceptorOptions =
     , headerKey = defaultHeaderKey
     }
 
-
+#if MIN_VERSION_hs_opentelemetry_api(1,0,0)
 headersPropagator :: Propagator Context (Map Text Payload) (Map Text Payload)
 headersPropagator =
   Propagator
-    { PROPAGATOR_FIELDS = ["tracecontext"]
+    { propagatorFields = ["tracecontext"]
     , extractor = \hs c -> do
         let traceParentHeader = payloadData <$> Map.lookup "traceparent" hs
             traceStateHeader = payloadData <$> Map.lookup "tracestate" hs
@@ -99,11 +91,34 @@ headersPropagator =
             . Map.insert "tracestate" (Payload traceStateHeader mempty)
             $ hs
     }
+#else
+headersPropagator :: Propagator Context (Map Text Payload) (Map Text Payload)
+headersPropagator =
+  Propagator
+    { propagatorNames = ["tracecontext"]
+    , extractor = \hs c -> do
+        let traceParentHeader = payloadData <$> Map.lookup "traceparent" hs
+            traceStateHeader = payloadData <$> Map.lookup "tracestate" hs
+            mspanContext = decodeSpanContext traceParentHeader traceStateHeader
+        pure $! case mspanContext of
+          Nothing -> c
+          Just s -> Ctxt.insertSpan (wrapSpanContext (s {isRemote = True})) c
+    , injector = \c hs -> case Ctxt.lookupSpan c of
+        Nothing -> pure hs
+        Just s -> do
+          (traceParentHeader, traceStateHeader) <- encodeSpanContext s
+          pure
+            . Map.insert "traceparent" (Payload traceParentHeader mempty)
+            . Map.insert "tracestate" (Payload traceStateHeader mempty)
+            $ hs
+    }
+#endif
 
+#if MIN_VERSION_hs_opentelemetry_api(1,0,0)
 headersBaggagePropagator :: Propagator Context (Map Text Payload) (Map Text Payload)
 headersBaggagePropagator =
   Propagator
-    { PROPAGATOR_FIELDS = ["baggage"]
+    { propagatorFields = ["baggage"]
     , extractor = \headers ctxt ->
         let payload = payloadData <$> Map.lookup "baggage" headers
         in pure $! case payload >>= decodeBaggage of
@@ -115,10 +130,33 @@ headersBaggagePropagator =
           let payload = Payload (encodeBaggage baggage) mempty
           in Map.insert "baggage" payload headers
     }
+#else
+headersBaggagePropagator :: Propagator Context (Map Text Payload) (Map Text Payload)
+headersBaggagePropagator =
+  Propagator
+    { propagatorNames = ["baggage"]
+    , extractor = \headers ctxt ->
+        let payload = payloadData <$> Map.lookup "baggage" headers
+        in pure $! case payload >>= decodeBaggage of
+          Nothing -> ctxt
+          Just baggage -> Ctxt.insertBaggage baggage ctxt
+    , injector = \ctxt headers -> pure $! case Ctxt.lookupBaggage ctxt of
+        Nothing -> headers
+        Just baggage ->
+          let payload = Payload (encodeBaggage baggage) mempty
+          in Map.insert "baggage" payload headers
+    }
+#endif
+
 
 tracerKey :: Vault.Key Tracer
 tracerKey = unsafePerformIO Vault.newKey
 {-# NOINLINE tracerKey #-}
+
+
+workflowSpanKey :: Vault.Key Span
+workflowSpanKey = unsafePerformIO Vault.newKey
+{-# NOINLINE workflowSpanKey #-}
 
 
 --    * Workflow is scheduled by a client
@@ -152,21 +190,19 @@ tracerKey = unsafePerformIO Vault.newKey
 -- CONTINUE_AS_NEW = 'ContinueAsNew',
 
 makeOpenTelemetryInterceptor :: MonadIO m => m (Interceptors env)
-
 -- TODO, we will need to account for replays when we support them
 makeOpenTelemetryInterceptor = do
   tracerProvider <- getGlobalTracerProvider
-  workflowSpans <- liftIO $ newIORef mempty
   let tracer =
         makeTracer
           tracerProvider
           "temporal-sdk"
           tracerOptions
-      finalizeWorkflow runId result = do
+      finalizeWorkflow inst result = do
         mSpan <-
-          atomicModifyIORef' workflowSpans $ \spans ->
-            let found = HashMap.lookup (rawRunId runId) spans
-             in (HashMap.delete (rawRunId runId) spans, found)
+          atomicModifyIORef' inst.workflowVault $ \vault ->
+            let found = Vault.lookup workflowSpanKey vault
+            in (Vault.delete workflowSpanKey vault, found)
         forM_ mSpan $ \span -> do
           forM_ result $ \case
             WorkflowExitFailed err -> do
@@ -237,8 +273,8 @@ makeOpenTelemetryInterceptor = do
                         }
                 span <- createSpan tracer ctxt ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs
                 priorContext <- attachContext $ Ctxt.insertSpan span ctxt
-                atomicModifyIORef' workflowSpans $ \spans ->
-                  (HashMap.insert (rawRunId input.executeWorkflowInputInfo.runId) span spans, ())
+                atomicModifyIORef' input.executeWorkflowInputVault $ \vault ->
+                  (Vault.insert workflowSpanKey span vault, ())
                 let restoreContext = case priorContext of
                       Nothing -> void detachContext
                       Just prior -> void $ attachContext prior

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -781,9 +781,6 @@ data WorkflowInstance = WorkflowInstance
     -- Uses Endo for O(1) append (diff-list style).
     workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
   , workflowQueryHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (QueryId -> Vector Payload -> Map Text Payload -> IO (Either SomeException Payload))))
-  , -- | Filled after the workflow body has run through its first evaluation,
-    -- so startup queries observe the handlers it registers before yielding.
-    workflowInitialHandlersReady :: {-# UNPACK #-} !(MVar ())
   , workflowUpdateHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) WorkflowUpdateImplementation))
   , workflowCallStack :: {-# UNPACK #-} !(IORef CallStack)
   , workflowIVarCounter :: {-# UNPACK #-} !(IORef Word64)
@@ -951,9 +948,10 @@ data HandleUpdateInput = HandleUpdateInput
 
 data WorkflowInboundInterceptor = WorkflowInboundInterceptor
   { executeWorkflow
-      :: ExecuteWorkflowInput
-      -> (ExecuteWorkflowInput -> IO (WorkflowExitVariant Payload))
-      -> IO (WorkflowExitVariant Payload)
+      :: forall a
+       . ExecuteWorkflowInput
+      -> (ExecuteWorkflowInput -> IO a)
+      -> IO a
   , handleQuery
       :: HandleQueryInput
       -> (HandleQueryInput -> IO (Either SomeException Payload))
@@ -967,12 +965,18 @@ data WorkflowInboundInterceptor = WorkflowInboundInterceptor
       -> (HandleUpdateInput -> IO (Either SomeException ()))
       -> IO (Either SomeException ())
   }
+interceptWorkflow
+  :: WorkflowInboundInterceptor
+  -> ExecuteWorkflowInput
+  -> (ExecuteWorkflowInput -> IO a)
+  -> IO a
+interceptWorkflow WorkflowInboundInterceptor {executeWorkflow = f} = f
 
 
 instance Semigroup WorkflowInboundInterceptor where
   a <> b =
     WorkflowInboundInterceptor
-      { executeWorkflow = \input cont -> a.executeWorkflow input $ \input' -> b.executeWorkflow input' cont
+      { executeWorkflow = \input cont -> interceptWorkflow a input $ \input' -> interceptWorkflow b input' cont
       , handleQuery = \input cont -> a.handleQuery input $ \input' -> b.handleQuery input' cont
       , handleUpdate = \input cont -> a.handleUpdate input $ \input' -> b.handleUpdate input' cont
       , validateUpdate = \input cont -> a.validateUpdate input $ \input' -> b.validateUpdate input' cont

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -4,7 +4,6 @@
 module Temporal.Workflow.Internal.Monad where
 
 import Control.Applicative
-import Control.Concurrent.Async
 import Control.Monad
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Logger
@@ -36,11 +35,13 @@ import System.Random (
   genWord64R,
   genWord8,
  )
-import System.Random.Stateful (FrozenGen (..), RandomGenM (..), StatefulGen (..), StdGen
+
+
 #if MIN_VERSION_random(1,3,0)
-                              , ThawedGen (..)
+import System.Random.Stateful (FrozenGen (..), RandomGenM (..), StatefulGen (..), StdGen, ThawedGen (..))
+#else
+import System.Random.Stateful (FrozenGen (..), RandomGenM (..), StatefulGen (..), StdGen)
 #endif
-                              )
 import Temporal.Common
 import qualified Temporal.Core.Worker as Core
 import Temporal.Exception
@@ -339,15 +340,20 @@ newWorkflowGenM g = Workflow $ \_ -> Done . WorkflowGenM <$> newIORef g
 instance RandomGenM WorkflowGenM StdGen Workflow where
   applyRandomGenM = applyWorkflowGen
 
-
+#if MIN_VERSION_random(1,3,0)
 instance FrozenGen StdGen Workflow where
   type MutableGen StdGen Workflow = WorkflowGenM
   freezeGen g = Workflow $ \_ -> Done <$> readIORef (unWorkflowGenM g)
 
-#if MIN_VERSION_random(1,3,0)
+
 instance ThawedGen StdGen Workflow where
-#endif
   thawGen = newWorkflowGenM
+#else
+instance FrozenGen StdGen Workflow where
+  type MutableGen StdGen Workflow = WorkflowGenM
+  freezeGen g = Workflow $ \_ -> Done <$> readIORef (unWorkflowGenM g)
+  thawGen = newWorkflowGenM
+#endif
 
 
 {-# INLINE addJob #-}
@@ -374,10 +380,10 @@ yield = Workflow $ \env -> do
   --
   -- Once the scheduler drains everything ahead of it, the filler runs, fills
   -- gate, and the parked continuation is re-queued and resumed.
-  -- 
+  --
   -- Keeping a job on the run queue for the duration of the yield is what prevents
   -- the scheduler from flushing commands and suspending.
-  -- 
+  --
   -- The gate is intentionally untracked so this momentary block does not show
   -- up in __stack_trace queries.
   gate <- newIVar
@@ -514,9 +520,10 @@ newIVar = do
   pure IVar {ivarId = 0, ..}
 
 
--- | Allocate an IVar with a unique id drawn from the per-instance counter.
--- Tracked IVars have their blocking call stacks recorded so that built-in
--- queries can report all concurrent stacks.
+{- | Allocate an IVar with a unique id drawn from the per-instance counter.
+Tracked IVars have their blocking call stacks recorded so that built-in
+queries can report all concurrent stacks.
+-}
 newTrackedIVar :: InstanceM (IVar a)
 newTrackedIVar = do
   inst <- ask
@@ -776,10 +783,10 @@ data WorkflowInstance = WorkflowInstance
   , workflowCommands :: {-# UNPACK #-} !(TVar (Reversed WorkflowCommand))
   , workflowSequenceMaps :: {-# UNPACK #-} !(TVar SequenceMaps)
   , workflowSignalHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (Vector Payload -> Workflow ())))
-  , -- | Signals that arrived before their handler was registered.
-    -- These are buffered and delivered when setSignalHandler is called.
-    -- Uses Endo for O(1) append (diff-list style).
-    workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
+  , workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
+  -- ^ Signals that arrived before their handler was registered.
+  -- These are buffered and delivered when setSignalHandler is called.
+  -- Uses Endo for O(1) append (diff-list style).
   , workflowQueryHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (QueryId -> Vector Payload -> Map Text Payload -> IO (Either SomeException Payload))))
   , workflowUpdateHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) WorkflowUpdateImplementation))
   , workflowCallStack :: {-# UNPACK #-} !(IORef CallStack)
@@ -787,12 +794,10 @@ data WorkflowInstance = WorkflowInstance
   , workflowBlockedStacks :: {-# UNPACK #-} !(IORef (HashMap Word64 CallStack))
   , workflowCompleteActivation :: !(Core.WorkflowActivationCompletion -> IO (Either Core.WorkerError ()))
   , workflowInstanceContinuationEnv :: {-# UNPACK #-} !ContinuationEnv
+  , workflowAdvance :: {-# UNPACK #-} !(IORef (Core.WorkflowActivation -> InstanceM ()))
   , workflowCancellationVar :: {-# UNPACK #-} !(IVar ())
   , workflowDeadlockTimeout :: Maybe Int
-  , workflowVault :: {-# UNPACK #-} !Vault
-  , -- These are how the instance gets its work done
-    activationChannel :: {-# UNPACK #-} !(TQueue Core.WorkflowActivation)
-  , executionThread :: {-# UNPACK #-} !(IORef (Async ()))
+  , workflowVault :: {-# UNPACK #-} !(IORef Vault)
   , inboundInterceptor :: {-# UNPACK #-} !WorkflowInboundInterceptor
   , outboundInterceptor :: {-# UNPACK #-} !WorkflowOutboundInterceptor
   , -- Improves error reporting
@@ -918,6 +923,7 @@ data ExecuteWorkflowInput = ExecuteWorkflowInput
   , executeWorkflowInputArgs :: Vector Payload
   , executeWorkflowInputHeaders :: Map Text Payload
   , executeWorkflowInputInfo :: Info
+  , executeWorkflowInputVault :: IORef Vault
   }
 
 
@@ -953,7 +959,7 @@ data WorkflowInboundInterceptor = WorkflowInboundInterceptor
       -> (ExecuteWorkflowInput -> IO a)
       -> IO a
   , finalizeWorkflow
-      :: RunId
+      :: WorkflowInstance
       -> Maybe (WorkflowExitVariant Payload)
       -> IO ()
   , handleQuery
@@ -969,6 +975,8 @@ data WorkflowInboundInterceptor = WorkflowInboundInterceptor
       -> (HandleUpdateInput -> IO (Either SomeException ()))
       -> IO (Either SomeException ())
   }
+
+
 interceptWorkflow
   :: WorkflowInboundInterceptor
   -> ExecuteWorkflowInput
@@ -977,7 +985,7 @@ interceptWorkflow
 interceptWorkflow WorkflowInboundInterceptor {executeWorkflow = f} = f
 
 
-finalizeWorkflowExecution :: WorkflowInboundInterceptor -> RunId -> Maybe (WorkflowExitVariant Payload) -> IO ()
+finalizeWorkflowExecution :: WorkflowInboundInterceptor -> WorkflowInstance -> Maybe (WorkflowExitVariant Payload) -> IO ()
 finalizeWorkflowExecution WorkflowInboundInterceptor {finalizeWorkflow = f} = f
 
 
@@ -985,7 +993,7 @@ instance Semigroup WorkflowInboundInterceptor where
   a <> b =
     WorkflowInboundInterceptor
       { executeWorkflow = \input cont -> interceptWorkflow a input $ \input' -> interceptWorkflow b input' cont
-      , finalizeWorkflow = \runId result -> a.finalizeWorkflow runId result >> b.finalizeWorkflow runId result
+      , finalizeWorkflow = \inst result -> a.finalizeWorkflow inst result >> b.finalizeWorkflow inst result
       , handleQuery = \input cont -> a.handleQuery input $ \input' -> b.handleQuery input' cont
       , handleUpdate = \input cont -> a.handleUpdate input $ \input' -> b.handleUpdate input' cont
       , validateUpdate = \input cont -> a.validateUpdate input $ \input' -> b.validateUpdate input' cont

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -952,6 +952,10 @@ data WorkflowInboundInterceptor = WorkflowInboundInterceptor
        . ExecuteWorkflowInput
       -> (ExecuteWorkflowInput -> IO a)
       -> IO a
+  , finalizeWorkflow
+      :: RunId
+      -> Maybe (WorkflowExitVariant Payload)
+      -> IO ()
   , handleQuery
       :: HandleQueryInput
       -> (HandleQueryInput -> IO (Either SomeException Payload))
@@ -973,10 +977,15 @@ interceptWorkflow
 interceptWorkflow WorkflowInboundInterceptor {executeWorkflow = f} = f
 
 
+finalizeWorkflowExecution :: WorkflowInboundInterceptor -> RunId -> Maybe (WorkflowExitVariant Payload) -> IO ()
+finalizeWorkflowExecution WorkflowInboundInterceptor {finalizeWorkflow = f} = f
+
+
 instance Semigroup WorkflowInboundInterceptor where
   a <> b =
     WorkflowInboundInterceptor
       { executeWorkflow = \input cont -> interceptWorkflow a input $ \input' -> interceptWorkflow b input' cont
+      , finalizeWorkflow = \runId result -> a.finalizeWorkflow runId result >> b.finalizeWorkflow runId result
       , handleQuery = \input cont -> a.handleQuery input $ \input' -> b.handleQuery input' cont
       , handleUpdate = \input cont -> a.handleUpdate input $ \input' -> b.handleUpdate input' cont
       , validateUpdate = \input cont -> a.validateUpdate input $ \input' -> b.validateUpdate input' cont
@@ -987,6 +996,7 @@ instance Monoid WorkflowInboundInterceptor where
   mempty =
     WorkflowInboundInterceptor
       { executeWorkflow = \input cont -> cont input
+      , finalizeWorkflow = \_ _ -> pure ()
       , handleQuery = \input cont -> cont input
       , handleUpdate = \input cont -> cont input
       , validateUpdate = \input cont -> cont input

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -781,6 +781,9 @@ data WorkflowInstance = WorkflowInstance
     -- Uses Endo for O(1) append (diff-list style).
     workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
   , workflowQueryHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (QueryId -> Vector Payload -> Map Text Payload -> IO (Either SomeException Payload))))
+  , -- | Filled after the workflow body has run through its first evaluation,
+    -- so startup queries observe the handlers it registers before yielding.
+    workflowInitialHandlersReady :: {-# UNPACK #-} !(MVar ())
   , workflowUpdateHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) WorkflowUpdateImplementation))
   , workflowCallStack :: {-# UNPACK #-} !(IORef CallStack)
   , workflowIVarCounter :: {-# UNPACK #-} !(IORef Word64)

--- a/sdk/src/Temporal/Workflow/Unsafe.hs
+++ b/sdk/src/Temporal/Workflow/Unsafe.hs
@@ -72,7 +72,7 @@ guarantees; reading the vault itself is deterministic and replay-safe.
 unsafeReadWorkflowVault :: Workflow Vault
 unsafeReadWorkflowVault = do
   inst <- askInstance
-  pure inst.workflowVault
+  performUnsafeNonDeterministicIO $ readIORef inst.workflowVault
 
 
 {- | Whether the workflow is currently replaying recorded history rather than

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -15,8 +15,7 @@ import Data.Vault.Strict (Vault)
 import qualified Data.Vector as V
 import qualified Focus
 import Lens.Family2
-import qualified ListT
-import OpenTelemetry.Context.ThreadLocal
+import OpenTelemetry.Context.ThreadLocal ()
 import OpenTelemetry.Trace.Core hiding (inSpan, inSpan')
 import OpenTelemetry.Trace.Monad
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Message
@@ -29,7 +28,6 @@ import qualified Proto.Temporal.Sdk.Core.WorkflowCompletion.WorkflowCompletion_F
 import RequireCallStack
 import qualified StmContainers.Map as StmMap
 import Temporal.Common
-import Temporal.Common.Async
 import qualified Temporal.Common.Logging as Logging
 import qualified Temporal.Core.Client as C
 import Temporal.Core.Worker (InactiveForReplay)
@@ -39,6 +37,7 @@ import qualified Temporal.Exception as Err
 import Temporal.Payload
 import Temporal.SearchAttributes.Internal
 import Temporal.Workflow.Definition
+import Temporal.Workflow.Internal.Instance (runInstanceM)
 import Temporal.Workflow.Internal.Monad hiding (try)
 import Temporal.WorkflowInstance
 import UnliftIO
@@ -105,11 +104,10 @@ are drained.
 The Async handle only completes successfully on poller shutdown.
 -}
 execute :: (MonadLoggerIO m, MonadUnliftIO m, MonadCatch m, MonadTracer m, RequireCallStack) => WorkflowWorker -> m ()
-execute worker@WorkflowWorker {workerCore} = flip runReaderT worker $ do
+execute worker = flip runReaderT worker $ do
   Logging.logDebug "Starting workflow worker"
   whileM_ go
   where
-    c = Core.getWorkerConfig workerCore
     go = inSpan' "Workflow activation step" defaultSpanArguments $ \s -> do
       -- logs <- liftIO $ fetchLogs globalRuntime
       -- forM_ logs $ \l -> case l.level of
@@ -123,8 +121,6 @@ execute worker@WorkflowWorker {workerCore} = flip runReaderT worker $ do
         -- TODO should we do anything else on shutdown?
         (Left (Core.WorkerError Core.PollShutdown _)) -> do
           Logging.logDebug "Poller shutting down"
-          runningWorkflows <- liftIO $ ListT.toList $ StmMap.listTNonAtomic $ worker.runningWorkflows
-          mapConcurrently_ (cancel <=< readIORef . executionThread . snd) runningWorkflows
           pure False
         (Left err) -> do
           Logging.logError $ Text.pack $ show err
@@ -132,14 +128,7 @@ execute worker@WorkflowWorker {workerCore} = flip runReaderT worker $ do
           pure True
         (Right activation) -> do
           Logging.logDebug $ Text.pack ("Got activation " <> show activation)
-          -- We want to handle activations as fast as possible, so we don't want to block
-          -- on dispatching jobs. We link the activator thread to the run-loop so that any
-          -- unhandled exceptions in that logic aren't ignored.
-          activationCtxt <- getContext
-          activator <- asyncLabelled (Text.unpack $ Text.concat ["temporal/worker/workflow/activate", Core.namespace c, "/", Core.taskQueue c]) $ do
-            _ <- attachContext activationCtxt
-            handleActivation activation
-          link activator
+          handleActivation activation
           pure True
 
 
@@ -155,18 +144,20 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
   if shouldRun
     then do
       mInst <- createOrFetchWorkflowInstance
-      forM_ mInst $ \inst -> do
-        -- Signals in the initialization activation were already buffered into the
-        -- instance (see applyStartWorkflow), so drop them here rather than
-        -- delivering them a second time through the channel.
-        let isInitActivation = not $ V.null activationInitializeWorkflowJobs
-            keepJob job =
-              isNothing (job ^. Activation.maybe'initializeWorkflow)
-                && not (isInitActivation && isJust (job ^. Activation.maybe'signalWorkflow))
-            withoutStart = filter keepJob (activation ^. Activation.jobs)
-        case withoutStart of
-          [] -> pure ()
-          otherJobs -> atomically $ writeTQueue inst.activationChannel (activation & Activation.jobs .~ otherJobs)
+      forM_ mInst $ \(inst, handledInitialJobs) -> do
+        unless handledInitialJobs do
+          -- Signals in the initialization activation were already buffered into the
+          -- instance (see applyStartWorkflow), so drop them here rather than
+          -- delivering them a second time.
+          let isInitActivation = not $ V.null activationInitializeWorkflowJobs
+              keepJob job =
+                isNothing (job ^. Activation.maybe'initializeWorkflow)
+                  && not (isInitActivation && isJust (job ^. Activation.maybe'signalWorkflow))
+              withoutStart = filter keepJob (activation ^. Activation.jobs)
+          unless (null withoutStart) $
+            liftIO $
+              runInstanceM inst $
+                advanceWorkflow (activation & Activation.jobs .~ withoutStart)
     else do
       Logging.logDebug "Workflow does not need to run."
       let completionMessage =
@@ -194,14 +185,14 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
         )
         (activation ^. Activation.vec'jobs)
 
-    createOrFetchWorkflowInstance :: ReaderT WorkflowWorker m (Maybe WorkflowInstance)
+    createOrFetchWorkflowInstance :: ReaderT WorkflowWorker m (Maybe (WorkflowInstance, Bool))
     createOrFetchWorkflowInstance = inSpan' "createOrFetchWorkflowInstance" (defaultSpanArguments {attributes = HashMap.fromList [("temporal.activation.run_id", toAttribute $ activation ^. Activation.runId)]}) $ \s -> do
       worker@WorkflowWorker {workerCore} <- ask
       minst <- atomically $ StmMap.lookup (RunId $ activation ^. Activation.runId) worker.runningWorkflows
       case minst of
         Just inst -> do
           addAttribute s "temporal.workflow.worker.instance_state" ("existing" :: Text)
-          pure $ Just inst
+          pure $ Just (inst, False)
         Nothing -> do
           addAttribute s "temporal.workflow.worker.instance_state" ("new" :: Text)
           vExistingInstance <- forM activationInitializeWorkflowJobs $ \(_job, initializeWorkflow) -> do
@@ -317,7 +308,11 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     let initialSignals =
                           V.toList $
                             V.mapMaybe (^. Activation.maybe'signalWorkflow) (activation ^. Activation.vec'jobs)
-                    (inst, startWorker) <-
+                        keepJob job =
+                          isNothing (job ^. Activation.maybe'initializeWorkflow)
+                            && isNothing (job ^. Activation.maybe'signalWorkflow)
+                        withoutStart = filter keepJob (activation ^. Activation.jobs)
+                    (inst, startWorkflow) <-
                       create
                         ( \wf -> do
                             Core.completeWorkflowActivation workerCore wf
@@ -334,8 +329,12 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                         initialSignals
                     liftIO $ addBuiltinQueryHandlers inst
                     published <- upsertWorkflowInstance runId_ inst
-                    liftIO startWorker
-                    pure $ Just published
+                    liftIO $
+                      startWorkflow $
+                        if null withoutStart
+                          then Nothing
+                          else Just (activation & Activation.jobs .~ withoutStart)
+                    pure $ Just (published, True)
           pure $ join (vExistingInstance V.!? 0)
 
     removeEvictedWorkflowInstances :: ReaderT WorkflowWorker m ()
@@ -361,7 +360,6 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     Logging.logDebug msg
                 Just wf -> do
                   pure $ do
-                    liftIO $ finalizeWorkflowExecution wf.inboundInterceptor runId_ Nothing
-                    cancel =<< readIORef wf.executionThread
+                    liftIO $ finalizeWorkflowExecution wf.inboundInterceptor wf Nothing
                     Logging.logDebug $ Text.pack ("Evicting workflow instance with run ID " ++ show runId_ ++ ", message: " ++ show (removeFromCache ^. Activation.message))
         _ -> pure ()

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -51,8 +51,7 @@ data EvictionWithRunID = EvictionWithRunID
   deriving stock (Show)
 
 
-data WorkflowWorker
-  = forall ty.
+data WorkflowWorker = forall ty.
   Core.KnownWorkerType ty =>
   WorkflowWorker
   { workerWorkflowFunctions :: {-# UNPACK #-} !(HashMap Text WorkflowDefinition)
@@ -317,8 +316,8 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     -- them from the activation channel so they aren't delivered twice.
                     let initialSignals =
                           V.toList $
-                            V.mapMaybe (\j -> j ^. Activation.maybe'signalWorkflow) (activation ^. Activation.vec'jobs)
-                    inst <-
+                            V.mapMaybe (^. Activation.maybe'signalWorkflow) (activation ^. Activation.vec'jobs)
+                    (inst, startWorker) <-
                       create
                         ( \wf -> do
                             Core.completeWorkflowActivation workerCore wf
@@ -334,7 +333,9 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                         initializeWorkflow
                         initialSignals
                     liftIO $ addBuiltinQueryHandlers inst
-                    Just <$> upsertWorkflowInstance runId_ inst
+                    published <- upsertWorkflowInstance runId_ inst
+                    liftIO startWorker
+                    pure $ Just published
           pure $ join (vExistingInstance V.!? 0)
 
     removeEvictedWorkflowInstances :: ReaderT WorkflowWorker m ()

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -360,6 +360,7 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     Logging.logDebug msg
                 Just wf -> do
                   pure $ do
+                    liftIO $ finalizeWorkflowExecution wf.inboundInterceptor runId_ Nothing
                     cancel =<< readIORef wf.executionThread
                     Logging.logDebug $ Text.pack ("Evicting workflow instance with run ID " ++ show runId_ ++ ", message: " ++ show (removeFromCache ^. Activation.message))
         _ -> pure ()

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -21,6 +21,7 @@ module Temporal.WorkflowInstance (
 import Control.Applicative
 import qualified Control.Exception as E
 import Control.Monad
+import qualified Control.Monad.Catch as Catch
 import Control.Monad.Logger
 import Control.Monad.Reader
 import qualified Data.Aeson as Aeson
@@ -92,7 +93,7 @@ import Temporal.Exception
 import qualified Temporal.Exception as Err
 import Temporal.Payload
 import Temporal.SearchAttributes.Internal
-import Temporal.Workflow.Eval (ActivationResult (..), SuspendableWorkflowExecution, injectWorkflowSignalOrUpdate, runWorkflow)
+import Temporal.Workflow.Eval (ActivationResult (..), SuspendableWorkflowExecution, injectWorkflowSignalOrUpdate, rethrowAsyncExceptions, runWorkflow)
 import Temporal.Workflow.Internal.Instance
 import Temporal.Workflow.Internal.Monad
 import Temporal.Workflow.Types
@@ -151,11 +152,10 @@ create
     workflowCommands <- newTVarIO $ Reversed []
     workflowSignalHandlers <- newIORef mempty
     workflowBufferedSignals <- newIORef mempty
+    workflowQueryHandlers <- newIORef mempty
     workflowCallStack <- newIORef emptyCallStack
     workflowIVarCounter <- newIORef 1
     workflowBlockedStacks <- newIORef mempty
-    workflowQueryHandlers <- newIORef mempty
-    workflowInitialHandlersReady <- newEmptyMVar
     workflowUpdateHandlers <- newIORef mempty
     workflowInstanceInfo <- newIORef info
     workflowInstanceContinuationEnv <- ContinuationEnv <$> newIORef JobNil
@@ -167,24 +167,39 @@ create
     -- pretty innocuous since writing to the executionThread var happens before anything else
     -- is allowed to interact with the instance.
     let inst = WorkflowInstance {..}
+    exec <- liftIO $ runInstanceM inst $ setUpWorkflowExecution start
+    initialStep <-
+      liftIO . E.try @SomeException $
+        interceptWorkflow inboundInterceptor exec $ \exec' ->
+          runInstanceM inst $ do
+            Logging.logDebug "Executing workflow"
+            wf <- applyStartWorkflow initialSignals exec' workflowFn
+            resume wf
     workerThread <- liftIO $ async $ runInstanceM inst $ do
-      Logging.logDebug "Start workflow execution thread"
-      exec <- setUpWorkflowExecution start
-      res <- liftIO $ inboundInterceptor.executeWorkflow exec $ \exec' -> runInstanceM inst $ runTopLevel $ do
-        Logging.logDebug "Executing workflow"
-        wf <- applyStartWorkflow initialSignals exec' workflowFn
-        liftIO $ putMVar workflowInitialHandlersReady ()
-        runWorkflowToCompletion wf
-      Logging.logDebug "Workflow execution completed"
-      addCommand =<< convertExitVariantToCommand res
-      flushCommands
-      Logging.logDebug "Handling leftover queries"
-      handleQueriesAfterCompletion
-    -- If we have an exception crash the workflow thread, then we need to throw to the worker too,
-    -- otherwise it will just hang forever.
+      res <- case initialStep of
+        Left err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)
+        Right (Right result) -> pure $ WorkflowExitSuccess result
+        Right (Left firstSuspension) ->
+          runTopLevel $ runWorkflowToCompletion $ resumeAfterFirstSuspension firstSuspension
+      finishWorkflow res
     link workerThread
     writeIORef executionThread workerThread
     pure inst
+
+
+resumeAfterFirstSuspension
+  :: Await [ActivationResult] (SuspendableWorkflowExecution Payload)
+  -> SuspendableWorkflowExecution Payload
+resumeAfterFirstSuspension (Await next) = await >>= next
+
+
+finishWorkflow :: WorkflowExitVariant Payload -> InstanceM ()
+finishWorkflow res = do
+  Logging.logDebug "Workflow execution completed"
+  addCommand =<< convertExitVariantToCommand res
+  flushCommands
+  Logging.logDebug "Handling leftover queries"
+  handleQueriesAfterCompletion
 
 
 runWorkflowToCompletion :: HasCallStack => SuspendableWorkflowExecution Payload -> InstanceM Payload
@@ -440,7 +455,6 @@ applyStartWorkflow initialSignals execInput workflowFn = do
             -- Safe on replay: the first activation carries the same signals,
             -- and buffering emits no commands.
             pure . runWorkflow $ traverse_ applySignalWorkflow initialSignals *> act
-
   liftIO $ executeWorkflowBase execInput
 
 
@@ -454,9 +468,6 @@ applyUpdateRandomSeed updateRandomSeed = do
 applyQueryWorkflow :: HasCallStack => QueryWorkflow -> InstanceM ()
 applyQueryWorkflow queryWorkflow = do
   inst <- ask
-  -- A start confirms persistence, not that the workflow body has installed its
-  -- synchronous query handlers. Wait only through that initial evaluation.
-  liftIO $ readMVar inst.workflowInitialHandlersReady
   instInfo <- readIORef inst.workflowInstanceInfo
   handles <- readIORef inst.workflowQueryHandlers
   Logging.logDebug $ Text.pack ("Applying query: " <> show (queryWorkflow ^. Activation.queryType))
@@ -994,12 +1005,14 @@ convertExitVariantToCommand variant = do
 -- Note: this is intended to exclusively handle top-level workflow execution.
 --
 -- Don't use elsewhere.
+workflowExitFromException :: SomeException -> WorkflowExitVariant a
+workflowExitFromException err
+  | Just continueAsNew <- E.fromException err = WorkflowExitContinuedAsNew continueAsNew
+  | Just cancelled <- E.fromException err = WorkflowExitCancelled cancelled
+  | otherwise = WorkflowExitFailed err
+
+
 runTopLevel :: InstanceM Payload -> InstanceM (WorkflowExitVariant Payload)
-runTopLevel m = do
+runTopLevel m =
   (WorkflowExitSuccess <$> m)
-    `catches` [ Handler $ \e@(ContinueAsNewException {}) -> pure $ WorkflowExitContinuedAsNew e
-              , Handler $ \WorkflowCancelRequested -> do
-                  pure $ WorkflowExitCancelled WorkflowCancelRequested
-              , Handler $ \(e :: SomeException) -> do
-                  pure $ WorkflowExitFailed e
-              ]
+    `Catch.catches` [Catch.Handler $ \err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)]

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -195,11 +195,16 @@ resumeAfterFirstSuspension (Await next) = await >>= next
 
 finishWorkflow :: WorkflowExitVariant Payload -> InstanceM ()
 finishWorkflow res = do
-  Logging.logDebug "Workflow execution completed"
-  addCommand =<< convertExitVariantToCommand res
-  flushCommands
-  Logging.logDebug "Handling leftover queries"
-  handleQueriesAfterCompletion
+  inst <- ask
+  let finalize = liftIO $ do
+        info <- readIORef inst.workflowInstanceInfo
+        finalizeWorkflowExecution inst.inboundInterceptor info.runId (Just res)
+  (`Catch.finally` finalize) do
+    Logging.logDebug "Workflow execution completed"
+    addCommand =<< convertExitVariantToCommand res
+    flushCommands
+    Logging.logDebug "Handling leftover queries"
+    handleQueriesAfterCompletion
 
 
 runWorkflowToCompletion :: HasCallStack => SuspendableWorkflowExecution Payload -> InstanceM Payload

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -155,6 +155,7 @@ create
     workflowIVarCounter <- newIORef 1
     workflowBlockedStacks <- newIORef mempty
     workflowQueryHandlers <- newIORef mempty
+    workflowInitialHandlersReady <- newEmptyMVar
     workflowUpdateHandlers <- newIORef mempty
     workflowInstanceInfo <- newIORef info
     workflowInstanceContinuationEnv <- ContinuationEnv <$> newIORef JobNil
@@ -172,6 +173,7 @@ create
       res <- liftIO $ inboundInterceptor.executeWorkflow exec $ \exec' -> runInstanceM inst $ runTopLevel $ do
         Logging.logDebug "Executing workflow"
         wf <- applyStartWorkflow initialSignals exec' workflowFn
+        liftIO $ putMVar workflowInitialHandlersReady ()
         runWorkflowToCompletion wf
       Logging.logDebug "Workflow execution completed"
       addCommand =<< convertExitVariantToCommand res
@@ -452,6 +454,9 @@ applyUpdateRandomSeed updateRandomSeed = do
 applyQueryWorkflow :: HasCallStack => QueryWorkflow -> InstanceM ()
 applyQueryWorkflow queryWorkflow = do
   inst <- ask
+  -- A start confirms persistence, not that the workflow body has installed its
+  -- synchronous query handlers. Wait only through that initial evaluation.
+  liftIO $ readMVar inst.workflowInitialHandlersReady
   instInfo <- readIORef inst.workflowInstanceInfo
   handles <- readIORef inst.workflowQueryHandlers
   Logging.logDebug $ Text.pack ("Applying query: " <> show (queryWorkflow ^. Activation.queryType))

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -6,8 +6,8 @@ module Temporal.WorkflowInstance (
   Info (..),
   RootExecution (..),
   create,
+  advanceWorkflow,
   activate,
-  addCommand,
   nextActivitySequence,
   nextChildWorkflowSequence,
   nextExternalCancelSequence,
@@ -116,7 +116,7 @@ create
   -> [SignalWorkflow]
   -- ^ Signals delivered in the same activation as the start job (e.g. via
   -- @signalWithStart@). Buffered before the workflow body runs; see 'applyStartWorkflow'.
-  -> m (WorkflowInstance, IO ())
+  -> m (WorkflowInstance, Maybe WorkflowActivation -> IO ())
 create
   workflowCompleteActivation
   workflowFn
@@ -124,7 +124,7 @@ create
   errorConverters
   inboundInterceptor
   outboundInterceptor
-  workflowVault
+  baseWorkflowVault
   payloadProcessor
   info
   start
@@ -160,12 +160,8 @@ create
     workflowInstanceInfo <- newIORef info
     workflowInstanceContinuationEnv <- ContinuationEnv <$> newIORef JobNil
     workflowCancellationVar <- newIVar
-    activationChannel <- newTQueueIO
-    executionThread <- newIORef (error "Workflow thread not yet started")
-    -- The execution thread is funny because it needs access to the instance, but the instance
-    -- needs access to the execution thread. It's a bit of a circular dependency, but
-    -- pretty innocuous since writing to the executionThread var happens before anything else
-    -- is allowed to interact with the instance.
+    workflowVault <- newIORef baseWorkflowVault
+    workflowAdvance <- newIORef (error "Workflow continuation not initialized")
     let inst = WorkflowInstance {..}
     exec <- liftIO $ runInstanceM inst $ setUpWorkflowExecution start
     initialStep <-
@@ -175,101 +171,96 @@ create
             Logging.logDebug "Executing workflow"
             wf <- applyStartWorkflow initialSignals exec' workflowFn
             resume wf
-    startWorker <- newEmptyMVar
-    workerThread <- liftIO $ async $ do
-      readMVar startWorker
-      runInstanceM inst $ do
-        res <- case initialStep of
-          Left err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)
-          Right (Right result) -> pure $ WorkflowExitSuccess result
-          Right (Left firstSuspension) ->
-            runTopLevel $ runWorkflowToCompletion $ resumeAfterFirstSuspension firstSuspension
-        finishWorkflow res
-    link workerThread
-    writeIORef executionThread workerThread
-    pure (inst, putMVar startWorker ())
+    pure (inst, runInstanceM inst . startWorkflow initialStep)
 
 
-resumeAfterFirstSuspension
-  :: Await [ActivationResult] (SuspendableWorkflowExecution Payload)
-  -> SuspendableWorkflowExecution Payload
-resumeAfterFirstSuspension (Await next) = await >>= next
+startWorkflow
+  :: Either SomeException (Either (Await [ActivationResult] (SuspendableWorkflowExecution Payload)) Payload)
+  -> Maybe WorkflowActivation
+  -> InstanceM ()
+startWorkflow initialStep = \case
+  Nothing -> initializeWorkflowContinuation initialStep
+  Just activation -> do
+    initializeWorkflowContinuationWithoutFlush initialStep
+    advanceWorkflow activation
+
+
+initializeWorkflowContinuation
+  :: Either SomeException (Either (Await [ActivationResult] (SuspendableWorkflowExecution Payload)) Payload)
+  -> InstanceM ()
+initializeWorkflowContinuation = \case
+  Left err -> do
+    rethrowAsyncExceptions err
+    finishWorkflow $ workflowExitFromException err
+  Right (Right result) -> finishWorkflow $ WorkflowExitSuccess result
+  Right (Left suspension) -> suspendWorkflow suspension
+
+
+initializeWorkflowContinuationWithoutFlush
+  :: Either SomeException (Either (Await [ActivationResult] (SuspendableWorkflowExecution Payload)) Payload)
+  -> InstanceM ()
+initializeWorkflowContinuationWithoutFlush = \case
+  Left err -> do
+    rethrowAsyncExceptions err
+    finishWorkflow $ workflowExitFromException err
+  Right (Right result) -> finishWorkflow $ WorkflowExitSuccess result
+  Right (Left suspension) -> installWorkflowSuspension suspension
+
+
+advanceWorkflow :: WorkflowActivation -> InstanceM ()
+advanceWorkflow activation = do
+  inst <- ask
+  liftIO (readIORef inst.workflowAdvance) >>= ($ activation)
+
+
+installWorkflowSuspension :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> InstanceM ()
+installWorkflowSuspension suspension = do
+  inst <- ask
+  liftIO $ writeIORef inst.workflowAdvance $ advanceSuspension suspension
+
+
+suspendWorkflow :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> InstanceM ()
+suspendWorkflow suspension = do
+  installWorkflowSuspension suspension
+  flushCommands
+
+
+advanceSuspension :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> WorkflowActivation -> InstanceM ()
+advanceSuspension suspension activation = do
+  next <- runIdentity <$> activate activation (Identity suspension)
+  step <- Catch.try @InstanceM @SomeException $ resume next
+  initializeWorkflowContinuation step
 
 
 finishWorkflow :: WorkflowExitVariant Payload -> InstanceM ()
 finishWorkflow res = do
   inst <- ask
+  liftIO $ writeIORef inst.workflowAdvance handleCompletedActivation
   let finalize = liftIO $ do
-        info <- readIORef inst.workflowInstanceInfo
-        finalizeWorkflowExecution inst.inboundInterceptor info.runId (Just res)
+        finalizeWorkflowExecution inst.inboundInterceptor inst (Just res)
   (`Catch.finally` finalize) do
     Logging.logDebug "Workflow execution completed"
     addCommand =<< convertExitVariantToCommand res
     flushCommands
-    Logging.logDebug "Handling leftover queries"
-    handleQueriesAfterCompletion
 
 
-runWorkflowToCompletion :: HasCallStack => SuspendableWorkflowExecution Payload -> InstanceM Payload
-runWorkflowToCompletion wf = do
-  inst <- ask
-  let completeStep :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> InstanceM (SuspendableWorkflowExecution Payload)
-      completeStep suspension = do
-        Logging.logDebug "Awaiting activation results from workflow"
-        -- If the workflow is blocked, then we necessarily have to signal the temporal-core
-        -- that we are stuck. Once we get unstuck (e.g. something is in the activation channel)
-        -- then we can resume the workflow.
-        --
-        -- There are a few cases like singalWithStart where a workflow will reach a blocking
-        -- state, but we aren't actually ready to flush the commands yet. So, we read
-        -- from the activation channel and resume the workflow until the channel is emptied.
-        --
-        -- Once we're blocked in that way, then we should flush the commands and wait for
-        -- the next activation(s?).
-        activation <- join $ atomically $ do
-          mActivition <- tryReadTQueue inst.activationChannel
-          case mActivition of
-            Nothing -> do
-              pure $ do
-                flushCommands
-                atomically $ readTQueue inst.activationChannel
-            Just act -> pure $ pure act
-        fmap runIdentity $ activate activation $ Identity suspension
-  supplyM completeStep wf
-
-
-{- | This runs indefinitely, handling queries that come in after the workflow has completed.
-
-Termination occurs when we receive an eviction signal from Temporal. At that point,
-the thread has 'cancel' called on it, which breaks us out of the loop.
-
-TODO perhaps we need to ensure that any any completed queries have added their commands
-to the command queue before we exit this loop?
--}
-handleQueriesAfterCompletion :: InstanceM ()
-handleQueriesAfterCompletion = forever $ do
+handleCompletedActivation :: WorkflowActivation -> InstanceM ()
+handleCompletedActivation activation = do
   w <- ask
-  activation <- atomically . readTQueue =<< asks activationChannel
   completion <- UnliftIO.try $ activate activation Proxy
-
   case completion of
     Left err -> do
       Logging.logDebug ("Workflow failure: " <> Text.pack (show err))
       let appFailure = mkApplicationFailure err w.errorConverters
           enrichedApplicationFailure = applicationFailureToFailureProto appFailure
-
           failureProto :: Completion.Failure
           failureProto = defMessage & Completion.failure .~ enrichedApplicationFailure
-
           completionMessage =
             defMessage
               & Completion.runId .~ (activation ^. Activation.runId)
               & Completion.failed .~ failureProto
-      inst <- ask
-      liftIO (inst.workflowCompleteActivation completionMessage >>= either throwIO pure)
-    Right Proxy -> do
-      -- At this point, the workflow isn't running, so we can always flush the commands.
-      flushCommands
+      liftIO (w.workflowCompleteActivation completionMessage >>= either throwIO pure)
+    Right Proxy -> flushCommands
 
 
 isBuiltinQuery :: Text.Text -> Bool
@@ -425,6 +416,7 @@ setUpWorkflowExecution initializeWorkflow = do
       , executeWorkflowInputArgs = fmap convertFromProtoPayload (initializeWorkflow ^. Command.vec'arguments)
       , executeWorkflowInputHeaders = hdrs
       , executeWorkflowInputInfo = info
+      , executeWorkflowInputVault = inst.workflowVault
       }
 
 
@@ -1018,9 +1010,3 @@ workflowExitFromException err
   | Just continueAsNew <- E.fromException err = WorkflowExitContinuedAsNew continueAsNew
   | Just cancelled <- E.fromException err = WorkflowExitCancelled cancelled
   | otherwise = WorkflowExitFailed err
-
-
-runTopLevel :: InstanceM Payload -> InstanceM (WorkflowExitVariant Payload)
-runTopLevel m =
-  (WorkflowExitSuccess <$> m)
-    `Catch.catches` [Catch.Handler $ \err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)]

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -5,6 +5,8 @@ module Temporal.WorkflowInstance (
   WorkflowInstance,
   Info (..),
   RootExecution (..),
+  WorkflowExecutionContext (..),
+  workflowExecutionContextKey,
   create,
   advanceWorkflow,
   activate,
@@ -43,9 +45,11 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Time.Clock.System (SystemTime (..))
 import Data.Vault.Strict (Vault)
+import qualified Data.Vault.Strict as Vault
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Data.Version (showVersion)
+import GHC.IO (unsafePerformIO)
 import GHC.Stack (HasCallStack, emptyCallStack, getCallStack)
 import qualified GHC.Stack
 import Lens.Family2
@@ -98,6 +102,21 @@ import Temporal.Workflow.Internal.Instance
 import Temporal.Workflow.Internal.Monad
 import Temporal.Workflow.Types
 import UnliftIO
+
+
+{- | Restores a workflow's ambient execution context for one activation.
+
+Interceptors install this in the per-instance vault.  The worker invokes it
+when it resumes a saved workflow continuation on a later activation.
+-}
+newtype WorkflowExecutionContext = WorkflowExecutionContext
+  { runWorkflowExecutionContext :: IO () -> IO ()
+  }
+
+
+workflowExecutionContextKey :: Vault.Key WorkflowExecutionContext
+workflowExecutionContextKey = unsafePerformIO Vault.newKey
+{-# NOINLINE workflowExecutionContextKey #-}
 
 
 create
@@ -209,6 +228,16 @@ initializeWorkflowContinuationWithoutFlush = \case
 
 advanceWorkflow :: WorkflowActivation -> InstanceM ()
 advanceWorkflow activation = do
+  inst <- ask
+  vault <- liftIO $ readIORef inst.workflowVault
+  case Vault.lookup workflowExecutionContextKey vault of
+    Nothing -> advanceWorkflowWithoutContext activation
+    Just WorkflowExecutionContext {runWorkflowExecutionContext} ->
+      liftIO $ runWorkflowExecutionContext $ runInstanceM inst $ advanceWorkflowWithoutContext activation
+
+
+advanceWorkflowWithoutContext :: WorkflowActivation -> InstanceM ()
+advanceWorkflowWithoutContext activation = do
   inst <- ask
   liftIO (readIORef inst.workflowAdvance) >>= ($ activation)
 

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -116,7 +116,7 @@ create
   -> [SignalWorkflow]
   -- ^ Signals delivered in the same activation as the start job (e.g. via
   -- @signalWithStart@). Buffered before the workflow body runs; see 'applyStartWorkflow'.
-  -> m WorkflowInstance
+  -> m (WorkflowInstance, IO ())
 create
   workflowCompleteActivation
   workflowFn
@@ -175,16 +175,19 @@ create
             Logging.logDebug "Executing workflow"
             wf <- applyStartWorkflow initialSignals exec' workflowFn
             resume wf
-    workerThread <- liftIO $ async $ runInstanceM inst $ do
-      res <- case initialStep of
-        Left err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)
-        Right (Right result) -> pure $ WorkflowExitSuccess result
-        Right (Left firstSuspension) ->
-          runTopLevel $ runWorkflowToCompletion $ resumeAfterFirstSuspension firstSuspension
-      finishWorkflow res
+    startWorker <- newEmptyMVar
+    workerThread <- liftIO $ async $ do
+      readMVar startWorker
+      runInstanceM inst $ do
+        res <- case initialStep of
+          Left err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)
+          Right (Right result) -> pure $ WorkflowExitSuccess result
+          Right (Left firstSuspension) ->
+            runTopLevel $ runWorkflowToCompletion $ resumeAfterFirstSuspension firstSuspension
+        finishWorkflow res
     link workerThread
     writeIORef executionThread workerThread
-    pure inst
+    pure (inst, putMVar startWorker ())
 
 
 resumeAfterFirstSuspension

--- a/sdk/test/QuerySpec.hs
+++ b/sdk/test/QuerySpec.hs
@@ -1,8 +1,8 @@
 module QuerySpec where
 
 import Control.Exception (SomeException)
+import Control.Monad (forM_)
 import qualified Control.Monad.Catch as Catch
-import qualified Data.Vector as V
 import Data.Text (Text)
 import qualified Data.Text as Text
 import RequireCallStack (provideCallStack)
@@ -32,7 +32,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "basic-query-wf" opts)
+      h <- useClient (C.start wf . reference "basic-query-wf" opts)
       waitForWorkflowStart h
       result <- C.query h echoQuery C.defaultQueryOptions "hello"
       C.cancel h (C.CancellationOptions mempty)
@@ -49,11 +49,27 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "query-args-wf" opts)
+      h <- useClient (C.start wf . reference "query-args-wf" opts)
       result <- C.query h echoQuery C.defaultQueryOptions "echo-me-back"
       C.cancel h (C.CancellationOptions mempty)
       result `shouldBe` Right "echo-me-back"
-
+  specify "immediately serves newly started workflow query handlers" $ \TestEnv {..} -> do
+    let query :: W.KnownQuery '[Text] Text
+        query = W.KnownQuery "initializationQuery" defaultCodec
+        workflow :: MyWorkflow ()
+        workflow = do
+          W.setQueryHandler query pure
+          W.sleep $ seconds 5
+        wf = W.provideWorkflow defaultCodec "initializationQueryWorkflow" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOpts taskQueue
+      wfId <- W.WorkflowId <$> uuidText
+      h <- useClient (C.start wf . reference wfId opts)
+      forM_ [1 :: Int .. 100] $ \_ -> do
+        result <- useClient $ C.query h query C.defaultQueryOptions "ready"
+        result `shouldBe` Right "ready"
+      C.cancel h (C.CancellationOptions mempty)
   specify "query reflects current state" $ \TestEnv {..} -> do
     let incSignal :: W.KnownSignal '[]
         incSignal = W.KnownSignal "inc" defaultCodec
@@ -70,7 +86,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "query-state-wf" opts)
+      h <- useClient (C.start wf . reference "query-state-wf" opts)
       r0 <- C.query h stateQuery C.defaultQueryOptions "q"
       r0 `shouldBe` Right 0
       C.signal h incSignal C.defaultSignalOptions
@@ -93,7 +109,7 @@ tests = describe "Query" $ do
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
-      h <- useClient (C.start wf.reference wfId opts)
+      h <- useClient (C.start wf . reference wfId opts)
       _ <- C.waitWorkflowResult h
       result <- C.query h stateQuery C.defaultQueryOptions "q"
       result `shouldBe` Right "completed"
@@ -112,7 +128,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "multi-query-wf" opts)
+      h <- useClient (C.start wf . reference "multi-query-wf" opts)
       rA <- C.query h queryA C.defaultQueryOptions "q"
       rB <- C.query h queryB C.defaultQueryOptions "q"
       C.cancel h (C.CancellationOptions mempty)
@@ -130,7 +146,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "query-no-block-wf" opts)
+      h <- useClient (C.start wf . reference "query-no-block-wf" opts)
       result <- C.query h echoQuery C.defaultQueryOptions "quick"
       result `shouldBe` Right "quick"
       C.cancel h (C.CancellationOptions mempty)
@@ -151,7 +167,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "query-no-waitcond-wf" opts)
+      h <- useClient (C.start wf . reference "query-no-waitcond-wf" opts)
       result <- C.query h stateQuery C.defaultQueryOptions "q"
       result `shouldBe` Right False
       C.signal h unblockSig C.defaultSignalOptions
@@ -171,7 +187,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "query-not-found-wf" opts)
+      h <- useClient (C.start wf . reference "query-not-found-wf" opts)
       queryResult <- Catch.try @IO @SomeException $ C.query h stateQuery C.defaultQueryOptions "q"
       C.signal h sig C.defaultSignalOptions
       _ <- C.waitWorkflowResult h
@@ -195,7 +211,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference "query-coord-wf" opts)
+      h <- useClient (C.start wf . reference "query-coord-wf" opts)
       r0 <- C.query h q C.defaultQueryOptions ()
       r0 `shouldBe` Right 0
       C.signal h sig C.defaultSignalOptions 5
@@ -220,7 +236,7 @@ tests = describe "Query" $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
       result <- useClient $ do
-        h <- C.start wf.reference wfId opts
+        h <- C.start wf . reference wfId opts
         (r :: Either C.QueryRejected Text) <- C.query h stackTraceQuery C.defaultQueryOptions ()
         C.signal h unblockSig C.defaultSignalOptions
         _ <- C.waitWorkflowResult h
@@ -248,7 +264,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf.reference (W.WorkflowId wfId) opts)
+      h <- useClient (C.start wf . reference (W.WorkflowId wfId) opts)
       r1 <- C.query h q1 C.defaultQueryOptions ()
       r1 `shouldBe` Right "answer"
       r2 <- C.query h q2 C.defaultQueryOptions ()
@@ -273,7 +289,7 @@ tests = describe "Query" $ do
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
-      h <- useClient (C.start wf.reference wfId opts)
+      h <- useClient (C.start wf . reference wfId opts)
       result <- C.query h unknownQuery C.defaultQueryOptions "anything"
       C.signal h sig C.defaultSignalOptions
       _ <- C.waitWorkflowResult h

--- a/sdk/test/QuerySpec.hs
+++ b/sdk/test/QuerySpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module QuerySpec where
 
 import Control.Exception (SomeException)
@@ -32,7 +34,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "basic-query-wf" opts)
+      h <- useClient (C.start wf.reference "basic-query-wf" opts)
       waitForWorkflowStart h
       result <- C.query h echoQuery C.defaultQueryOptions "hello"
       C.cancel h (C.CancellationOptions mempty)
@@ -49,7 +51,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "query-args-wf" opts)
+      h <- useClient (C.start wf.reference "query-args-wf" opts)
       result <- C.query h echoQuery C.defaultQueryOptions "echo-me-back"
       C.cancel h (C.CancellationOptions mempty)
       result `shouldBe` Right "echo-me-back"
@@ -65,7 +67,7 @@ tests = describe "Query" $ do
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
-      h <- useClient (C.start wf . reference wfId opts)
+      h <- useClient (C.start wf.reference wfId opts)
       forM_ [1 :: Int .. 100] $ \_ -> do
         result <- useClient $ C.query h query C.defaultQueryOptions "ready"
         result `shouldBe` Right "ready"
@@ -86,7 +88,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "query-state-wf" opts)
+      h <- useClient (C.start wf.reference "query-state-wf" opts)
       r0 <- C.query h stateQuery C.defaultQueryOptions "q"
       r0 `shouldBe` Right 0
       C.signal h incSignal C.defaultSignalOptions
@@ -109,7 +111,7 @@ tests = describe "Query" $ do
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
-      h <- useClient (C.start wf . reference wfId opts)
+      h <- useClient (C.start wf.reference wfId opts)
       _ <- C.waitWorkflowResult h
       result <- C.query h stateQuery C.defaultQueryOptions "q"
       result `shouldBe` Right "completed"
@@ -128,7 +130,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "multi-query-wf" opts)
+      h <- useClient (C.start wf.reference "multi-query-wf" opts)
       rA <- C.query h queryA C.defaultQueryOptions "q"
       rB <- C.query h queryB C.defaultQueryOptions "q"
       C.cancel h (C.CancellationOptions mempty)
@@ -146,7 +148,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "query-no-block-wf" opts)
+      h <- useClient (C.start wf.reference "query-no-block-wf" opts)
       result <- C.query h echoQuery C.defaultQueryOptions "quick"
       result `shouldBe` Right "quick"
       C.cancel h (C.CancellationOptions mempty)
@@ -167,7 +169,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "query-no-waitcond-wf" opts)
+      h <- useClient (C.start wf.reference "query-no-waitcond-wf" opts)
       result <- C.query h stateQuery C.defaultQueryOptions "q"
       result `shouldBe` Right False
       C.signal h unblockSig C.defaultSignalOptions
@@ -187,7 +189,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "query-not-found-wf" opts)
+      h <- useClient (C.start wf.reference "query-not-found-wf" opts)
       queryResult <- Catch.try @IO @SomeException $ C.query h stateQuery C.defaultQueryOptions "q"
       C.signal h sig C.defaultSignalOptions
       _ <- C.waitWorkflowResult h
@@ -211,7 +213,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference "query-coord-wf" opts)
+      h <- useClient (C.start wf.reference "query-coord-wf" opts)
       r0 <- C.query h q C.defaultQueryOptions ()
       r0 `shouldBe` Right 0
       C.signal h sig C.defaultSignalOptions 5
@@ -236,7 +238,7 @@ tests = describe "Query" $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
       result <- useClient $ do
-        h <- C.start wf . reference wfId opts
+        h <- C.start wf.reference wfId opts
         (r :: Either C.QueryRejected Text) <- C.query h stackTraceQuery C.defaultQueryOptions ()
         C.signal h unblockSig C.defaultSignalOptions
         _ <- C.waitWorkflowResult h
@@ -264,7 +266,7 @@ tests = describe "Query" $ do
         conf = configure () wf $ do baseConf
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
-      h <- useClient (C.start wf . reference (W.WorkflowId wfId) opts)
+      h <- useClient (C.start wf.reference (W.WorkflowId wfId) opts)
       r1 <- C.query h q1 C.defaultQueryOptions ()
       r1 `shouldBe` Right "answer"
       r2 <- C.query h q2 C.defaultQueryOptions ()
@@ -289,7 +291,7 @@ tests = describe "Query" $ do
     withWorker conf $ do
       let opts = defaultStartOpts taskQueue
       wfId <- W.WorkflowId <$> uuidText
-      h <- useClient (C.start wf . reference wfId opts)
+      h <- useClient (C.start wf.reference wfId opts)
       result <- C.query h unknownQuery C.defaultQueryOptions "anything"
       C.signal h sig C.defaultSignalOptions
       _ <- C.waitWorkflowResult h


### PR DESCRIPTION
## Summary
- make query dispatch wait for a workflow’s first synchronous evaluation to finish
- prevent an immediate query after `Client.start` from observing a top-level handler as missing
- add a query immediate-start regression test

## Why
`Client.start` confirms persistence before the worker has necessarily registered its synchronous query handlers. The temporal-outbox worker’s immediate `getConfig` query could therefore fail with `QueryNotFound`.

## Verification
`cabal test temporal-sdk-tests --test-option=--match --test-option=Query --test-show-details=direct`
