### PR TITLE
Fix workflow context restoration with OTel 1

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -149,6 +149,14 @@ headersBaggagePropagator =
     }
 #endif
 
+#if MIN_VERSION_hs_opentelemetry_api(1,0,0)
+restoreContext = void . detachContext
+#else
+restoreContext = \case
+  Nothing -> void detachContext
+  Just prior -> void $ attachContext prior
+#endif
+
 
 tracerKey :: Vault.Key Tracer
 tracerKey = unsafePerformIO Vault.newKey
@@ -275,9 +283,6 @@ makeOpenTelemetryInterceptor = do
                         }
                 span <- createSpan tracer ctxt ("RunWorkflow:" <> rawWorkflowType input.executeWorkflowInputType) spanArgs
                 let workflowContext = Ctxt.insertSpan span ctxt
-                    restoreContext = \case
-                      Nothing -> void detachContext
-                      Just prior -> void $ attachContext prior
                     withWorkflowContext :: IO a -> IO a
                     withWorkflowContext action = do
                       priorContext <- attachContext workflowContext


### PR DESCRIPTION
Restores the workflow trace context with `detachContext`'s token-based API when built against hs-opentelemetry-api 1.x.

This unblocks the Mercury Web Backend Nix input bump for the query-handler startup-race merge.

Verified: `nix build --no-link --override-input temporal-sdk git+file:///Users/ian/Code/mercury/hs-temporal-sdk .#hsPkgs.temporal-sdk` from mercury-web-backend.